### PR TITLE
Heap tracking

### DIFF
--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -66,7 +66,9 @@ let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
   let symbol ty () : Value.int32 Choice.t =
     let id = Atomic.fetch_and_add sym_cnt 1 in
     let r = Expr.mk_symbol @@ mk_symbol ty (Format.sprintf "symbol_%i" id) in
-    Choice.return r
+    match ty with
+    | Ty_bitv S8 -> Choice.return @@ Expr.(Cvtop (ExtU 24, r) @: Ty_bitv S32)
+    | _ -> Choice.return r
   in
   let assume_i32 (i : Value.int32) : unit Choice.t =
     let c = Value.I32.to_bool i in
@@ -81,6 +83,9 @@ let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
     [ ( "i32"
       , Symbolic.P.Extern_func.Extern_func
           (Func (Arg (I32, Res), R1 I32), symbolic_i32) )
+    ; ( "i8_symbol"
+      , Symbolic.P.Extern_func.Extern_func
+          (Func (UArg Res, R1 I32), symbol (Ty_bitv S8)) )
     ; ( "i32_symbol"
       , Symbolic.P.Extern_func.Extern_func
           (Func (UArg Res, R1 I32), symbol (Ty_bitv S32)) )

--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -136,7 +136,7 @@ let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
               (fun _ (m : Symbolic_memory.M.t) ->
                 if not (Hashtbl.mem m.chunks base) then
                   (* TODO: trap instead? *)
-                  failwith "Memory leak use after free";
+                  failwith "Memory leak double free";
                 Hashtbl.remove m.chunks base )
               tbl )
           memories )

--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -135,7 +135,7 @@ let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
             Symbolic_memory.ITbl.iter
               (fun _ (m : Symbolic_memory.M.t) ->
                 if not (Hashtbl.mem m.chunks base) then
-                  (* Raise trap here instead *)
+                  (* TODO: trap instead? *)
                   failwith "Memory leak use after free";
                 Hashtbl.remove m.chunks base )
               tbl )

--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -110,8 +110,16 @@ let symbolic_extern_module : Symbolic.P.extern_func Link.extern_module =
 
 let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
   let open Expr in
-  let i32 v = match v.e with Val (Num (I32 v)) -> v | _ -> assert false in
-  let ptr v = match v.e with Ptr (b, _) -> b | _ -> assert false in
+  let i32 v =
+    match v.e with
+    | Val (Num (I32 v)) -> v
+    | _ -> Log.err {|Unable to cast int32 of "%a"|} Expr.pp v
+  in
+  let ptr v =
+    match v.e with
+    | Ptr (b, _) -> b
+    | _ -> Log.err {|Unable to fetch pointer base of "%a"|} Expr.pp v
+  in
   let abort () : unit Choice.t = Choice.add_pc @@ Value.Bool.const false in
   let alloc (base : Value.int32) (size : Value.int32) : Value.int32 Choice.t =
     let base : int32 = i32 base in

--- a/src/interpret.ml
+++ b/src/interpret.ml
@@ -1171,7 +1171,7 @@ module Make (P : Interpret_functor_intf.P) :
       in
       if out_of_bounds then Choice.trap Out_of_bounds_memory_access
       else
-        let res =
+        let* res =
           (if sx = S then Memory.load_16_s else Memory.load_16_u) mem addr
         in
         st
@@ -1193,7 +1193,7 @@ module Make (P : Interpret_functor_intf.P) :
       in
       if out_of_bounds then Choice.trap Out_of_bounds_memory_access
       else
-        let res =
+        let* res =
           (if sx = S then Memory.load_8_s else Memory.load_8_u) mem addr
         in
         st
@@ -1224,7 +1224,7 @@ module Make (P : Interpret_functor_intf.P) :
       in
       if out_of_bounds then Choice.trap Out_of_bounds_memory_access
       else begin
-        Memory.store_8 mem ~addr n;
+        let* () = Memory.store_8 mem ~addr n in
         (* Thread memory ? *)
         st stack
       end
@@ -1246,13 +1246,13 @@ module Make (P : Interpret_functor_intf.P) :
           let> out_of_bounds = I32.(lt_u memory_length (addr + const 4l)) in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else
-            let res = Memory.load_32 mem addr in
+            let* res = Memory.load_32 mem addr in
             st @@ Stack.push_i32 stack res
         | S64 ->
           let> out_of_bounds = I32.(lt_u memory_length (addr + const 8l)) in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else
-            let res = Memory.load_64 mem addr in
+            let* res = Memory.load_64 mem addr in
             st @@ Stack.push_i64 stack res
       end
     | F_load (nn, { offset; _ }) ->
@@ -1271,14 +1271,14 @@ module Make (P : Interpret_functor_intf.P) :
           let> out_of_bounds = I32.(lt_u memory_length (addr + const 4l)) in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else
-            let res = Memory.load_32 mem addr in
+            let* res = Memory.load_32 mem addr in
             let res = F32.of_bits res in
             st @@ Stack.push_f32 stack res
         | S64 ->
           let> out_of_bounds = I32.(lt_u memory_length (addr + const 8l)) in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else
-            let res = Memory.load_64 mem addr in
+            let* res = Memory.load_64 mem addr in
             let res = F64.of_bits res in
             st @@ Stack.push_f64 stack res
       end
@@ -1300,7 +1300,7 @@ module Make (P : Interpret_functor_intf.P) :
           in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else begin
-            Memory.store_32 mem ~addr n;
+            let* () = Memory.store_32 mem ~addr n in
             st stack
           end
         | S64 ->
@@ -1313,7 +1313,7 @@ module Make (P : Interpret_functor_intf.P) :
           in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else begin
-            Memory.store_64 mem ~addr n;
+            let* () = Memory.store_64 mem ~addr n in
             st stack
           end )
     | F_store (nn, { offset; _ }) -> (
@@ -1334,7 +1334,7 @@ module Make (P : Interpret_functor_intf.P) :
           in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else begin
-            Memory.store_32 mem ~addr (F32.to_bits n);
+            let* () = Memory.store_32 mem ~addr (F32.to_bits n) in
             st stack
           end
         | S64 ->
@@ -1347,7 +1347,7 @@ module Make (P : Interpret_functor_intf.P) :
           in
           if out_of_bounds then Choice.trap Out_of_bounds_memory_access
           else begin
-            Memory.store_64 mem ~addr (F64.to_bits n);
+            let* () = Memory.store_64 mem ~addr (F64.to_bits n) in
             st stack
           end )
     | I64_load32 (sx, { offset; _ }) ->
@@ -1363,7 +1363,8 @@ module Make (P : Interpret_functor_intf.P) :
       in
       if out_of_bounds then Choice.trap Out_of_bounds_memory_access
       else begin
-        let res = I64.of_int32 @@ Memory.load_32 mem addr in
+        let* res = Memory.load_32 mem addr in
+        let res = I64.of_int32 res in
         let res =
           match sx with
           | S -> res
@@ -1400,7 +1401,7 @@ module Make (P : Interpret_functor_intf.P) :
         in
         if out_of_bounds then Choice.trap Out_of_bounds_memory_access
         else begin
-          Memory.store_16 mem ~addr n;
+          let* () = Memory.store_16 mem ~addr n in
           st stack
         end
     | I64_store32 { offset; _ } ->
@@ -1418,7 +1419,7 @@ module Make (P : Interpret_functor_intf.P) :
       in
       if out_of_bounds then Choice.trap Out_of_bounds_memory_access
       else begin
-        Memory.store_32 mem ~addr n;
+        let* () = Memory.store_32 mem ~addr n in
         st stack
       end
     | Data_drop (Raw i) ->

--- a/src/interpret_functor_intf.ml
+++ b/src/interpret_functor_intf.ml
@@ -122,25 +122,25 @@ module type P = sig
   module Memory : sig
     type t
 
-    val load_8_s : t -> int32 -> int32
+    val load_8_s : t -> int32 -> int32 Choice.t
 
-    val load_8_u : t -> int32 -> int32
+    val load_8_u : t -> int32 -> int32 Choice.t
 
-    val load_16_s : t -> int32 -> int32
+    val load_16_s : t -> int32 -> int32 Choice.t
 
-    val load_16_u : t -> int32 -> int32
+    val load_16_u : t -> int32 -> int32 Choice.t
 
-    val load_32 : t -> int32 -> int32
+    val load_32 : t -> int32 -> int32 Choice.t
 
-    val load_64 : t -> int32 -> int64
+    val load_64 : t -> int32 -> int64 Choice.t
 
-    val store_8 : t -> addr:int32 -> int32 -> unit
+    val store_8 : t -> addr:int32 -> int32 -> unit Choice.t
 
-    val store_16 : t -> addr:int32 -> int32 -> unit
+    val store_16 : t -> addr:int32 -> int32 -> unit Choice.t
 
-    val store_32 : t -> addr:int32 -> int32 -> unit
+    val store_32 : t -> addr:int32 -> int32 -> unit Choice.t
 
-    val store_64 : t -> addr:int32 -> int64 -> unit
+    val store_64 : t -> addr:int32 -> int64 -> unit Choice.t
 
     val grow : t -> int32 -> unit
 

--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -106,7 +106,47 @@ module P = struct
   end
 
   module Memory = struct
-    include Symbolic_memory.M
+    module M = Symbolic_memory.M
+
+    type t = M.t
+
+    let return_or_trap = function
+      | Ok v -> Choice.return v
+      | Error t -> Choice.trap t
+
+    let load_8_s m a = return_or_trap @@ M.load_8_s m a
+
+    let load_8_u m a = return_or_trap @@ M.load_8_s m a
+
+    let load_16_s m a = return_or_trap @@ M.load_8_s m a
+
+    let load_16_u m a = return_or_trap @@ M.load_8_s m a
+
+    let load_32 m a = return_or_trap @@ M.load_8_s m a
+
+    let load_64 m a = return_or_trap @@ M.load_8_s m a
+
+    let store_8 m ~addr v = return_or_trap @@ M.store_8 m ~addr v
+
+    let store_16 m ~addr v = return_or_trap @@ M.store_16 m ~addr v
+
+    let store_32 m ~addr v = return_or_trap @@ M.store_32 m ~addr v
+
+    let store_64 m ~addr v = return_or_trap @@ M.store_64 m ~addr v
+
+    let grow = M.grow
+
+    let fill = M.fill
+
+    let blit = M.blit
+
+    let blit_string = M.blit_string
+
+    let size = M.size
+
+    let size_in_pages = M.size_in_pages
+
+    let get_limit_max = M.get_limit_max
   end
 
   module Data = struct

--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -116,15 +116,15 @@ module P = struct
 
     let load_8_s m a = return_or_trap @@ M.load_8_s m a
 
-    let load_8_u m a = return_or_trap @@ M.load_8_s m a
+    let load_8_u m a = return_or_trap @@ M.load_8_u m a
 
-    let load_16_s m a = return_or_trap @@ M.load_8_s m a
+    let load_16_s m a = return_or_trap @@ M.load_16_s m a
 
-    let load_16_u m a = return_or_trap @@ M.load_8_s m a
+    let load_16_u m a = return_or_trap @@ M.load_16_u m a
 
-    let load_32 m a = return_or_trap @@ M.load_8_s m a
+    let load_32 m a = return_or_trap @@ M.load_32 m a
 
-    let load_64 m a = return_or_trap @@ M.load_8_s m a
+    let load_64 m a = return_or_trap @@ M.load_64 m a
 
     let store_8 m ~addr v = return_or_trap @@ M.store_8 m ~addr v
 

--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -106,47 +106,31 @@ module P = struct
   end
 
   module Memory = struct
-    module M = Symbolic_memory.M
-
-    type t = M.t
+    include Symbolic_memory.M
 
     let return_or_trap = function
       | Ok v -> Choice.return v
       | Error t -> Choice.trap t
 
-    let load_8_s m a = return_or_trap @@ M.load_8_s m a
+    let load_8_s m a = return_or_trap @@ load_8_s m a
 
-    let load_8_u m a = return_or_trap @@ M.load_8_u m a
+    let load_8_u m a = return_or_trap @@ load_8_u m a
 
-    let load_16_s m a = return_or_trap @@ M.load_16_s m a
+    let load_16_s m a = return_or_trap @@ load_16_s m a
 
-    let load_16_u m a = return_or_trap @@ M.load_16_u m a
+    let load_16_u m a = return_or_trap @@ load_16_u m a
 
-    let load_32 m a = return_or_trap @@ M.load_32 m a
+    let load_32 m a = return_or_trap @@ load_32 m a
 
-    let load_64 m a = return_or_trap @@ M.load_64 m a
+    let load_64 m a = return_or_trap @@ load_64 m a
 
-    let store_8 m ~addr v = return_or_trap @@ M.store_8 m ~addr v
+    let store_8 m ~addr v = return_or_trap @@ store_8 m ~addr v
 
-    let store_16 m ~addr v = return_or_trap @@ M.store_16 m ~addr v
+    let store_16 m ~addr v = return_or_trap @@ store_16 m ~addr v
 
-    let store_32 m ~addr v = return_or_trap @@ M.store_32 m ~addr v
+    let store_32 m ~addr v = return_or_trap @@ store_32 m ~addr v
 
-    let store_64 m ~addr v = return_or_trap @@ M.store_64 m ~addr v
-
-    let grow = M.grow
-
-    let fill = M.fill
-
-    let blit = M.blit
-
-    let blit_string = M.blit_string
-
-    let size = M.size
-
-    let size_in_pages = M.size_in_pages
-
-    let get_limit_max = M.get_limit_max
+    let store_64 m ~addr v = return_or_trap @@ store_64 m ~addr v
   end
 
   module Data = struct

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -5,6 +5,8 @@
 module Intf = Interpret_functor_intf
 module Value = Symbolic_value.S
 
+let ( let* ) = Stdlib.Result.bind
+
 module M = struct
   module Expr = Encoding.Expr
   module Ty = Encoding.Ty
@@ -84,7 +86,8 @@ module M = struct
     | Some b -> Some b
     | None -> Option.bind m.parent (load_byte_opt a)
 
-  let load_byte m a = Option.value (load_byte_opt a m) ~default:(Val (Num (I8 0)) @: Ty_bitv S8)
+  let load_byte m a =
+    Option.value (load_byte_opt a m) ~default:(Val (Num (I8 0)) @: Ty_bitv S8)
 
   let merge_extracts (e1, h, m1) (e2, m2, l) =
     if not (m1 = m2 && Expr.equal e1 e2) then
@@ -133,46 +136,55 @@ module M = struct
   (* TODO: *)
   (* 1. Let pointers have symbolic offsets *)
   (* 2. Let addresses have symbolic values *)
-  let calculate_address m (a : int32) : Int32.t =
+  let calculate_address m (a : int32) : (Int32.t, Trap.t) Stdlib.Result.t =
     match a.e with
-    | Val (Num (I32 i)) -> i
+    | Val (Num (I32 i)) -> Ok i
     | Ptr (base, offset) -> (
       match Hashtbl.find_opt m.chunks base with
-      | None -> failwith "Memory leak use after free"
+      | None -> Error Trap.Memory_leak_use_after_free
       | Some size ->
         let ptr = Int32.add base (i32 offset) in
         if ptr < base || ptr > Int32.add base (i32 size) then
-          failwith "Heap buffer overflow"
-        else ptr )
+          Error Trap.Out_of_bounds_memory_access
+        else Ok ptr )
     | _ -> Format.kasprintf failwith "Cannot calculate address of: %a" Expr.pp a
 
   let load_8_s m a =
-    let v = loadn m (calculate_address m a) 1 in
+    let* a = calculate_address m a in
+    let v = loadn m a 1 in
     match v.e with
-    | Val (Num (I8 i8)) -> Value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
-    | _ -> Cvtop (ExtS 24, v) @: Ty_bitv S32
+    | Val (Num (I8 i8)) ->
+      Ok (Value.const_i32 (Int32.extend_s 8 (Int32.of_int i8)))
+    | _ -> Ok (Cvtop (ExtS 24, v) @: Ty_bitv S32)
 
   let load_8_u m a =
-    let v = loadn m (calculate_address m a) 1 in
+    let* a = calculate_address m a in
+    let v = loadn m a 1 in
     match v.e with
-    | Val (Num (I8 i)) -> Value.const_i32 (Int32.of_int i)
-    | _ -> Cvtop (ExtU 24, v) @: Ty_bitv S32
+    | Val (Num (I8 i)) -> Ok (Value.const_i32 (Int32.of_int i))
+    | _ -> Ok (Cvtop (ExtU 24, v) @: Ty_bitv S32)
 
   let load_16_s m a =
-    let v = loadn m (calculate_address m a) 2 in
+    let* a = calculate_address m a in
+    let v = loadn m a 2 in
     match v.e with
-    | Val (Num (I32 i16)) -> Value.const_i32 (Int32.extend_s 16 i16)
-    | _ -> Cvtop (ExtS 16, v) @: Ty_bitv S32
+    | Val (Num (I32 i16)) -> Ok (Value.const_i32 (Int32.extend_s 16 i16))
+    | _ -> Ok (Cvtop (ExtS 16, v) @: Ty_bitv S32)
 
   let load_16_u m a =
-    let v = loadn m (calculate_address m a) 2 in
+    let* a = calculate_address m a in
+    let v = loadn m a 2 in
     match v.e with
-    | Val (Num (I32 _)) -> v
-    | _ -> Cvtop (ExtU 16, v) @: Ty_bitv S32
+    | Val (Num (I32 _)) -> Ok v
+    | _ -> Ok (Cvtop (ExtU 16, v) @: Ty_bitv S32)
 
-  let load_32 m a = loadn m (calculate_address m a) 4
+  let load_32 m a =
+    let* a = calculate_address m a in
+    Ok (loadn m a 4)
 
-  let load_64 m a = loadn m (calculate_address m a) 8
+  let load_64 m a =
+    let* a = calculate_address m a in
+    Ok (loadn m a 8)
 
   let extract v pos =
     match v.e with
@@ -189,12 +201,13 @@ module M = struct
     | _ -> Extract (v, pos + 1, pos) @: Ty_bitv S8
 
   let storen m ~addr v n =
-    let a0 = calculate_address m addr in
+    let* a0 = calculate_address m addr in
     for i = 0 to n - 1 do
       let addr' = Int32.add a0 (Int32.of_int i) in
       let v' = extract v i in
       Hashtbl.replace m.data addr' v'
-    done
+    done;
+    Ok ()
 
   let store_8 m ~addr v = storen m ~addr v 1
 
@@ -206,8 +219,6 @@ module M = struct
 
   let get_limit_max _m = None (* TODO *)
 end
-
-module M' : Intf.Memory_data = M
 
 module ITbl = Hashtbl.Make (struct
   include Int

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -145,7 +145,7 @@ module M = struct
       | Some size ->
         let ptr = Int32.add base (i32 offset) in
         if ptr < base || ptr > Int32.add base (i32 size) then
-          Error Trap.Out_of_bounds_memory_access
+          Error Trap.Memory_heap_buffer_overflow
         else Ok ptr )
     | _ -> Format.kasprintf failwith "Cannot calculate address of: %a" Expr.pp a
 

--- a/src/symbolic_value.ml
+++ b/src/symbolic_value.ml
@@ -29,7 +29,7 @@ let binop ty op e1 e2 =
     Val (Num (Eval_numeric.eval_binop ty op n1 n2)) @: ty
   | Ptr _, _ | _, Ptr _ ->
     (* Does pointer arithmetic *)
-    Expr.simplify @@ (Binop (op, e1, e2) @: Ty_bitv S32)
+    Expr.simplify @@ Binop (op, e1, e2) @: Ty_bitv S32
   | _ -> Binop (op, e1, e2) @: ty
 
 let relop ty op e1 e2 =
@@ -41,7 +41,8 @@ let relop ty op e1 e2 =
     Val (if Eval_numeric.eval_relop ty op n base then True else False) @: ty
   | Ptr (b, { e = Val (Num o); _ }), Val (Num n) ->
     let base = Eval_numeric.eval_binop (Ty_bitv S32) Add (I32 b) o in
-    Val (if Eval_numeric.eval_relop ty op base n then True else False) @: ty
+    let b = Eval_numeric.eval_relop ty op base n in
+    Val (if b then True else False) @: ty
   | _ -> Relop (op, e1, e2) @: ty
 
 let cvtop ty op e =

--- a/src/trap.ml
+++ b/src/trap.ml
@@ -14,6 +14,7 @@ type t =
   | Indirect_call_type_mismatch
   | Extern_call_arg_type_mismatch
   | Extern_call_null_arg
+  | Memory_leak_use_after_free
 
 let to_string = function
   | Out_of_bounds_table_access -> "out of bounds table access"
@@ -28,3 +29,4 @@ let to_string = function
   | Indirect_call_type_mismatch -> "indirect call type mismatch"
   | Extern_call_arg_type_mismatch -> "extern call arg type mismatch"
   | Extern_call_null_arg -> "extern call null arg"
+  | Memory_leak_use_after_free -> "memory leak use after free"

--- a/src/trap.ml
+++ b/src/trap.ml
@@ -15,6 +15,7 @@ type t =
   | Extern_call_arg_type_mismatch
   | Extern_call_null_arg
   | Memory_leak_use_after_free
+  | Memory_heap_buffer_overflow
 
 let to_string = function
   | Out_of_bounds_table_access -> "out of bounds table access"
@@ -30,3 +31,4 @@ let to_string = function
   | Extern_call_arg_type_mismatch -> "extern call arg type mismatch"
   | Extern_call_null_arg -> "extern call null arg"
   | Memory_leak_use_after_free -> "memory leak use after free"
+  | Memory_heap_buffer_overflow -> "memory heap buffer overflow"

--- a/src/trap.mli
+++ b/src/trap.mli
@@ -11,5 +11,6 @@ type t =
   | Extern_call_arg_type_mismatch
   | Extern_call_null_arg
   | Memory_leak_use_after_free
+  | Memory_heap_buffer_overflow
 
 val to_string : t -> string

--- a/src/trap.mli
+++ b/src/trap.mli
@@ -10,5 +10,6 @@ type t =
   | Indirect_call_type_mismatch
   | Extern_call_arg_type_mismatch
   | Extern_call_null_arg
+  | Memory_leak_use_after_free
 
 val to_string : t -> string


### PR DESCRIPTION
Hi @zapashcanon!

Here's a quick summary of the introduced changes:

1. Adds heap pointer tracking to the symbolic memory, enabling the detection of:
    - Heap buffer overflows
    - Use-after-free errors
    - Double frees
    - Memory leaks (Currently not reporting, but we only need to check if there are still bindings in the `chunks` table at the end of the program)

2. Enables the creation of `I8` symbols with the external function `i8_symbol`.

3. Stores concrete bytes in the symbolic memory using `I8` instead of `I32`.

Ideally, in the external functions, I would prefer a more direct way of interacting with the memory. This would simplify the code for `alloc` and `free`, and it would also allow for a more accurate characterization of memory leaks.

Also, I added a couple C examples [here](https://github.com/formalsec/waspc/tree/main/examples/memory-safety), but the compiled version is also there if you want to test it directly :smiley: 