### PR TITLE
fix memory.fill: interpret the arg as unsigned

### DIFF
--- a/src/int32.mli
+++ b/src/int32.mli
@@ -32,6 +32,8 @@ val to_int64 : t -> int64
 
 val extend_s : int -> t -> t
 
+val unsigned_to_int : t -> int option
+
 (** unary operators *)
 
 val clz : t -> int

--- a/src/interpret.ml
+++ b/src/interpret.ml
@@ -766,7 +766,7 @@ let exec_instr instr (state : State.exec_state) =
     let* mem = get_memory_raw env mem_0 in
     let data = Link.Memory.get_data mem in
     let max_size = Link.Memory.get_limit_max mem in
-    let delta, stack = Stack.pop_i32_to_int stack in
+    let delta, stack = Stack.pop_ui32_to_int stack in
     let delta = delta * page_size in
     let old_size = Bytes.length data in
     let new_size = old_size + delta in
@@ -1138,10 +1138,8 @@ let exec_instr instr (state : State.exec_state) =
     call_indirect ~return:false state (tbl_i, typ_i)
   | Return_call_indirect (tbl_i, typ_i) ->
     call_indirect ~return:true state (tbl_i, typ_i)
-  | Call_ref typ_i ->
-    call_ref ~return:false state typ_i
-  | Return_call_ref typ_i ->
-    call_ref ~return:true state typ_i
+  | Call_ref typ_i -> call_ref ~return:false state typ_i
+  | Return_call_ref typ_i -> call_ref ~return:true state typ_i
   | Array_new_canon _t ->
     let len, stack = Stack.pop_i32_to_int stack in
     let _default, stack = Stack.pop stack in

--- a/src/optimize.ml
+++ b/src/optimize.ml
@@ -248,9 +248,8 @@ let locals_func body_expr =
     | Return_call_indirect (_, _)
     | Call _
     | Call_indirect (_, _)
-    | Call_ref _
-    | Return_call_ref _
-    | Array_get _ | Array_get_u _ | Array_new_canon _
+    | Call_ref _ | Return_call_ref _ | Array_get _ | Array_get_u _
+    | Array_new_canon _
     | Array_new_canon_data (_, _)
     | Array_new_canon_default _
     | Array_new_canon_elem (_, _)
@@ -321,9 +320,8 @@ let locals_used_in_func locals nb_args body_expr =
       | Return_call_indirect (_, _)
       | Call _
       | Call_indirect (_, _)
-      | Call_ref _
-      | Return_call_ref _
-      | Array_get _ | Array_get_u _ | Array_new_canon _
+      | Call_ref _ | Return_call_ref _ | Array_get _ | Array_get_u _
+      | Array_new_canon _
       | Array_new_canon_data (_, _)
       | Array_new_canon_default _
       | Array_new_canon_elem (_, _)

--- a/src/stack.ml
+++ b/src/stack.ml
@@ -45,6 +45,12 @@ let pop_i32_to_int s =
   let hd, tl = pop_i32 s in
   (Int32.to_int hd, tl)
 
+let pop_ui32_to_int s =
+  let hd, tl = pop_i32 s in
+  match Int32.unsigned_to_int hd with
+  | None -> Log.err "invalid type (expected unsigned i32)"
+  | Some hd -> (hd, tl)
+
 let pop_i32_to_char s =
   let hd, tl = pop_i32 s in
   (Char.chr (Int32.to_int hd mod 256), tl)

--- a/src/stack.ml
+++ b/src/stack.ml
@@ -53,7 +53,9 @@ let pop_ui32_to_int s =
 
 let pop_i32_to_char s =
   let hd, tl = pop_i32 s in
-  (Char.chr (Int32.to_int hd mod 256), tl)
+  match Int32.unsigned_to_int hd with
+  | None -> Log.err "invalid type (expected unsigned i32)"
+  | Some n -> (Char.chr (n mod 256), tl)
 
 let pop2_i32 s =
   try

--- a/src/stack.mli
+++ b/src/stack.mli
@@ -26,6 +26,8 @@ val pop_i32_to_char : 'a t -> char * 'a t
 
 val pop_i32_to_int : 'a t -> int * 'a t
 
+val pop_ui32_to_int : 'a t -> int * 'a t
+
 val pop2_i32 : 'a t -> (int32 * int32) * 'a t
 
 val pop_i64 : 'a t -> int64 * 'a t

--- a/src/types.ml
+++ b/src/types.ml
@@ -632,8 +632,8 @@ struct
       | Return_call_indirect (tbl_id, ty_id) ->
         Format.fprintf fmt "return_call_indirect %a %a" indice tbl_id block_type
           ty_id
-      | Return_call_ref ty_id -> Format.fprintf fmt "return_call_ref %a" block_type
-          ty_id
+      | Return_call_ref ty_id ->
+        Format.fprintf fmt "return_call_ref %a" block_type ty_id
       | Call id -> Format.fprintf fmt "call %a" indice id
       | Call_indirect (tbl_id, ty_id) ->
         Format.fprintf fmt "call_indirect %a %a" indice tbl_id block_type ty_id

--- a/test/passing/memory_fill.wast
+++ b/test/passing/memory_fill.wast
@@ -1,0 +1,11 @@
+(module
+  (memory 0)
+  (func (export "f")
+    i32.const -1
+    i32.const -1
+    i32.const -1
+    memory.fill
+  )
+)
+
+(assert_trap (invoke "f") "out of bounds memory access")

--- a/test/passing/neg_memory_grow.wast
+++ b/test/passing/neg_memory_grow.wast
@@ -1,0 +1,9 @@
+(module
+  (memory 0)
+  (func (export "f") (result i32)
+    i32.const -1
+    memory.grow
+  )
+)
+
+(assert_return (invoke "f") (i32.const -1))


### PR DESCRIPTION
This is based on #39.

Fix #38.

cc @epatrizio 