### PR TITLE
Adds unsafe flag to skip typechecker

### DIFF
--- a/src/compile.ml
+++ b/src/compile.ml
@@ -4,25 +4,25 @@
 
 let ( let* ) o f = match o with Error msg -> Error msg | Ok v -> f v
 
-let until_check m = Check.modul m
+let until_check ?(unsafe = false) m = if unsafe then Ok m else Check.modul m
 
-let until_group m =
-  let* m = until_check m in
+let until_group ?unsafe m =
+  let* m = until_check ?unsafe m in
   let* m = Grouped.of_symbolic m in
   Ok m
 
-let until_assign m =
-  let* m = until_group m in
+let until_assign ?unsafe m =
+  let* m = until_group ?unsafe m in
   let* m = Assigned.of_grouped m in
   Ok m
 
-let until_simplify m =
-  let* m = until_assign m in
+let until_simplify ?unsafe m =
+  let* m = until_assign ?unsafe m in
   let* m = Rewrite.modul m in
   Ok m
 
 let until_typecheck ?(unsafe = false) m =
-  let* m = until_simplify m in
+  let* m = until_simplify ~unsafe m in
   if unsafe then Ok m
   else
     let* () = Typecheck.modul m in

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -21,17 +21,19 @@ let until_simplify m =
   let* m = Rewrite.modul m in
   Ok m
 
-let until_typecheck m =
+let until_typecheck ?(unsafe = false) m =
   let* m = until_simplify m in
-  let* () = Typecheck.modul m in
-  Ok m
+  if unsafe then Ok m
+  else
+    let* () = Typecheck.modul m in
+    Ok m
 
-let until_optimize ~optimize m =
-  let* m = until_typecheck m in
+let until_optimize ?unsafe ~optimize m =
+  let* m = until_typecheck ?unsafe m in
   if optimize then Ok (Optimize.modul m) else Ok m
 
-let until_link link_state ~optimize ~name m =
-  let* m = until_optimize ~optimize m in
+let until_link ?unsafe link_state ~optimize ~name m =
+  let* m = until_optimize ?unsafe ~optimize m in
   Link.modul link_state ~name m
 
 let until_interpret link_state ~optimize ~name m =

--- a/src/compile.mli
+++ b/src/compile.mli
@@ -1,8 +1,8 @@
 (** Utility functions to compile a module until a given step. *)
 
-val until_check : Symbolic.modul -> Symbolic.modul Result.t
+val until_check : ?unsafe:bool -> Symbolic.modul -> Symbolic.modul Result.t
 
-val until_simplify : Symbolic.modul -> Simplified.modul Result.t
+val until_simplify : ?unsafe:bool -> Symbolic.modul -> Simplified.modul Result.t
 
 (** compile a module with a given link state and produce a new link state and a
     runnable module *)

--- a/src/compile.mli
+++ b/src/compile.mli
@@ -7,7 +7,8 @@ val until_simplify : Symbolic.modul -> Simplified.modul Result.t
 (** compile a module with a given link state and produce a new link state and a
     runnable module *)
 val until_link :
-     'f Link.state
+     ?unsafe:bool
+  -> 'f Link.state
   -> optimize:bool
   -> name:string option
   -> Symbolic.modul


### PR DESCRIPTION
Attemps to introduce unsafe flag for optimized owi_sym.

This flag facilitates benchmarking on WebAssembly programs derived from C code, where prior typechecking has already occurred during compilation.