### PR TITLE
error properly on unknown label instead of crash

### DIFF
--- a/test/script/gc.t
+++ b/test/script/gc.t
@@ -12,11 +12,11 @@
   [1]
   $ dune exec owi -- script --no-exhaustion gc/extern.wast
   owi: internal error, uncaught exception:
-       File "src/typecheck.ml", line 493, characters 4-10: Assertion failed
-       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 493, characters 4-16
+       File "src/typecheck.ml", line 496, characters 4-10: Assertion failed
+       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 496, characters 4-16
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
-       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 505, characters 15-59
-       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 527, characters 6-112
+       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 508, characters 15-59
+       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 530, characters 6-112
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
        Called from Owi__Compile.until_typecheck in file "src/compile.ml", line 28, characters 14-31
        Called from Owi__Compile.until_optimize in file "src/compile.ml", line 32, characters 11-36
@@ -49,11 +49,11 @@
   [125]
   $ dune exec owi -- script --no-exhaustion gc/ref_cast.wast
   owi: internal error, uncaught exception:
-       File "src/typecheck.ml", line 493, characters 4-10: Assertion failed
-       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 493, characters 4-16
+       File "src/typecheck.ml", line 496, characters 4-10: Assertion failed
+       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 496, characters 4-16
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
-       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 505, characters 15-59
-       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 527, characters 6-112
+       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 508, characters 15-59
+       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 530, characters 6-112
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
        Called from Owi__Compile.until_typecheck in file "src/compile.ml", line 28, characters 14-31
        Called from Owi__Compile.until_optimize in file "src/compile.ml", line 32, characters 11-36
@@ -71,11 +71,11 @@
   [125]
   $ dune exec owi -- script --no-exhaustion gc/ref_eq.wast
   owi: internal error, uncaught exception:
-       File "src/typecheck.ml", line 493, characters 4-10: Assertion failed
-       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 493, characters 4-16
+       File "src/typecheck.ml", line 496, characters 4-10: Assertion failed
+       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 496, characters 4-16
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
-       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 505, characters 15-59
-       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 527, characters 6-112
+       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 508, characters 15-59
+       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 530, characters 6-112
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
        Called from Owi__Compile.until_typecheck in file "src/compile.ml", line 28, characters 14-31
        Called from Owi__Compile.until_optimize in file "src/compile.ml", line 32, characters 11-36
@@ -93,11 +93,11 @@
   [125]
   $ dune exec owi -- script --no-exhaustion gc/ref_test.wast
   owi: internal error, uncaught exception:
-       File "src/typecheck.ml", line 493, characters 4-10: Assertion failed
-       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 493, characters 4-16
+       File "src/typecheck.ml", line 496, characters 4-10: Assertion failed
+       Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 496, characters 4-16
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
-       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 505, characters 15-59
-       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 527, characters 6-112
+       Called from Owi__Typecheck.typecheck_expr in file "src/typecheck.ml", line 508, characters 15-59
+       Called from Owi__Typecheck.typecheck_function in file "src/typecheck.ml", line 530, characters 6-112
        Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
        Called from Owi__Compile.until_typecheck in file "src/compile.ml", line 28, characters 14-31
        Called from Owi__Compile.until_optimize in file "src/compile.ml", line 32, characters 11-36

--- a/test/validate/dune
+++ b/test/validate/dune
@@ -1,2 +1,2 @@
 (cram
- (deps %{bin:owi}))
+ (deps %{bin:owi} unknown_label.wat))

--- a/test/validate/unknown_label.t
+++ b/test/validate/unknown_label.t
@@ -1,0 +1,3 @@
+  $ dune exec owi -- validate ./unknown_label.wat
+  unknown label 2
+  [1]

--- a/test/validate/unknown_label.wat
+++ b/test/validate/unknown_label.wat
@@ -1,0 +1,15 @@
+(module
+  (func $f
+    (loop
+      br 0
+      br 1
+      br 2
+      (loop
+        br 0
+        br 1
+        br 2
+        br 3
+        br 4
+      )
+    )
+  ))


### PR DESCRIPTION
fix #50

TODO: once #137 is merged, add a test for this in `test/validate`