### PR TITLE
switch to digestif

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,7 @@
   (graphics :dev)
   (tiny_httpd :dev)
   (ocamlformat :dev)
-  sha
+  digestif
   xmlm
   pyml
   re2

--- a/owi.opam
+++ b/owi.opam
@@ -34,7 +34,7 @@ depends: [
   "graphics" {dev}
   "tiny_httpd" {dev}
   "ocamlformat" {dev}
-  "sha"
+  "digestif"
   "xmlm"
   "pyml"
   "re2"

--- a/src/dune
+++ b/src/dune
@@ -71,6 +71,7 @@
  (private_modules convert lexer menhir_parser spectest wutf8 tracing)
  (libraries
   bos
+  digestif
   dune-site
   encoding
   hc
@@ -80,7 +81,6 @@
   ppxlib
   pyml
   re2
-  sha
   sedlex
   uutf
   runtime_events


### PR DESCRIPTION
Fix #101.

@filipeom, I don't really understand what was the old code doing:

```ocaml
let hash = List.fold_left (fun _ f -> Sha256.file f) Sha256.zero files in
```

It seems like we were discarding the context each time, which does not make sense to me. Also as we are concatenating all the files with: `let file = String.concat " " files in`, I'm not sure we are really computing the right hash. Could you explain why we are doing these two things ?

(This should be rebased after #133 is merged to avoid the `Fpath.v` conversion.