### PR TITLE
Updates encoding pin

### DIFF
--- a/owi.opam
+++ b/owi.opam
@@ -50,5 +50,5 @@ build: [
 dev-repo: "git+https://github.com/ocamlpro/owi.git"
 available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
 pin-depends: [
-  [ "encoding.dev" "git+https://github.com/formalsec/encoding"]
+  [ "encoding.v0.0.1" "git+https://github.com/formalsec/encoding"]
 ]

--- a/owi.opam
+++ b/owi.opam
@@ -49,6 +49,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocamlpro/owi.git"
 available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
-pin-depends: [
-  [ "encoding.v0.0.1" "git+https://github.com/formalsec/encoding"]
-]

--- a/owi.opam.template
+++ b/owi.opam.template
@@ -1,4 +1,4 @@
 available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
 pin-depends: [
-  [ "encoding.dev" "git+https://github.com/formalsec/encoding"]
+  [ "encoding.v0.0.1" "git+https://github.com/formalsec/encoding"]
 ]

--- a/owi.opam.template
+++ b/owi.opam.template
@@ -1,4 +1,1 @@
 available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
-pin-depends: [
-  [ "encoding.v0.0.1" "git+https://github.com/formalsec/encoding"]
-]

--- a/src/choice_monad.mli
+++ b/src/choice_monad.mli
@@ -1,4 +1,4 @@
-exception Assertion of Encoding.Expression.expr * Thread.t
+exception Assertion of Encoding.Expr.t * Thread.t
 
 module type T =
   Choice_monad_intf.Complete

--- a/src/choice_monad_intf.ml
+++ b/src/choice_monad_intf.ml
@@ -35,7 +35,7 @@ end
 type 'a eval =
   | EVal of 'a
   | ETrap of Trap.t
-  | EAssert of Encoding.Expression.expr
+  | EAssert of Encoding.Expr.t
 
 module type Complete_with_trap = sig
   include Complete

--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -1,6 +1,5 @@
 open Syntax
-module E = Encoding
-module Expr = E.Expr
+module Expr = Encoding.Expr
 module Value = Symbolic_value.S
 module Choice = Symbolic.P.Choice
 module Solver = Thread.Solver
@@ -50,6 +49,7 @@ let names = [| "plop"; "foo"; "bar" |]
 let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
   let sprintf = Printf.sprintf in
   let sym_cnt = Atomic.make 0 in
+  let mk_symbol = Encoding.Symbol.mk_symbol in
   let symbolic_i32 (i : Value.int32) : Value.int32 Choice.t =
     let name =
       match i.e with
@@ -60,13 +60,13 @@ let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
     in
     let id = Atomic.fetch_and_add sym_cnt 1 in
     let r =
-      E.(Expr.mk_symbol Symbol.(sprintf "%s_%i" name id @: Ty_bitv S32))
+      Expr.mk_symbol @@ mk_symbol (Ty_bitv S32) (sprintf "%s_%i" name id)
     in
     Choice.return r
   in
   let symbol ty () : Value.int32 Choice.t =
     let id = Atomic.fetch_and_add sym_cnt 1 in
-    let r = E.(Expr.mk_symbol Symbol.(sprintf "symbol_%i" id @: ty)) in
+    let r = Expr.mk_symbol @@ mk_symbol ty (sprintf "symbol_%i" id) in
     Choice.return r
   in
   let assume_i32 (i : Value.int32) : unit Choice.t =

--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -105,6 +105,7 @@ let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
   { functions }
 
 let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
+  let abort () : unit Choice.t = Choice.add_pc @@ Value.Bool.const false in
   let alloc (base : Value.int32) (_size : Value.int32) : Value.int32 Choice.t =
     Choice.return base
   in
@@ -120,6 +121,7 @@ let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
     ; ( "dealloc"
       , Symbolic.P.Extern_func.Extern_func (Func (Arg (I32, Res), R0), dealloc)
       )
+    ; ("abort", Symbolic.P.Extern_func.Extern_func (Func (UArg Res, R0), abort))
     ; ( "is_symbolic"
       , Symbolic.P.Extern_func.Extern_func
           (Func (Arg (I32, Arg (I32, Res)), R1 I32), is_symbolic) )


### PR DESCRIPTION
Sets the encoding pin to v0.0.1, guaranteeing smooth future installations and providing a safeguard against conflicts with additions to the encoding's main branch. Should the pull request at https://github.com/ocaml/opam-repository/pull/24809 be accepted in the future, the pin can be removed.