### PR TITLE
allow to give a name when linking a module, without having to register it later

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ val script : Types.Symbolic.script =
 val m : Types.Symbolic.modul =
 ...
 # let module_to_run, link_state =
-    match Compile.until_link Link.empty_state m with
+    match Compile.until_link Link.empty_state ~name:None m with
     | Ok v -> v
     | Error e -> failwith e;;
 val module_to_run : Link.module_to_run =

--- a/example/README.md
+++ b/example/README.md
@@ -92,7 +92,8 @@ let extern_module : Link.extern_module =
   { functions }
 
 (* a link state that contains our custom module, available under the name `sausage` *)
-let link_state = Link.extern_module "sausage" extern_module Link.empty_state
+let link_state =
+  Link.extern_module Link.empty_state ~name:"sausage" extern_module
 
 (* a pure wasm module refering to `sausage` *)
 let pure_wasm_module =
@@ -104,7 +105,7 @@ let pure_wasm_module =
 let module_to_run =
   match pure_wasm_module with
   | Types.Symbolic.Module m :: _ -> begin
-    match Compile.until_link link_state m with
+    match Compile.until_link link_state ~name:None m with
     | Error msg -> failwith msg
     | Ok (m, _state) -> m
   end

--- a/example/extern.ml
+++ b/example/extern.ml
@@ -26,7 +26,8 @@ let extern_module : Link.extern_module =
   { functions }
 
 (* a link state that contains our custom module, available under the name `sausage` *)
-let link_state = Link.extern_module "sausage" extern_module Link.empty_state
+let link_state =
+  Link.extern_module Link.empty_state ~name:"sausage" extern_module
 
 (* a pure wasm module refering to `sausage` *)
 let pure_wasm_module =
@@ -38,7 +39,7 @@ let pure_wasm_module =
 let module_to_run =
   match pure_wasm_module with
   | Types.Symbolic.Module m :: _ -> begin
-    match Compile.until_link link_state m with
+    match Compile.until_link link_state ~name:None m with
     | Error msg -> failwith msg
     | Ok (m, _state) -> m
   end

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -7,7 +7,7 @@ let simplify_then_link_then_run file =
       (fun ((to_run, state) as acc) instruction ->
         match instruction with
         | Types.Symbolic.Module m ->
-          let* m, state = Compile.until_link state m in
+          let* m, state = Compile.until_link state ~name:None m in
           Ok (m :: to_run, state)
         | Types.Symbolic.Register (name, id) ->
           let* state = Link.register_module state ~name ~id in

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -11,11 +11,11 @@ let until_typecheck m =
   let* () = Typecheck.module_ m in
   Ok m
 
-let until_link link_state m =
+let until_link link_state ~name m =
   let* m = until_typecheck m in
-  Link.modul m link_state
+  Link.modul link_state ~name m
 
-let until_interpret link_state m =
-  let* m, link_state = until_link link_state m in
+let until_interpret link_state ~name m =
+  let* m, link_state = until_link link_state ~name m in
   let* () = Interpret.module_ m in
   Ok link_state

--- a/src/compile.mli
+++ b/src/compile.mli
@@ -4,9 +4,14 @@
     runnable module *)
 val until_link :
      Link.state
+  -> name:string option
   -> Types.Symbolic.modul
   -> (Link.module_to_run * Link.state, string) result
 
 (** compile and interpret a module with a given link state and produce a new
     link state *)
-val until_interpret : Link.state -> Types.Symbolic.modul -> (Link.state, string) result
+val until_interpret :
+     Link.state
+  -> name:string option
+  -> Types.Symbolic.modul
+  -> (Link.state, string) result

--- a/src/link.mli
+++ b/src/link.mli
@@ -97,7 +97,10 @@ val empty_state : state
 (** link a module with a given link state, producing a runnable module and a new
     link state *)
 val modul :
-  Types.Simplified.modul -> state -> (module_to_run * state, string) result
+     state
+  -> name:string option
+  -> Types.Simplified.modul
+  -> (module_to_run * state, string) result
 
 (** register a module inside a link state, producing a new link state *)
 val register_module :
@@ -108,4 +111,4 @@ type extern_module = { functions : (string * Value.Func.extern_func) list }
 
 (** register an extern module with a given link state, producing a new link
     state *)
-val extern_module : string -> extern_module -> state -> state
+val extern_module : state -> name:string -> extern_module -> state


### PR DESCRIPTION
@chambart, this is indeed better than #19, even though it's a little bit more invasive