### PR TITLE
Fix symbolic br_table

### DIFF
--- a/example/c/README.md
+++ b/example/c/README.md
@@ -131,18 +131,21 @@ int main (void) {
     old_x = x;
     old_y = y;
 
-    char c = program[i];
-
-    if (c == 'w') {
-      y--;
-    } else if (c == 's') {
-      y++;
-    } else if (c == 'a') {
-      x--;
-    } else if (c == 'd') {
-      x++;
-    } else {
-      return 1;
+    switch (program[i]) {
+      case 'w':
+        y--;
+        break;
+      case 's':
+        y++;
+        break;
+      case 'a':
+        x--;
+        break;
+      case 'd':
+        x++;
+        break;
+      default:
+        return 1;
     }
 
     if (maze[y][x] == '#') {

--- a/example/c/maze.c
+++ b/example/c/maze.c
@@ -36,18 +36,21 @@ int main (void) {
     old_x = x;
     old_y = y;
 
-    char c = program[i];
-
-    if (c == 'w') {
-      y--;
-    } else if (c == 's') {
-      y++;
-    } else if (c == 'a') {
-      x--;
-    } else if (c == 'd') {
-      x++;
-    } else {
-      return 1;
+    switch (program[i]) {
+      case 'w':
+        y--;
+        break;
+      case 's':
+        y++;
+        break;
+      case 'a':
+        x--;
+        break;
+      case 'd':
+        x++;
+        break;
+      default:
+        return 1;
     }
 
     if (maze[y][x] == '#') {

--- a/src/symbolic_choice.ml
+++ b/src/symbolic_choice.ml
@@ -79,11 +79,17 @@ end = struct
         let thread2 = Thread.clone { thread with pc = with_not_v } in
         M.cons (true, thread1) (M.return (false, thread2)) )
 
+  let fresh_symbol_count = ref 0
+  let fresh_symbol name =
+    let n = !fresh_symbol_count in
+    incr fresh_symbol_count;
+    Printf.sprintf "%s_%i" name n
+
   let fix_symbol (e : Expr.t) pc =
     match e.node.e with
     | Symbol sym -> (pc, sym)
     | _ ->
-      let sym = Symbol.("choice_i32" @: Ty_bitv S32) in
+      let sym = Symbol.(fresh_symbol "choice_i32" @: Ty_bitv S32) in
       let assign = Expr.(Relop (Eq, mk_symbol sym, e) @: Ty_bitv S32) in
       (assign :: pc, sym)
 

--- a/src/thread.ml
+++ b/src/thread.ml
@@ -10,6 +10,7 @@ type solver = S : 'a solver_module * 'a -> solver
 
 type t =
   { solver : solver
+  ; choices : int
   ; pc : Symbolic_value.S.vbool list
   ; memories : Symbolic_memory.memories
   ; tables : Symbolic_table.tables
@@ -31,14 +32,15 @@ let solver_mod : Solver.t solver_module = (module Solver)
 let create () =
   let solver = S (solver_mod, Solver.create ~logic:QF_BVFP ()) in
   { solver
+  ; choices = 0
   ; pc = []
   ; memories = Symbolic_memory.init ()
   ; tables = Symbolic_table.init ()
   ; globals = Symbolic_global.init ()
   }
 
-let clone { solver; pc; memories; tables; globals } =
+let clone { solver; choices; pc; memories; tables; globals } =
   let memories = Symbolic_memory.clone memories in
   let tables = Symbolic_table.clone tables in
   let globals = Symbolic_global.clone globals in
-  { solver; pc; memories; tables; globals }
+  { solver; choices; pc; memories; tables; globals }


### PR DESCRIPTION
Avoids sharing choice_i32 between different choices...
Also improve the performances by swaping the overflow test and the select_i32
Reverts the maze test to use a br_table