### PR TITLE
Concretise symbolic memory addresses and allow symbolic heap sizes

### DIFF
--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -113,12 +113,12 @@ let summaries_extern_module : Symbolic.P.extern_func Link.extern_module =
   let i32 v =
     match v.e with
     | Val (Num (I32 v)) -> v
-    | _ -> Log.err {|Unable to cast int32 of "%a"|} Expr.pp v
+    | _ -> Log.err {|alloc: cannot allocate base pointer "%a"|} Expr.pp v
   in
   let ptr v =
     match v.e with
     | Ptr (b, _) -> b
-    | _ -> Log.err {|Unable to fetch pointer base of "%a"|} Expr.pp v
+    | _ -> Log.err {|free: cannot fetch pointer base of "%a"|} Expr.pp v
   in
   let abort () : unit Choice.t = Choice.add_pc @@ Value.Bool.const false in
   let alloc (base : Value.int32) (size : Value.int32) : Value.int32 Choice.t =

--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -119,8 +119,6 @@ module P = struct
             (* TODO: can we remove this check? We should be in a SAT branch *)
             assert (Solver.check solver @@ Thread.pc thread);
             let concrete_offest = Solver.get_value solver offset in
-            Format.pp_std "Concretise: %a = %a@." Expr.pp offset Expr.pp
-              concrete_offest;
             let cond = Relop (Eq, offset, concrete_offest) @: a.ty in
             (* TODO: this should go to the pc *)
             Solver.add solver [ cond ];
@@ -129,8 +127,6 @@ module P = struct
             (* TODO: can we remove this check? We should be in a SAT branch *)
             assert (Solver.check solver @@ Thread.pc thread);
             let concrete_addr = Solver.get_value solver a in
-            Format.pp_std "Concretise: %a = %a@." Expr.pp a Expr.pp
-              concrete_addr;
             let cond = Relop (Eq, a, concrete_addr) @: a.ty in
             (* TODO: this should go to the pc *)
             Solver.add solver [ cond ];

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -41,7 +41,9 @@ module M = struct
     let old_size = Value.I32.mul m.size page_size in
     let new_size = Value.I32.(div (add old_size delta) page_size) in
     m.size <-
-      Triop (Ite, Value.I32.gt new_size m.size, new_size, m.size) @: Ty_bool
+      Value.Bool.select_expr
+        (Value.I32.gt new_size m.size)
+        ~if_true:new_size ~if_false:m.size
 
   let size { size; _ } = Value.I32.mul size page_size
 

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -93,13 +93,14 @@ module M = struct
       | None -> Val (Num (I8 0)) @: Ty_bitv S8
       | Some parent -> load_byte parent a )
 
+  (* TODO: don't rebuild so many values it generates unecessary hc lookups *)
   let merge_extracts (e1, h, m1) (e2, m2, l) =
-    if m1 <> m2 && not (Expr.equal e1 e2) then
+    if m1 = m2 && Expr.equal e1 e2 then
+      if h - l = Ty.size e1.ty then e1 else Extract (e1, h, l) @: e1.ty
+    else
       Expr.(
         Concat (Extract (e1, h, m1) @: e1.ty, Extract (e2, m2, l) @: e1.ty)
         @: e1.ty )
-    else if h - l = Ty.size e1.ty then e1
-    else Extract (e1, h, l) @: e1.ty
 
   let concat ~msb ~lsb offset =
     assert (offset > 0 && offset <= 8);

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -41,7 +41,7 @@ module M = struct
     let old_size = Value.I32.mul m.size page_size in
     let new_size = Value.I32.(div (add old_size delta) page_size) in
     m.size <-
-      Triop (Ite, Value.I32.gt new_size old_size, new_size, old_size) @: Ty_bool
+      Triop (Ite, Value.I32.gt new_size m.size, new_size, m.size) @: Ty_bool
 
   let size { size; _ } = Value.I32.mul size page_size
 

--- a/src/symbolic_value.ml
+++ b/src/symbolic_value.ml
@@ -169,8 +169,6 @@ module S = struct
   end
 
   module I32 = struct
-    open Expr
-
     type num = Expr.t
 
     type vbool = Expr.t

--- a/src/symbolic_value.ml
+++ b/src/symbolic_value.ml
@@ -157,7 +157,7 @@ module S = struct
       | Some false -> if_false
       | None -> Triop (Ite, c, if_true, if_false) @: Ty_bool
 
-    let pp ppf (e : vbool) = Format.pp_string ppf (Expr.to_string e)
+    let pp ppf (e : vbool) = Expr.pp ppf e
   end
 
   module I32 = struct

--- a/src/symbolic_value.ml
+++ b/src/symbolic_value.ml
@@ -277,7 +277,9 @@ module S = struct
 
     let wrap_i64 x = cvtop ty WrapI64 x
 
-    let extend_s n x = cvtop ty (ExtS n) x
+    (* FIXME: This is probably wrong? *)
+    let extend_s n x =
+      cvtop ty (ExtS (32 - n)) (Extract (x, n / 8, 0) @: Ty_bitv S32)
   end
 
   module I64 = struct
@@ -375,7 +377,9 @@ module S = struct
 
     let reinterpret_f64 x = cvtop ty Reinterpret_float x
 
-    let extend_s n x = cvtop ty (ExtS n) x
+    (* FIXME: This is probably wrong? *)
+    let extend_s n x =
+      cvtop ty (ExtS (64 - n)) (Extract (x, n / 8, 0) @: Ty_bitv S64)
 
     let extend_i32_s x = cvtop ty (ExtS 32) x
 

--- a/test/sym/grow.wast
+++ b/test/sym/grow.wast
@@ -8,11 +8,11 @@
     (local.set
       $x
       (call $i32_symbol))
-    ;; assume: x >= 0
+    ;; assume: x >= 1
     (call $assume
       (i32.ge_s
         (local.get $x)
-        (i32.const 0)))
+        (i32.const 1)))
     ;; assume: x < 3
     (call $assume
       (i32.lt_s
@@ -21,9 +21,13 @@
     (memory.grow
       (local.get $x))
     (drop)
-    ;; Store something on the second page: addr > 65_536, fails when x = 0
+    ;; Store something on the second page: pass
     (i32.store
       (i32.const 65536)
+      (i32.const 42))
+    ;; Store something on the third page (addr > 131_072) fails when x = 1
+    (i32.store
+      (i32.const 131072)
       (i32.const 1337)))
   (func $start
     call $test_out_of_bounds_with_symbolic_grow)

--- a/test/sym/grow.wast
+++ b/test/sym/grow.wast
@@ -1,0 +1,31 @@
+(module
+  (import "symbolic" "i32_symbol" (func $i32_symbol (result i32)))
+  (import "symbolic" "assume" (func $assume (param i32)))
+  ;; This is just to see whether we can detect the failure
+  (func $test_out_of_bounds_with_symbolic_grow
+      (local $x i32)
+    ;; x = i32.symbol
+    (local.set
+      $x
+      (call $i32_symbol))
+    ;; assume: x >= 0
+    (call $assume
+      (i32.ge_s
+        (local.get $x)
+        (i32.const 0)))
+    ;; assume: x < 3
+    (call $assume
+      (i32.lt_s
+        (local.get $x)
+        (i32.const 3)))
+    (memory.grow
+      (local.get $x))
+    (drop)
+    ;; Store something on the second page: addr > 65_536, fails when x = 0
+    (i32.store
+      (i32.const 65536)
+      (i32.const 1337)))
+  (func $start
+    call $test_out_of_bounds_with_symbolic_grow)
+  (memory $m 1)
+  (start $start))


### PR DESCRIPTION
## Two things this PR addresses

1. **Allow Symbolic Heap Sizes:** `memory.grow` now accepts symbolic arguments (example in [grow.wast](https://github.com/formalsec/owi/blob/concretise/test/sym/grow.wast)).

2. **Concretisation of Symbolic Memory Accesses:** This results in an under-approximating analysis, meaning that we accept some unsoundness for increased completeness.

Example of a scenario we might fail to encounter:

   ```c
   #include <owi.h>
   int main() {
     int i = owi_i32();
     int n = 16;
     owi_assume(i > 0);

     int *chunk = (int *)malloc(sizeof(int) * n);
     chunk[i] = 0;

     return 0;
   }
   ```

Depending on the concretisation of `i`, we might not flag the heap buffer overflow vulnerability. However, previously, we would encounter a failure.

But, we can always introduce some form of branching here to try to mitigate this.

## What We Still Don't Support

Symbolic allocations, i.e., using `malloc(symbolic_size)`, are not yet supported. This is because it would make the `__heap_base` (i.e., `bump_pointer` in `malloc`) symbolic. However, I can also concretise the interactions with `malloc`. @krtab, please let me know if this is required for #99.