### PR TITLE
Adds collections-c symbolic tests

### DIFF
--- a/test/c/collections-c/bugs/buggy_tests.t
+++ b/test/c/collections-c/bugs/buggy_tests.t
@@ -1,0 +1,25 @@
+Bug-triggering tests:
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array_test_remove.c
+  Trap: memory heap buffer overflow
+  Model:
+    (model
+      (symbol_0 (i32 8)))
+  Reached problem!
+  [1]
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list_test_zipIterAdd.c --no-value
+  Assert failure: false
+  Model:
+    (model
+      (symbol_0 i32)
+      (symbol_1 i32)
+      (symbol_10 i32)
+      (symbol_2 i32)
+      (symbol_3 i32)
+      (symbol_4 i32)
+      (symbol_5 i32)
+      (symbol_6 i32)
+      (symbol_7 i32)
+      (symbol_8 i32)
+      (symbol_9 i32))
+  Reached problem!
+  [1]

--- a/test/c/collections-c/bugs/dune
+++ b/test/c/collections-c/bugs/dune
@@ -1,0 +1,7 @@
+(cram
+ (deps
+  %{bin:owi}
+  (package owi)
+  (source_tree include)
+  (source_tree src)
+  (source_tree testsuite)))

--- a/test/c/collections-c/bugs/include/array.h
+++ b/test/c/collections-c/bugs/include/array.h
@@ -1,0 +1,171 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_ARRAY_H
+#define COLLECTIONS_C_ARRAY_H
+
+#include "common.h"
+
+/**
+ * A dynamic array that expands automatically as elements are
+ * added. The array supports amortized constant time insertion
+ * and removal of elements at the end of the array, as well as
+ * constant time access.
+ */
+typedef struct array_s Array;
+
+/**
+ * Array configuration structure. Used to initialize a new Array
+ * with specific values.
+ */
+typedef struct array_conf_s {
+  /**
+   * The initial capacity of the array */
+  size_t capacity;
+
+  /**
+   * The rate at which the buffer expands (capacity * exp_factor). */
+  float exp_factor;
+
+  /**
+   * Memory allocators used to allocate the Array structure and the
+   * underlying data buffers. */
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+} ArrayConf;
+
+/**
+ * Array iterator structure. Used to iterate over the elements of
+ * the array in an ascending order. The iterator also supports
+ * operations for safely adding and removing elements during
+ * iteration.
+ */
+typedef struct array_iter_s {
+  /**
+   * The array associated with this iterator */
+  Array *ar;
+
+  /**
+   * The current position of the iterator.*/
+  size_t index;
+
+  /**
+   * Set to true if the last returned element was removed. */
+  bool last_removed;
+} ArrayIter;
+
+/**
+ * Array zip iterator structure. Used to iterate over the elements of two
+ * arrays in lockstep in an ascending order until one of the Arrays is
+ * exhausted. The iterator also supports operations for safely adding
+ * and removing elements during iteration.
+ */
+typedef struct array_zip_iter_s {
+  Array *ar1;
+  Array *ar2;
+  size_t index;
+  bool last_removed;
+} ArrayZipIter;
+
+enum cc_stat array_new(Array **out);
+enum cc_stat array_new_conf(ArrayConf const *const conf, Array **out);
+void array_conf_init(ArrayConf *conf);
+
+void array_destroy(Array *ar);
+void array_destroy_cb(Array *ar, void (*cb)(void *));
+
+enum cc_stat array_add(Array *ar, void *element);
+enum cc_stat array_add_at(Array *ar, void *element, size_t index);
+enum cc_stat array_replace_at(Array *ar, void *element, size_t index,
+                              void **out);
+enum cc_stat array_swap_at(Array *ar, size_t index1, size_t index2);
+
+enum cc_stat array_remove(Array *ar, void *element, void **out);
+enum cc_stat array_remove_at(Array *ar, size_t index, void **out);
+enum cc_stat array_remove_last(Array *ar, void **out);
+void array_remove_all(Array *ar);
+void array_remove_all_free(Array *ar);
+
+enum cc_stat array_get_at(Array *ar, size_t index, void **out);
+enum cc_stat array_get_last(Array *ar, void **out);
+
+enum cc_stat array_subarray(Array *ar, size_t from, size_t to, Array **out);
+enum cc_stat array_copy_shallow(Array *ar, Array **out);
+enum cc_stat array_copy_deep(Array *ar, void *(*cp)(void *), Array **out);
+
+void array_reverse(Array *ar);
+enum cc_stat array_trim_capacity(Array *ar);
+
+size_t array_contains(Array *ar, void *element);
+size_t array_contains_value(Array *ar, void *element,
+                            int (*cmp)(const void *, const void *));
+size_t array_size(Array *ar);
+size_t array_capacity(Array *ar);
+
+enum cc_stat array_index_of(Array *ar, void *element, size_t *index);
+void array_sort(Array *ar, int (*cmp)(const void *, const void *));
+
+void array_map(Array *ar, void (*fn)(void *));
+void array_reduce(Array *ar, void (*fn)(void *, void *, void *), void *result);
+
+enum cc_stat array_filter_mut(Array *ar, bool (*predicate)(const void *));
+enum cc_stat array_filter(Array *ar, bool (*predicate)(const void *),
+                          Array **out);
+
+void array_iter_init(ArrayIter *iter, Array *ar);
+enum cc_stat array_iter_next(ArrayIter *iter, void **out);
+enum cc_stat array_iter_remove(ArrayIter *iter, void **out);
+enum cc_stat array_iter_add(ArrayIter *iter, void *element);
+enum cc_stat array_iter_replace(ArrayIter *iter, void *element, void **out);
+size_t array_iter_index(ArrayIter *iter);
+
+void array_zip_iter_init(ArrayZipIter *iter, Array *a1, Array *a2);
+enum cc_stat array_zip_iter_next(ArrayZipIter *iter, void **out1, void **out2);
+enum cc_stat array_zip_iter_add(ArrayZipIter *iter, void *e1, void *e2);
+enum cc_stat array_zip_iter_remove(ArrayZipIter *iter, void **out1,
+                                   void **out2);
+enum cc_stat array_zip_iter_replace(ArrayZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2);
+size_t array_zip_iter_index(ArrayZipIter *iter);
+
+const void *const *array_get_buffer(Array *ar);
+
+#define ARRAY_FOREACH(val, array, body)                                        \
+  {                                                                            \
+    ArrayIter array_iter_53d46d2a04458e7b;                                     \
+    array_iter_init(&array_iter_53d46d2a04458e7b, array);                      \
+    void *val;                                                                 \
+    while (array_iter_next(&array_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+      body                                                                     \
+  }
+
+#define ARRAY_FOREACH_ZIP(val1, val2, array1, array2, body)                    \
+  {                                                                            \
+    ArrayZipIter array_zip_iter_ea08d3e52f25883b3;                             \
+    array_zip_iter_init(&array_zip_iter_ea08d3e52f25883b, array1, array2);     \
+    void *val1;                                                                \
+    void *val2;                                                                \
+    while (array_zip_iter_next(&array_zip_iter_ea08d3e52f25883b3, &val1,       \
+                               &val2) != CC_ITER_END)                          \
+      body                                                                     \
+  }
+
+#endif /* COLLECTIONS_C_ARRAY_H */

--- a/test/c/collections-c/bugs/include/common.h
+++ b/test/c/collections-c/bugs/include/common.h
@@ -1,0 +1,68 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_COMMON_H
+#define COLLECTIONS_C_COMMON_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef ARCH_64
+#define MAX_POW_TWO (((size_t)1) << 63)
+#else
+#define MAX_POW_TWO (((size_t)1) << 31)
+#endif /* ARCH_64 */
+
+enum cc_stat {
+  CC_OK = 0,
+
+  CC_ERR_ALLOC = 1,
+  CC_ERR_INVALID_CAPACITY = 2,
+  CC_ERR_INVALID_RANGE = 3,
+  CC_ERR_MAX_CAPACITY = 4,
+  CC_ERR_KEY_NOT_FOUND = 6,
+  CC_ERR_VALUE_NOT_FOUND = 7,
+  CC_ERR_OUT_OF_RANGE = 8,
+
+  CC_ITER_END = 9,
+};
+
+#define CC_MAX_ELEMENTS 16777216LU
+
+#if defined(_MSC_VER)
+
+#define INLINE __inline
+#define FORCE_INLINE __forceinline
+
+#else
+
+#define INLINE inline
+#define FORCE_INLINE inline __attribute__((always_inline))
+
+#endif /* _MSC_VER */
+
+int cc_common_cmp_ptr(const void *key1, const void *key2);
+
+#define CC_CMP_STRING cc_common_cmp_str
+#define CC_CMP_POINTER cc_common_cmp_ptr
+
+#endif /* COLLECTIONS_C_COMMON_H */

--- a/test/c/collections-c/bugs/include/list.h
+++ b/test/c/collections-c/bugs/include/list.h
@@ -1,0 +1,190 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_LIST_H
+#define COLLECTIONS_C_LIST_H
+
+#include "common.h"
+
+/**
+ * A doubly linked list. List is a sequential structure that
+ * supports insertion, deletion and lookup from both ends in
+ * constant time, while the worst case is O(n/2) at the middle
+ * of the list.
+ */
+typedef struct list_s List;
+
+/**
+ * List node.
+ *
+ * @note Modifying the links may invalidate the list structure.
+ */
+typedef struct node_s {
+  void *data;
+  struct node_s *next;
+  struct node_s *prev;
+} Node;
+
+/**
+ * List iterator structure. Used to iterate over the elements of the
+ * list in an ascending or descending order. The iterator also supports
+ * operations for safely adding and removing elements during iteration.
+ */
+typedef struct list_iter_s {
+  /**
+   * The current position of the iterator.*/
+  size_t index;
+
+  /**
+   * The list associated with this iterator */
+  List *list;
+
+  /**
+   * Last returned node */
+  Node *last;
+
+  /**
+   * Next node in the sequence. */
+  Node *next;
+} ListIter;
+
+/**
+ * List zip iterator structure. Used to iterate over two Lists in
+ * lockstep in an ascending order until one of the lists is exhausted.
+ * The iterator also supports operations for safely adding and
+ * removing elements during iteration.
+ */
+typedef struct list_zip_iter_s {
+  List *l1;
+  List *l2;
+  Node *l1_last;
+  Node *l2_last;
+  Node *l1_next;
+  Node *l2_next;
+  size_t index;
+} ListZipIter;
+
+/**
+ * List configuration structure. Used to initialize a new List with specific
+ * values.
+ */
+typedef struct list_conf_s {
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+} ListConf;
+
+void list_conf_init(ListConf *conf);
+enum cc_stat list_new(List **list);
+enum cc_stat list_new_conf(ListConf const *const conf, List **list);
+void list_destroy(List *list);
+void list_destroy_cb(List *list, void (*cb)(void *));
+
+enum cc_stat list_splice(List *list1, List *list2);
+enum cc_stat list_splice_at(List *list, List *list2, size_t index);
+
+enum cc_stat list_add(List *list, void *element);
+enum cc_stat list_add_at(List *list, void *element, size_t index);
+enum cc_stat list_add_all(List *list1, List *list2);
+enum cc_stat list_add_all_at(List *list, List *list2, size_t index);
+enum cc_stat list_add_first(List *list, void *element);
+enum cc_stat list_add_last(List *list, void *element);
+
+enum cc_stat list_remove(List *list, void *element, void **out);
+enum cc_stat list_remove_first(List *list, void **out);
+enum cc_stat list_remove_last(List *list, void **out);
+enum cc_stat list_remove_at(List *list, size_t index, void **out);
+
+enum cc_stat list_remove_all(List *list);
+enum cc_stat list_remove_all_cb(List *list, void (*cb)(void *));
+
+enum cc_stat list_get_at(List *list, size_t index, void **out);
+enum cc_stat list_get_first(List *list, void **out);
+enum cc_stat list_get_last(List *list, void **out);
+
+enum cc_stat list_sublist(List *list, size_t from, size_t to, List **out);
+enum cc_stat list_copy_shallow(List *list, List **out);
+enum cc_stat list_copy_deep(List *list, void *(*cp)(void *), List **out);
+
+enum cc_stat list_replace_at(List *list, void *element, size_t index,
+                             void **out);
+
+size_t list_contains(List *list, void *element);
+size_t list_contains_value(List *list, void *element,
+                           int (*cmp)(const void *, const void *));
+enum cc_stat list_index_of(List *list, void *element,
+                           int (*cmp)(const void *, const void *),
+                           size_t *index);
+enum cc_stat list_to_array(List *list, void ***out);
+
+void list_reverse(List *list);
+enum cc_stat list_sort(List *list, int (*cmp)(void const *, void const *));
+void list_sort_in_place(List *list, int (*cmp)(void const *, void const *));
+size_t list_size(List *list);
+
+void list_foreach(List *list, void (*op)(void *));
+
+enum cc_stat list_filter_mut(List *list, bool (*predicate)(const void *));
+enum cc_stat list_filter(List *list, bool (*predicate)(const void *),
+                         List **out);
+
+void list_iter_init(ListIter *iter, List *list);
+enum cc_stat list_iter_remove(ListIter *iter, void **out);
+enum cc_stat list_iter_add(ListIter *iter, void *element);
+enum cc_stat list_iter_replace(ListIter *iter, void *element, void **out);
+size_t list_iter_index(ListIter *iter);
+enum cc_stat list_iter_next(ListIter *iter, void **out);
+
+void list_diter_init(ListIter *iter, List *list);
+enum cc_stat list_diter_remove(ListIter *iter, void **out);
+enum cc_stat list_diter_add(ListIter *iter, void *element);
+enum cc_stat list_diter_replace(ListIter *iter, void *element, void **out);
+size_t list_diter_index(ListIter *iter);
+enum cc_stat list_diter_next(ListIter *iter, void **out);
+
+void list_zip_iter_init(ListZipIter *iter, List *l1, List *l2);
+enum cc_stat list_zip_iter_next(ListZipIter *iter, void **out1, void **out2);
+enum cc_stat list_zip_iter_add(ListZipIter *iter, void *e1, void *e2);
+enum cc_stat list_zip_iter_remove(ListZipIter *iter, void **out1, void **out2);
+enum cc_stat list_zip_iter_replace(ListZipIter *iter, void *e1, void *e2,
+                                   void **out1, void **out2);
+size_t list_zip_iter_index(ListZipIter *iter);
+
+#define LIST_FOREACH(val, list, body)                                          \
+  {                                                                            \
+    ListIter list_iter_53d46d2a04458e7b;                                       \
+    list_iter_init(&list_iter_53d46d2a04458e7b, list);                         \
+    void *val;                                                                 \
+    while (list_iter_next(&list_iter_53d46d2a04458e7b, &val) != CC_ITER_END)   \
+      body                                                                     \
+  }
+
+#define LIST_FOREACH_ZIP(val1, val2, list1, list2, body)                       \
+  {                                                                            \
+    ListZipIter list_zip_iter_ea08d3e52f25883b3;                               \
+    list_zip_iter_init(&list_zip_iter_ea08d3e52f25883b, list1, list2);         \
+    void *val1;                                                                \
+    void *val2;                                                                \
+    while (list_zip_iter_next(&list_zip_iter_ea08d3e52f25883b3, &val1,         \
+                              &val2) != CC_ITER_END)                           \
+      body                                                                     \
+  }
+
+#endif /* COLLECTIONS_C_LIST_H */

--- a/test/c/collections-c/bugs/include/utils.h
+++ b/test/c/collections-c/bugs/include/utils.h
@@ -1,0 +1,18 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include <owi.h>
+
+#define symb_str(X)                          \
+    int X = owi_i32();                      \
+    char str_##X[] = {X, '\0'}
+
+void CHECK_EQUAL_C_STRING(char *s1, char *s2);
+
+void *copy(void *e1);
+
+int cmp(void const *e1, void const *e2);
+
+int zero_if_ptr_eq(void const *e1, void const *e2);
+
+#endif /* TEST_UTILS_H */

--- a/test/c/collections-c/bugs/src/array.c
+++ b/test/c/collections-c/bugs/src/array.c
@@ -1,0 +1,1084 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "array.h"
+
+#define DEFAULT_CAPACITY 8
+#define DEFAULT_EXPANSION_FACTOR 2
+
+struct array_s {
+  size_t size;
+  size_t capacity;
+  float exp_factor;
+  void **buffer;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static enum cc_stat expand_capacity(Array *ar);
+
+/**
+ * Creates a new empty array and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created Array is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new Array structure failed.
+ */
+enum cc_stat array_new(Array **out) {
+  ArrayConf c;
+  array_conf_init(&c);
+  return array_new_conf(&c, out);
+}
+
+/**
+ * Creates a new empty Array based on the specified ArrayConf struct and
+ * returns a status code.
+ *
+ * The Array is allocated using the allocators specified in the ArrayConf
+ * struct. The allocation may fail if underlying allocator fails. It may also
+ * fail if the values of exp_factor and capacity in the ArrayConf do not meet
+ * the following condition: <code>exp_factor < (CC_MAX_ELEMENTS /
+ * capacity)</code>.
+ *
+ * @param[in] conf array configuration structure
+ * @param[out] out pointer to where the newly created Array is to be stored
+ *
+ * @return CC_OK if the creation was successful, CC_ERR_INVALID_CAPACITY if
+ * the above mentioned condition is not met, or CC_ERR_ALLOC if the memory
+ * allocation for the new Array structure failed.
+ */
+enum cc_stat array_new_conf(ArrayConf const *const conf, Array **out) {
+  float ex;
+
+  /* The expansion factor must be greater than one for the
+   * array to grow */
+  if (conf->exp_factor <= 1)
+    ex = DEFAULT_EXPANSION_FACTOR;
+  else
+    ex = conf->exp_factor;
+
+  /* Needed to avoid an integer overflow on the first resize and
+   * to easily check for any future overflows. */
+  if (!conf->capacity || ex >= CC_MAX_ELEMENTS / conf->capacity)
+    return CC_ERR_INVALID_CAPACITY;
+
+  Array *ar = conf->mem_calloc(1, sizeof(Array));
+
+  if (!ar)
+    return CC_ERR_ALLOC;
+
+  void **buff = conf->mem_alloc(conf->capacity * sizeof(void *));
+
+  if (!buff) {
+    conf->mem_free(ar);
+    return CC_ERR_ALLOC;
+  }
+
+  ar->buffer = buff;
+  ar->exp_factor = ex;
+  ar->capacity = conf->capacity;
+  ar->mem_alloc = conf->mem_alloc;
+  ar->mem_calloc = conf->mem_calloc;
+  ar->mem_free = conf->mem_free;
+
+  *out = ar;
+  return CC_OK;
+}
+
+/**
+ * Initializes the fields of the ArrayConf struct to default values.
+ *
+ * @param[in, out] conf ArrayConf structure that is being initialized
+ */
+void array_conf_init(ArrayConf *conf) {
+  conf->exp_factor = DEFAULT_EXPANSION_FACTOR;
+  conf->capacity = DEFAULT_CAPACITY;
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Destroys the Array structure, but leaves the data it used to hold intact.
+ *
+ * @param[in] ar the array that is to be destroyed
+ */
+void array_destroy(Array *ar) {
+  ar->mem_free(ar->buffer);
+  ar->mem_free(ar);
+}
+
+/**
+ * Destroys the Array structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a array that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] ar the array that is being destroyed
+ */
+void array_destroy_cb(Array *ar, void (*cb)(void *)) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    cb(ar->buffer[i]);
+
+  array_destroy(ar);
+}
+
+/**
+ * Adds a new element to the Array. The element is appended to the array making
+ * it the last element (the one with the highest index) of the Array.
+ *
+ * @param[in] ar the array to which the element is being added
+ * @param[in] element the element that is being added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_ALLOC if the
+ * memory allocation for the new element failed, or CC_ERR_MAX_CAPACITY if the
+ * array is already at maximum capacity.
+ */
+enum cc_stat array_add(Array *ar, void *element) {
+  if (ar->size >= ar->capacity) {
+    enum cc_stat status = expand_capacity(ar);
+    if (status != CC_OK)
+      return status;
+  }
+
+  ar->buffer[ar->size] = element;
+  ar->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the array at a specified position by shifting all
+ * subsequent elements by one. The specified index must be within the bounds
+ * of the array. This function may also fail if the memory allocation for
+ * the new element was unsuccessful.
+ *
+ * @param[in] ar the array to which the element is being added
+ * @param[in] element the element that is being added
+ * @param[in] index the position in the array at which the element is being
+ *            added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, CC_ERR_ALLOC if the memory
+ * allocation for the new element failed, or CC_ERR_MAX_CAPACITY if the
+ * array is already at maximum capacity.
+ */
+enum cc_stat array_add_at(Array *ar, void *element, size_t index) {
+  if (index == ar->size)
+    return array_add(ar, element);
+
+  if ((ar->size == 0 && index != 0) || index > (ar->size - 1))
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (ar->size >= ar->capacity) {
+    enum cc_stat status = expand_capacity(ar);
+    if (status != CC_OK)
+      return status;
+  }
+
+  size_t shift = (ar->size - index) * sizeof(void *);
+
+  memmove(&(ar->buffer[index + 1]), &(ar->buffer[index]), shift);
+
+  ar->buffer[index] = element;
+  ar->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces an array element at the specified index and optionally sets the out
+ * parameter to the value of the replaced element. The specified index must be
+ * within the bounds of the Array.
+ *
+ * @param[in]  ar      array whose element is being replaced
+ * @param[in]  element replacement element
+ * @param[in]  index   index at which the replacement element should be inserted
+ * @param[out] out     pointer to where the replaced element is stored, or NULL
+ * if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat array_replace_at(Array *ar, void *element, size_t index,
+                              void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (out)
+    *out = ar->buffer[index];
+
+  ar->buffer[index] = element;
+
+  return CC_OK;
+}
+
+enum cc_stat array_swap_at(Array *ar, size_t index1, size_t index2) {
+  void *tmp;
+  if (index1 >= ar->size || index2 >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+  tmp = ar->buffer[index1];
+  ar->buffer[index1] = ar->buffer[index2];
+  ar->buffer[index2] = tmp;
+  return CC_OK;
+}
+
+/**
+ * Removes the specified element from the Array if such element exists and
+ * optionally sets the out parameter to the value of the removed element.
+ *
+ * @param[in] ar array from which the element is being removed
+ * @param[in] element element being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat array_remove(Array *ar, void *element, void **out) {
+  size_t index;
+  enum cc_stat status = array_index_of(ar, element, &index);
+
+  if (status == CC_ERR_OUT_OF_RANGE)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  if (index != ar->size - 1) {
+    size_t block_size = (ar->size - index) * sizeof(void *);
+
+    memmove(&(ar->buffer[index]), &(ar->buffer[index + 1]), block_size);
+  }
+  ar->size--;
+
+  if (out)
+    *out = element;
+
+  return CC_OK;
+}
+
+/**
+ * Removes an Array element from the specified index and optionally sets the
+ * out parameter to the value of the removed element. The index must be within
+ * the bounds of the array.
+ *
+ * @param[in] ar the array from which the element is being removed
+ * @param[in] index the index of the element being removed.
+ * @param[out] out  pointer to where the removed value is stored,
+ *                  or NULL if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the index was out of range.
+ */
+enum cc_stat array_remove_at(Array *ar, size_t index, void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (out)
+    *out = ar->buffer[index];
+
+  if (index != ar->size - 1) {
+    size_t block_size = (ar->size - 1 - index) * sizeof(void *);
+
+    memmove(&(ar->buffer[index]), &(ar->buffer[index + 1]), block_size);
+  }
+  ar->size--;
+
+  return CC_OK;
+}
+
+/**
+ * Removes an Array element from the end of the array and optionally sets the
+ * out parameter to the value of the removed element.
+ *
+ * @param[in] ar the array whose last element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the Array is already empty.
+ */
+enum cc_stat array_remove_last(Array *ar, void **out) {
+  return array_remove_at(ar, ar->size - 1, out);
+}
+
+/**
+ * Removes all elements from the specified array. This function does not shrink
+ * the array capacity.
+ *
+ * @param[in] ar array from which all elements are to be removed
+ */
+void array_remove_all(Array *ar) { ar->size = 0; }
+
+/**
+ * Removes and frees all elements from the specified array. This function does
+ * not shrink the array capacity.
+ *
+ * @param[in] ar array from which all elements are to be removed
+ */
+void array_remove_all_free(Array *ar) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    free(ar->buffer[i]);
+
+  array_remove_all(ar);
+}
+
+/**
+ * Gets an Array element from the specified index and sets the out parameter to
+ * its value. The specified index must be within the bounds of the array.
+ *
+ * @param[in] ar the array from which the element is being retrieved
+ * @param[in] index the index of the array element
+ * @param[out] out pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat array_get_at(Array *ar, size_t index, void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  *out = ar->buffer[index];
+  return CC_OK;
+}
+
+/**
+ * Gets the last element of the array or the element at the highest index
+ * and sets the out parameter to its value.
+ *
+ * @param[in] ar the array whose last element is being returned
+ * @param[out] out pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if the
+ * Array is empty.
+ */
+enum cc_stat array_get_last(Array *ar, void **out) {
+  if (ar->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return array_get_at(ar, ar->size - 1, out);
+}
+
+/**
+ * Returns the underlying array buffer.
+ *
+ * @note Any direct modification of the buffer may invalidate the Array.
+ *
+ * @param[in] ar array whose underlying buffer is being returned
+ *
+ * @return array's internal buffer.
+ */
+const void *const *array_get_buffer(Array *ar) {
+  return (const void *const *)ar->buffer;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of the
+ * Array.
+ *
+ * @param[in] ar array being searched
+ * @param[in] element the element whose index is being looked up
+ * @param[out] index  pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat array_index_of(Array *ar, void *element, size_t *index) {
+  size_t i;
+  for (i = 0; i < ar->size; i++) {
+    if (ar->buffer[i] == element) {
+      *index = i;
+      return CC_OK;
+    }
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Creates a subarray of the specified Array, ranging from <code>b</code>
+ * index (inclusive) to <code>e</code> index (inclusive). The range indices
+ * must be within the bounds of the Array, while the <code>e</code> index
+ * must be greater or equal to the <code>b</code> index.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original Array.
+ *
+ * @param[in] ar array from which the subarray is being created
+ * @param[in] b the beginning index (inclusive) of the subarray that must be
+ *              within the bounds of the array and must not exceed the
+ *              the end index
+ * @param[in] e the end index (inclusive) of the subarray that must be within
+ *              the bounds of the array and must be greater or equal to the
+ *              beginning index
+ * @param[out] out pointer to where the new sublist is stored
+ *
+ * @return CC_OK if the subarray was successfully created, CC_ERR_INVALID_RANGE
+ * if the specified index range is invalid, or CC_ERR_ALLOC if the memory
+ * allocation for the new subarray failed.
+ */
+enum cc_stat array_subarray(Array *ar, size_t b, size_t e, Array **out) {
+  if (b > e || e >= ar->size)
+    return CC_ERR_INVALID_RANGE;
+
+  Array *sub_ar = ar->mem_calloc(1, sizeof(Array));
+
+  if (!sub_ar)
+    return CC_ERR_ALLOC;
+
+  /* Try to allocate the buffer */
+  if (!(sub_ar->buffer = ar->mem_alloc(ar->capacity * sizeof(void *)))) {
+    ar->mem_free(sub_ar);
+    return CC_ERR_ALLOC;
+  }
+
+  sub_ar->mem_alloc = ar->mem_alloc;
+  sub_ar->mem_calloc = ar->mem_calloc;
+  sub_ar->mem_free = ar->mem_free;
+  sub_ar->size = e - b + 1;
+  sub_ar->capacity = sub_ar->size;
+
+  memcpy(sub_ar->buffer, &(ar->buffer[b]), sub_ar->size * sizeof(void *));
+
+  *out = sub_ar;
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified Array. A shallow copy is a copy of
+ * the Array structure, but not the elements it holds.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original array.
+ *
+ * @param[in] ar the array to be copied
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat array_copy_shallow(Array *ar, Array **out) {
+  Array *copy = ar->mem_alloc(sizeof(Array));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+  copy->exp_factor = ar->exp_factor;
+  copy->size = ar->size;
+  copy->capacity = ar->capacity;
+  copy->mem_alloc = ar->mem_alloc;
+  copy->mem_calloc = ar->mem_calloc;
+  copy->mem_free = ar->mem_free;
+
+  memcpy(copy->buffer, ar->buffer, copy->size * sizeof(void *));
+
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified Array. A deep copy is a copy of
+ * both the Array structure and the data it holds.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original Array.
+ *
+ * @param[in] ar   array to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat array_copy_deep(Array *ar, void *(*cp)(void *), Array **out) {
+  Array *copy = ar->mem_alloc(sizeof(Array));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+
+  copy->exp_factor = ar->exp_factor;
+  copy->size = ar->size;
+  copy->capacity = ar->capacity;
+  copy->mem_alloc = ar->mem_alloc;
+  copy->mem_calloc = ar->mem_calloc;
+  copy->mem_free = ar->mem_free;
+
+  size_t i;
+  for (i = 0; i < copy->size; i++)
+    copy->buffer[i] = cp(ar->buffer[i]);
+
+  *out = copy;
+
+  return CC_OK;
+}
+
+/**
+ * Filters the Array by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] ar   array that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the Array
+ *
+ * @return CC_OK if the Array was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the Array is empty.
+ */
+enum cc_stat array_filter_mut(Array *ar, bool (*pred)(const void *)) {
+  if (ar->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t rm = 0;
+  size_t keep = 0;
+
+  /* Look for clusters of non matching elements before moving
+   * in order to minimize the number of memmoves */
+  for (size_t i = ar->size - 1; i != ((size_t)-1); i--) {
+    if (!pred(ar->buffer[i])) {
+      rm++;
+      continue;
+    }
+    if (rm > 0) {
+      if (keep > 0) {
+        size_t block_size = keep * sizeof(void *);
+        memmove(&(ar->buffer[i + 1]), &(ar->buffer[i + 1 + rm]), block_size);
+      }
+      ar->size -= rm;
+      rm = 0;
+    }
+    keep++;
+  }
+  /* Remove any remaining elements*/
+  if (rm > 0) {
+    size_t block_size = keep * sizeof(void *);
+    memmove(&(ar->buffer[0]), &(ar->buffer[rm]), block_size);
+
+    ar->size -= rm;
+  }
+  return CC_OK;
+}
+
+/**
+ * Filters the Array by creating a new Array that contains all elements from the
+ * original Array that return true on pred(element) without modifying the
+ * original Array.
+ *
+ * @param[in] ar   array that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the filtered array
+ * @param[out] out pointer to where the new filtered Array is to be stored
+ *
+ * @return CC_OK if the Array was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the Array is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new Array failed.
+ */
+enum cc_stat array_filter(Array *ar, bool (*pred)(const void *), Array **out) {
+  if (ar->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  Array *filtered = ar->mem_alloc(sizeof(Array));
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  if (!(filtered->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(filtered);
+    return CC_ERR_ALLOC;
+  }
+
+  filtered->exp_factor = ar->exp_factor;
+  filtered->size = 0;
+  filtered->capacity = ar->capacity;
+  filtered->mem_alloc = ar->mem_alloc;
+  filtered->mem_calloc = ar->mem_calloc;
+  filtered->mem_free = ar->mem_free;
+
+  size_t f = 0;
+  for (size_t i = 0; i < ar->size; i++) {
+    if (pred(ar->buffer[i])) {
+      filtered->buffer[f++] = ar->buffer[i];
+      filtered->size++;
+    }
+  }
+  *out = filtered;
+
+  return CC_OK;
+}
+
+/**
+ * Reverses the order of elements in the specified array.
+ *
+ * @param[in] ar array that is being reversed
+ */
+void array_reverse(Array *ar) {
+  size_t i;
+  size_t j;
+  for (i = 0, j = ar->size - 1; i < (ar->size - 1) / 2; i++, j--) {
+    void *tmp = ar->buffer[i];
+    ar->buffer[i] = ar->buffer[j];
+    ar->buffer[j] = tmp;
+  }
+}
+
+/**
+ * Trims the array's capacity, in other words, it shrinks the capacity to match
+ * the number of elements in the Array, however the capacity will never shrink
+ * below 1.
+ *
+ * @param[in] ar array whose capacity is being trimmed
+ *
+ * @return CC_OK if the capacity was trimmed successfully, or CC_ERR_ALLOC if
+ * the reallocation failed.
+ */
+enum cc_stat array_trim_capacity(Array *ar) {
+  if (ar->size == ar->capacity)
+    return CC_OK;
+
+  void **new_buff = ar->mem_calloc(ar->size, sizeof(void *));
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  size_t size = ar->size < 1 ? 1 : ar->size;
+
+  memcpy(new_buff, ar->buffer, size * sizeof(void *));
+  ar->mem_free(ar->buffer);
+
+  ar->buffer = new_buff;
+  ar->capacity = ar->size;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the number of occurrences of the element within the specified Array.
+ *
+ * @param[in] ar array that is being searched
+ * @param[in] element the element that is being searched for
+ *
+ * @return the number of occurrences of the element.
+ */
+size_t array_contains(Array *ar, void *element) {
+  return array_contains_value(ar, element, cc_common_cmp_ptr);
+}
+
+/**
+ * Returns the number of occurrences of the value pointed to by <code>e</code>
+ * within the specified Array.
+ *
+ * @param[in] ar array that is being searched
+ * @param[in] element the element that is being searched for
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ * are equal
+ *
+ * @return the number of occurrences of the value.
+ */
+size_t array_contains_value(Array *ar, void *element,
+                            int (*cmp)(const void *, const void *)) {
+  size_t o = 0;
+  size_t i;
+  for (i = 0; i < ar->size; i++) {
+    if (cmp(element, ar->buffer[i]) == 0)
+      o++;
+  }
+  return o;
+}
+
+/**
+ * Returns the size of the specified Array. The size of the array is the
+ * number of elements contained within the Array.
+ *
+ * @param[in] ar array whose size is being returned
+ *
+ * @return the the number of element within the Array.
+ */
+size_t array_size(Array *ar) { return ar->size; }
+
+/**
+ * Returns the capacity of the specified Array. The capacity of the Array is
+ * the maximum number of elements an Array can hold before it has to be resized.
+ *
+ * @param[in] ar array whose capacity is being returned
+ *
+ * @return the capacity of the Array.
+ */
+size_t array_capacity(Array *ar) { return ar->capacity; }
+
+/**
+ * Sorts the specified array.
+ *
+ * @note
+ * Pointers passed to the comparator function will be pointers to the array
+ * elements that are of type (void*) ie. void**. So an extra step of
+ * dereferencing will be required before the data can be used for comparison:
+ * eg. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @code
+ * enum cc_stat mycmp(const void *e1, const void *e2) {
+ *     MyType el1 = *(*((enum cc_stat**) e1));
+ *     MyType el2 = *(*((enum cc_stat**) e2));
+ *
+ *     if (el1 < el2) return -1;
+ *     if (el1 > el2) return 1;
+ *     return 0;
+ * }
+ *
+ * ...
+ *
+ * array_sort(array, mycmp);
+ * @endcode
+ *
+ * @param[in] ar  array to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                enum cc_stat cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ */
+void array_sort(Array *ar, int (*cmp)(const void *, const void *)) {
+  qsort(ar->buffer, ar->size, sizeof(void *), cmp);
+}
+
+/**
+ * Expands the Array capacity. This might fail if the the new buffer
+ * cannot be allocated. In case the expansion would overflow the index
+ * range, a maximum capacity buffer is allocated instead. If the capacity
+ * is already at the maximum capacity, no new buffer is allocated.
+ *
+ * @param[in] ar array whose capacity is being expanded
+ *
+ * @return CC_OK if the buffer was expanded successfully, CC_ERR_ALLOC if
+ * the memory allocation for the new buffer failed, or CC_ERR_MAX_CAPACITY
+ * if the array is already at maximum capacity.
+ */
+static enum cc_stat expand_capacity(Array *ar) {
+  if (ar->capacity == CC_MAX_ELEMENTS)
+    return CC_ERR_MAX_CAPACITY;
+
+  size_t new_capacity = ar->capacity * ar->exp_factor;
+
+  /* As long as the capacity is greater that the expansion factor
+   * at the point of overflow, this is check is valid. */
+  if (new_capacity <= ar->capacity)
+    ar->capacity = CC_MAX_ELEMENTS;
+  else
+    ar->capacity = new_capacity;
+
+  void **new_buff = ar->mem_alloc(new_capacity * sizeof(void *));
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  memcpy(new_buff, ar->buffer, ar->size * sizeof(void *));
+
+  ar->mem_free(ar->buffer);
+  ar->buffer = new_buff;
+
+  return CC_OK;
+}
+
+/**
+ * Applies the function fn to each element of the Array.
+ *
+ * @param[in] ar array on which this operation is performed
+ * @param[in] fn operation function that is to be invoked on each Array
+ *               element
+ */
+void array_map(Array *ar, void (*fn)(void *e)) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    fn(ar->buffer[i]);
+}
+
+/**
+ * A fold/reduce function that collects all of the elements in the array
+ * together. For example, if we have an array of [a,b,c...] the end result
+ * will be (...((a+b)+c)+...).
+ *
+ * @param[in] ar the array on which this operation is performed
+ * @param[in] fn the operation function that is to be invoked on each array
+ *               element
+ * @param[in] result the pointer which will collect the end result
+ */
+void array_reduce(Array *ar, void (*fn)(void *, void *, void *), void *result) {
+  if (ar->size == 1) {
+    fn(ar->buffer[0], NULL, result);
+    return;
+  }
+  if (ar->size > 1)
+    fn(ar->buffer[0], ar->buffer[1], result);
+
+  for (size_t i = 2; i < ar->size; i++)
+    fn(result, ar->buffer[i], result);
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] ar the array to iterate over
+ */
+void array_iter_init(ArrayIter *iter, Array *ar) {
+  iter->ar = ar;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the Array has been reached.
+ */
+enum cc_stat array_iter_next(ArrayIter *iter, void **out) {
+  if (iter->index >= iter->ar->size)
+    return CC_ITER_END;
+
+  *out = iter->ar->buffer[iter->index];
+
+  iter->index++;
+  iter->last_removed = false;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>array_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat array_iter_remove(ArrayIter *iter, void **out) {
+  enum cc_stat status = CC_ERR_VALUE_NOT_FOUND;
+
+  if (!iter->last_removed) {
+    status = array_remove_at(iter->ar, iter->index - 1, out);
+    if (status == CC_OK)
+      iter->last_removed = true;
+  }
+  return status;
+}
+
+/**
+ * Adds a new element to the Array after the last returned element by
+ * <code>array_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_ALLOC if the
+ * memory allocation for the new element failed, or CC_ERR_MAX_CAPACITY if
+ * the array is already at maximum capacity.
+ */
+enum cc_stat array_iter_add(ArrayIter *iter, void *element) {
+  return array_add_at(iter->ar, element, iter->index++);
+}
+
+/**
+ * Replaces the last returned element by <code>array_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat array_iter_replace(ArrayIter *iter, void *element, void **out) {
+  return array_replace_at(iter->ar, element, iter->index - 1, out);
+}
+
+/**
+ * Returns the index of the last returned element by <code>array_iter_next()
+ * </code>.
+ *
+ * @note
+ * This function should not be called before a call to <code>array_iter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index.
+ */
+size_t array_iter_index(ArrayIter *iter) { return iter->index - 1; }
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] ar1  first array
+ * @param[in] ar2  second array
+ */
+void array_zip_iter_init(ArrayZipIter *iter, Array *ar1, Array *ar2) {
+  iter->ar1 = ar1;
+  iter->ar2 = ar2;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first array element
+ * @param[out] out2 output of the second array element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the arrays has been reached.
+ */
+enum cc_stat array_zip_iter_next(ArrayZipIter *iter, void **out1, void **out2) {
+  if (iter->index >= iter->ar1->size || iter->index >= iter->ar2->size)
+    return CC_ITER_END;
+
+  *out1 = iter->ar1->buffer[iter->index];
+  *out2 = iter->ar2->buffer[iter->index];
+
+  iter->index++;
+  iter->last_removed = false;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>array_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[out] out1 output of the removed element from the first array
+ * @param[out] out2 output of the removed element from the second array
+ *
+ * @return CC_OK if the element was successfully removed, CC_ERR_OUT_OF_RANGE if
+ * the state of the iterator is invalid, or CC_ERR_VALUE_NOT_FOUND if the
+ * element was already removed.
+ */
+enum cc_stat array_zip_iter_remove(ArrayZipIter *iter, void **out1,
+                                   void **out2) {
+  if ((iter->index - 1) >= iter->ar1->size ||
+      (iter->index - 1) >= iter->ar2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (!iter->last_removed) {
+    array_remove_at(iter->ar1, iter->index - 1, out1);
+    array_remove_at(iter->ar2, iter->index - 1, out2);
+    iter->last_removed = true;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Adds a new element pair to the arrays after the last returned element pair by
+ * <code>array_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>array_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ * @param[in] e1   element added to the first array
+ * @param[in] e2   element added to the second array
+ *
+ * @return CC_OK if the element pair was successfully added to the arrays, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat array_zip_iter_add(ArrayZipIter *iter, void *e1, void *e2) {
+  size_t index = iter->index++;
+  Array *ar1 = iter->ar1;
+  Array *ar2 = iter->ar2;
+
+  /* Make sure both array buffers have room */
+  if ((ar1->size == ar1->capacity && (expand_capacity(ar1) != CC_OK)) ||
+      (ar2->size == ar2->capacity && (expand_capacity(ar2) != CC_OK)))
+    return CC_ERR_ALLOC;
+
+  array_add_at(ar1, e1, index);
+  array_add_at(ar2, e2, index);
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>array_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @param[in] iter  iterator on which this operation is being performed
+ * @param[in]  e1   first array's replacement element
+ * @param[in]  e2   second array's replacement element
+ * @param[out] out1 output of the replaced element from the first array
+ * @param[out] out2 output of the replaced element from the second array
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat array_zip_iter_replace(ArrayZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  if ((iter->index - 1) >= iter->ar1->size ||
+      (iter->index - 1) >= iter->ar2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  array_replace_at(iter->ar1, e1, iter->index - 1, out1);
+  array_replace_at(iter->ar2, e2, iter->index - 1, out2);
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>array_zip_iter_next()</code>.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ *
+ * @return current iterator index.
+ */
+size_t array_zip_iter_index(ArrayZipIter *iter) { return iter->index - 1; }

--- a/test/c/collections-c/bugs/src/common.c
+++ b/test/c/collections-c/bugs/src/common.c
@@ -1,0 +1,49 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2016 Srđan Panić <i@srdja.me>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common.h"
+
+/**
+ * String comparator function.
+ *
+ * @param[in] str1 first string
+ * @param[in] str2 second string
+ *
+ * @return
+ */
+int cc_common_cmp_str(const void *str1, const void *str2) {
+  return strcmp((const char *)str1, (const char *)str2);
+}
+
+/**
+ * Pointer comparator function.
+ *
+ * @param[in] ptr1 first pointer
+ * @param[in] ptr2 second pointer
+ *
+ * @return
+ */
+int cc_common_cmp_ptr(const void *ptr1, const void *ptr2) {
+  if (ptr1 < ptr2)
+    return -1;
+  else if (ptr1 > ptr2)
+    return 1;
+  return 0;
+}

--- a/test/c/collections-c/bugs/src/list.c
+++ b/test/c/collections-c/bugs/src/list.c
@@ -1,0 +1,1938 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "list.h"
+
+struct list_s {
+  size_t size;
+  Node *head;
+  Node *tail;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static void *unlinkn(List *list, Node *node);
+static bool unlinkn_all(List *list, void (*cb)(void *));
+static void link_behind(Node *node, Node *inserted);
+static void link_after(Node *base, Node *inserted);
+static void swap(Node *n1, Node *n2);
+static void swap_adjacent(Node *n1, Node *n2);
+static void splice_between(List *list1, List *list2, Node *left, Node *right);
+static bool link_all_externally(List *l, Node **h, Node **t);
+static Node *get_node(List *list, void *element);
+static enum cc_stat get_node_at(List *list, size_t index, Node **out);
+static enum cc_stat add_all_to_empty(List *l1, List *l2);
+
+/**
+ * Initializes the fields of the ListConf struct to default values.
+ *
+ * @param[in] conf the configuration struct that is being initialized
+ */
+void list_conf_init(ListConf *conf) {
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Creates a new empty list and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created List is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if
+ * the memory allocation for the new List failed.
+ */
+enum cc_stat list_new(List **out) {
+  ListConf lc;
+  list_conf_init(&lc);
+  return list_new_conf(&lc, out);
+}
+
+/**
+ * Creates a new empty list based on the specified ListConf struct and
+ * returns a status code.
+ *
+ * The List is allocated using the allocators specified in the ListConf
+ * struct. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf List configuration struct. All fields must be
+ *                 initialized to appropriate values.
+ * @param[out] out Pointer to where the newly created List is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new List structure failed.
+ */
+enum cc_stat list_new_conf(ListConf const *const conf, List **out) {
+  List *list = conf->mem_calloc(1, sizeof(List));
+
+  if (!list)
+    return CC_ERR_ALLOC;
+
+  list->mem_alloc = conf->mem_alloc;
+  list->mem_calloc = conf->mem_calloc;
+  list->mem_free = conf->mem_free;
+
+  *out = list;
+  return CC_OK;
+}
+
+/**
+ * Destroys the list structure, but leaves the data that it holds intact.
+ *
+ * @param[in] list list that is to be destroyed
+ */
+void list_destroy(List *list) {
+  if (list->size > 0)
+    list_remove_all(list);
+
+  list->mem_free(list);
+}
+
+/**
+ * Destroys the list structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a list that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] list list that is to be destroyed
+ */
+void list_destroy_cb(List *list, void (*cb)(void *)) {
+  list_remove_all_cb(list, cb);
+  list->mem_free(list);
+}
+
+/**
+ * Adds a new element to the list. The element is appended to the list making it
+ * the last element in the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add(List *list, void *element) {
+  return list_add_last(list, element);
+}
+
+/**
+ * Prepends a new element to the list (adds a new "head") making it the first
+ * element of the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being prepended
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add_first(List *list, void *element) {
+  Node *node = list->mem_calloc(1, sizeof(Node));
+
+  if (node == NULL)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    node->next = list->head;
+    list->head->prev = node;
+    list->head = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Appends a new element to the list (adds an new "tail") making it the last
+ * element of the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being appended
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add_last(List *list, void *element) {
+  Node *node = list->mem_calloc(1, sizeof(Node));
+
+  if (node == NULL)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    node->prev = list->tail;
+    list->tail->next = node;
+    list->tail = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Adds a new element at the specified location in the List and shifts all
+ * subsequent elements by one. This operation cannot be performed on an empty
+ * List. The index at which the new element is being added must be within the
+ * bounds of the List.
+ *
+ * @param[in] list list to which this element is being added
+ * @param[in] element element that is being added
+ * @param[in] index the position in the list at which the new element is being
+ *                  added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, or CC_ERR_ALLOC if the memory
+ * allocation for the new element failed.
+ */
+enum cc_stat list_add_at(List *list, void *element, size_t index) {
+  Node *base;
+  enum cc_stat stat = get_node_at(list, index, &base);
+
+  if (stat != CC_OK)
+    return stat;
+
+  Node *new = list->mem_calloc(1, sizeof(Node));
+
+  if (!new)
+    return CC_ERR_ALLOC;
+
+  new->data = element;
+  link_behind(base, new);
+
+  if (index == 0)
+    list->head = new;
+
+  list->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Adds all elements from the second list to the first. The elements from the
+ * second list are added after the last element of the first list.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ *
+ * @return CC_OK if the elements where successfully added, or CC_ERR_ALLOC if
+ * the memory allocation for the new elements failed.
+ */
+enum cc_stat list_add_all(List *list1, List *list2) {
+  if (list1->size == 0)
+    return add_all_to_empty(list1, list2);
+
+  return list_add_all_at(list1, list2, list1->size);
+}
+
+/**
+ * Adds all elements from the second list to the first list which is empty.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ *
+ * @return CC_OK if the element were successfully added, or CC_ERR_ALLOC if
+ * the memory allocation for the new elements failed.
+ */
+static enum cc_stat add_all_to_empty(List *list1, List *list2) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  Node *head = NULL;
+  Node *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  list1->head = head;
+  list1->tail = tail;
+  list1->size = list2->size;
+  return CC_OK;
+}
+
+/**
+ * Adds all elements from the second list to the first at the specified position
+ * by shifting all subsequent elements by the size of the second list. The index
+ * range at which the elements can be added ranges from 0 to max_index + 1.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ * @param[in] index position in the first list at which the element should be
+ *                  added
+ *
+ * @return CC_OK if the elements were successfully added,
+ * CC_ERR_INDEX_OUT_OF_BOUNDS if the index was out of range, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat list_add_all_at(List *list1, List *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (index > list1->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  /* Link the new nodes together outside of the list so
+     that if anything goes wrong we don't have to leave
+     garbage in the actual list. */
+  Node *head = NULL;
+  Node *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  /* Now we can safely attach the new nodes. */
+  Node *end = NULL;
+  get_node_at(list1, index, &end);
+
+  Node *base = NULL;
+  if (end)
+    base = end->prev;
+  else
+    get_node_at(list1, index - 1, &base);
+
+  if (!end) {
+    list1->tail->next = head;
+    head->prev = list1->tail;
+    list1->tail = tail;
+  } else if (!base) {
+    list1->head->prev = tail;
+    tail->next = list1->head;
+    list1->head = head;
+  } else {
+    head->prev = base;
+    base->next = head;
+    tail->next = end;
+    end->prev = tail;
+  }
+
+  list1->size += list2->size;
+
+  return CC_OK;
+}
+
+/**
+ * Duplicates the structure of the list without directly attaching it to a
+ * specific list. If the operation fails, the mess is cleaned up and false
+ * is returned to indicate failure.
+ *
+ * @param[in] list the list whose structure is being duplicated
+ * @param[in, out] h the pointer to which the new head will be attached
+ * @param[in, out] t the pointer to which the new tail will be attached
+ *
+ * @return true if the operation was successful, false otherwise.
+ */
+static bool link_all_externally(List *list, Node **h, Node **t) {
+  Node *insert = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    Node *new = list->mem_calloc(1, sizeof(Node));
+
+    if (!new) {
+      while (*h) {
+        Node *tmp = (*h)->next;
+        list->mem_free(*h);
+        *h = tmp;
+      }
+      return false;
+    }
+
+    new->data = insert->data;
+
+    if (!*h) {
+      *h = new;
+      *t = new;
+    } else {
+      (*t)->next = new;
+      new->prev = *t;
+      *t = new;
+    }
+
+    insert = insert->next;
+  }
+  return true;
+}
+
+/**
+ * Splices the two doubly linked lists together by appending the second list to
+ * the first. This function moves all elements from the second list into the
+ * first list, leaving the second list empty.
+ *
+ * @param[in] list1 the consumer list to which the elements are moved
+ * @param[in] list2 the producer list from which the elements are moved
+ *
+ * @return CC_OK if the elements were successfully moved, or CC_ERR_OUT_OF_RANGE
+ * if the index was not in range.
+ */
+enum cc_stat list_splice(List *list1, List *list2) {
+  return list_splice_at(list1, list2, list1->size);
+}
+
+/**
+ * Splices the two lists together at the specified index of the first list. This
+ * function moves all elements from the second list into the first list at the
+ * position specified by the <code>index</code> parameter. After this operation
+ * the second list will be left empty.
+ *
+ * @param[in] list1 the consumer list to which the elements are moved
+ * @param[in] list2 the producer list from which the elements are moved
+ * @param[in] index the index in the first list after which the elements from
+ * the second list should be inserted
+ *
+ * @return CC_OK if the elements were successfully moved, or CC_ERR_OUT_OF_RANGE
+ * if the index was not in range.
+ */
+enum cc_stat list_splice_at(List *list1, List *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (index > list1->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (list1->size == 0) {
+    // TODO move to splice_between
+    list1->head = list2->head;
+    list1->tail = list2->tail;
+    list1->size = list2->size;
+
+    list2->head = NULL;
+    list2->tail = NULL;
+    list2->size = 0;
+    return CC_OK;
+  }
+
+  Node *end = NULL;
+  get_node_at(list1, index, &end);
+
+  Node *base = NULL;
+  if (end)
+    base = end->prev;
+  else
+    get_node_at(list1, index - 1, &base);
+
+  splice_between(list1, list2, base, end);
+
+  return CC_OK;
+}
+
+/**
+ * Inserts the second list between the two nodes of the first list. If the left
+ * node is NULL, the head of the second list will become the head of the first
+ * list. Similarly, if the right node is null, the tail of the first list will
+ * become the tail of the second list.
+ *
+ * @param[in, out] l1 the list to which the elements are being transferred
+ * @param[in, out] l2 the list from which the elements are being transferred
+ * @param[in] left the node after which the element are being added
+ * @param[in] right the node behind which the elements are being added
+ */
+static void splice_between(List *l1, List *l2, Node *left, Node *right) {
+  if (!left) {
+    l1->head->prev = l2->tail;
+    l2->tail->next = l1->head;
+    l1->head = l2->head;
+  } else if (!right) {
+    l1->tail->next = l2->head;
+    l2->head->prev = l1->tail;
+    l1->tail = l2->tail;
+  } else {
+    left->next = l2->head;
+    l2->head->prev = left;
+    right->prev = l2->tail;
+    l2->tail->next = right;
+  }
+  l1->size += l2->size;
+
+  l2->head = NULL;
+  l2->tail = NULL;
+  l2->size = 0;
+}
+
+/**
+ * Removes the first occurrence of the element from the specified List
+ * and optionally sets the out parameter to the value of the removed
+ * element.
+ *
+ * @param[in] list list from which the element is being removed
+ * @param[in] element element that is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat list_remove(List *list, void *element, void **out) {
+  Node *node = get_node(list, element);
+
+  if (!node)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  if (out)
+    *out = node->data;
+
+  unlinkn(list, node);
+  return CC_OK;
+}
+
+/**
+ * Removes the element at the specified index and optionally sets the out
+ * parameter to the value of the removed element. The index must be
+ * within the bounds of the list.
+ *
+ * @param[in] list List from which the element is being removed.
+ * @param[in] index Index of the element is being removed. Must be be within the
+ *            index range of the list.
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored.
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat list_remove_at(List *list, size_t index, void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status != CC_OK)
+    return status;
+
+  if (out)
+    *out = node->data;
+
+  unlinkn(list, node);
+  return CC_OK;
+}
+
+/**
+ * Removes and returns the first (head) element of the list and optionally sets
+ * the out parameter to the value of the removed element.
+ *
+ * @param[in] list list from which the first element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the List is already empty.
+ */
+enum cc_stat list_remove_first(List *list, void **out) {
+  if (!list->size)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(list, list->head);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and returns the last (tail) element of the list and optionally sets
+ * the out parameter to the value of the removed element.
+ *
+ * @param[in] list list from which the last element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the List is already empty.
+ */
+enum cc_stat list_remove_last(List *list, void **out) {
+  if (!list->size)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(list, list->tail);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes all elements from the specified list.
+ *
+ * @param[in] list list from which all elements are being removed
+ *
+ * @return CC_OK if the elements were successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat list_remove_all(List *list) {
+  bool unlinked = unlinkn_all(list, NULL);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Removes and frees all elements from the specified list.
+ *
+ * @note
+ * This function should not be called on a list that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] list list from which all the elements are being removed and
+ *            freed
+ *
+ * @return CC_OK if the elements were successfully removed and freed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat list_remove_all_cb(List *list, void (*cb)(void *)) {
+  bool unlinked = unlinkn_all(list, cb);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Replaces an element at the specified location and optionally sets the
+ * out parameter to the value of the replaced element. The specified index
+ * must be within the bounds of the list.
+ *
+ * @param[in] list list on which this operation is performed
+ * @param[in] element the replacement element
+ * @param[in] index index of the element that is being replaced
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat list_replace_at(List *list, void *element, size_t index,
+                             void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status == CC_OK) {
+    void *old = node->data;
+    node->data = element;
+    if (out)
+      *out = old;
+  }
+
+  return status;
+}
+
+/**
+ * Gets the first element from the specified list and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list list whose first element is being returned
+ * @param[in] out  pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat list_get_first(List *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->head->data;
+  return CC_OK;
+}
+
+/**
+ * Gets the last element from the specified list and sets the parameter to
+ * its value.
+ *
+ * @param[in] list list whose last element is being returned
+ * @param[in] out  pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat list_get_last(List *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->tail->data;
+  return CC_OK;
+}
+
+/**
+ * Gets the list element from the specified index and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list  List from which the element is being returned.
+ * @param[in] index The index of a list element being returned. The index must
+ *                  be within the bound of the list.
+ * @param[out] out  Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat list_get_at(List *list, size_t index, void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status == CC_OK)
+    *out = node->data;
+
+  return status;
+}
+
+/**
+ * Reverses the order of elements in the specified list.
+ *
+ * @param[in] list list that is being reversed
+ */
+void list_reverse(List *list) {
+  if (list->size == 0 || list->size == 1)
+    return;
+
+  Node *head_old = list->head;
+  Node *tail_old = list->tail;
+
+  Node *left = list->head;
+  Node *right = list->tail;
+
+  size_t i;
+  for (i = 0; i < list->size / 2; i++) {
+    Node *tmpl = left->next;
+    Node *tmpr = right->prev;
+
+    swap(left, right);
+
+    left = tmpl;
+    right = tmpr;
+  }
+
+  list->head = tail_old;
+  list->tail = head_old;
+}
+
+/**
+ * Creates a sublist of the specified List. The created sublist contains all
+ * the elements from the List that are contained between the two indices
+ * including the elements at the indices. For example, if a list contains 5
+ * elements [5, 6, 7, 8, 9], a sublist from index 1 to 3 will will be a new
+ * List of length 3, containing [6, 7, 8]. The returned sublist is only a copy
+ * of the original lists structure, meaning the data it points to is not copied.
+ *
+ * @param[in] list List from which the sublist is taken.
+ * @param[in] b    The beginning index, i.e., the first element to be included.
+ *                 Must be a positive integer and may not exceed the list size
+ *                 or the end index.
+ * @param[in] e    The ending index, i.e., the last element to be included. Must
+ *                 be a positive integer no greater than the list size and no
+ *                 smaller that the beginning index.
+ * @param[out] out Pointer to where the new sublist is stored.
+ *
+ * @return CC_OK if the sublist was successfully created, CC_ERR_INVALID_RANGE
+ * if the specified index range is invalid, or CC_ERR_ALLOC if the memory
+ * allocation for the new sublist failed.
+ */
+enum cc_stat list_sublist(List *list, size_t b, size_t e, List **out) {
+  if (b > e || e >= list->size)
+    return CC_ERR_INVALID_RANGE;
+
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *sub;
+  enum cc_stat status = list_new_conf(&conf, &sub);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node;
+  status = get_node_at(list, b, &node);
+
+  if (status != CC_OK) {
+    list->mem_free(sub);
+    return status;
+  }
+
+  size_t i;
+  for (i = b; i <= e; i++) {
+    status = list_add(sub, node->data);
+    if (status != CC_OK) {
+      list_destroy(sub);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = sub;
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified list. A shallow copy is a copy of the
+ * list structure. This operation does not copy the actual data that this list
+ * holds.
+ *
+ * @note The new list is allocated using the original lists allocators and also
+ *       inherits the configuration of the original list.
+ *
+ * @param[in] list list to be copied
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat list_copy_shallow(List *list, List **out) {
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *copy;
+  enum cc_stat status = list_new_conf(&conf, &copy);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  if (!node) {
+    *out = copy;
+    return CC_OK;
+  }
+  while (node) {
+    status = list_add(copy, node->data);
+    if (status != CC_OK) {
+      list_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified list. This functions copies the
+ * structure of the list along with all the data it holds. The element copying
+ * is done through the specified copy function that should return a pointer to
+ * the copy of the element passed to it.
+ *
+ * @param[in] list list to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return  CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat list_copy_deep(List *list, void *(*cp)(void *e1), List **out) {
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *copy;
+  enum cc_stat status = list_new_conf(&conf, &copy);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  if (!node) {
+    *out = copy;
+    return CC_OK;
+  }
+
+  while (node) {
+    status = list_add(copy, cp(node->data));
+    if (status != CC_OK) {
+      list_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates an array representation of the specified list. None of the elements
+ * are copied into the array and thus any modification of the elements within
+ * the array will affect the list elements as well. The size of the created
+ * array is the same as the size of the list from which this array was
+ * constructed.
+ *
+ * @param[in] list list on which this operation is being performed
+ * @param[out] out pointer to where the newly created array is stored
+ *
+ * @return CC_OK if the array was successfully created, CC_ERR_INVALID_RANGE if
+ * the list is emtpy, or CC_ERR_ALLOC if the memory allocation for the new array
+ * failed.
+ */
+enum cc_stat list_to_array(List *list, void ***out) {
+  if (list->size == 0)
+    return CC_ERR_INVALID_RANGE;
+
+  void **array = list->mem_calloc(list->size, sizeof(void *));
+
+  if (!array)
+    return CC_ERR_ALLOC;
+
+  Node *node = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    array[i] = node->data;
+    node = node->next;
+  }
+  *out = array;
+  return CC_OK;
+}
+
+/**
+ * Returns an integer representing the number of occurrences of the specified
+ * element within the list.
+ *
+ * @param[in] list list on which the search is performed
+ * @param[in] element element being searched for
+ *
+ * @return number of matches found.
+ */
+size_t list_contains(List *list, void *element) {
+  return list_contains_value(list, element, cc_common_cmp_ptr);
+}
+
+/**
+ * Returns the number occurrences of the value pointed to by
+ * <code>element</code> within the List.
+ *
+ * @param[in] list list on which the search is performed
+ * @param[in] element element being searched for
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ *                are equal
+ *
+ * @return number of matches found.
+ */
+size_t list_contains_value(List *list, void *element,
+                           int (*cmp)(const void *, const void *)) {
+  Node *node = list->head;
+  size_t e_count = 0;
+
+  while (node) {
+    if (cmp(node->data, element) == 0)
+      e_count++;
+    node = node->next;
+  }
+  return e_count;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of
+ * the list.
+ *
+ * @param[in] list list on which this operation is performed
+ * @param[in] element the element whose index is being looked up
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ *                are equal
+ * @param[out] index pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat list_index_of(List *list, void *element,
+                           int (*cmp)(const void *, const void *),
+                           size_t *index) {
+  Node *node = list->head;
+  size_t i = 0;
+
+  while (node) {
+    if (cmp(node->data, element) == 0) {
+      *index = i;
+      return CC_OK;
+    }
+    i++;
+    node = node->next;
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Returns the number of elements in the specified list.
+ *
+ * @param[in] list list whose size is being returned
+ *
+ * @return the number of the elements contained in the specified list.
+ */
+size_t list_size(List *list) { return list->size; }
+
+/**
+ * Sorts the specified list. This function makes no guaranties that the
+ * sort will be performed in place or in a stable way.
+ *
+ * @note Pointers passed to the comparator function will be pointers to
+ *       the list elements that are of type (void*), i.e. void**. So an
+ *       extra step of dereferencing will be required before the data can
+ *       be used for comparison:
+ *       e.g. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @param[in] list list to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                int cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ *
+ * @return CC_OK if the sort was performed successfully, or CC_ERR_ALLOC
+ * if it could not allocate enough memory to perform the sort.
+ */
+enum cc_stat list_sort(List *list, int (*cmp)(void const *e1, void const *e2)) {
+  void **elements;
+  enum cc_stat status = list_to_array(list, &elements);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  qsort(elements, list->size, sizeof(void *), cmp);
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    node->data = elements[i];
+    node = node->next;
+  }
+  list->mem_free(elements);
+  return CC_OK;
+}
+
+static Node *split(List *, Node *b, size_t l,
+                   int (*cmp)(void const *e1, void const *e2));
+static void merge(Node **, Node **, size_t, size_t,
+                  int (*cmp)(void const *e1, void const *e2));
+
+/**
+ * Sorts the specified list in place in a stable way.
+ *
+ * @note Pointers passed to the comparator function will be pointers to the list
+ *       elements that are of type (void*), i.e. void**. So an extra step of
+ *       dereferencing will be required before the data can be used for
+ * comparison: e.g. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @param[in] list list to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                int cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ */
+void list_sort_in_place(List *list,
+                        int (*cmp)(void const *e1, void const *e2)) {
+  split(list, list->head, list->size, cmp);
+}
+
+/**
+ * Splits the list section into two partitions.
+ *
+ * @param[in] list the sublist
+ * @param[in] b    the head node of the sublist
+ * @param[in] size number of nodes in the sublist
+ * @param[in] cmp  comparator function
+ *
+ * @return
+ */
+static Node *split(List *list, Node *b, size_t size,
+                   int (*cmp)(void const *, void const *)) {
+  if (size < 2)
+    return b;
+
+  size_t l_size = size / 2;
+  size_t r_size = size / 2 + (size % 2);
+
+  Node *center = b;
+
+  size_t i;
+  for (i = 0; i < l_size; i++)
+    center = center->next;
+
+  Node *l_head = split(list, b, l_size, cmp);
+  Node *r_head = split(list, center, r_size, cmp);
+
+  merge(&l_head, &r_head, l_size, r_size, cmp);
+
+  list->head = l_head;
+  list->tail = r_head;
+
+  return l_head;
+}
+
+/**
+ * Merges the two partitions together in place in a stable way. The left
+ * partition starts at the "left" node and ends "l_size" nodes to the right of
+ *it. Similarly the right partition starts at the "right" and ends "r_size"
+ *nodes to the right. Both "left" and "right" parameters are used for input and
+ * output. As an output parameter the "left" parameter will be assigned as the
+ * head node of the newly merged section, while the "right" parameter will be
+ * assigned the tail after the merge. The result of this function is a sorted
+ * section of the list in an ascending order.
+ *
+ *@param[in, out] left   the beginning of the left partition as input and the
+ *                       the head node of the merged section as the output
+ *@param[in, out] right  the beginning of the right partition as input and the
+ *                       the tail node of the merged section as the output
+ *@param[in]      l_size size of the the left partition
+ *@param[in]      r_size size of the right partition
+ *@param[in]      cmp    the comparator function
+ */
+static INLINE void merge(Node **left, Node **right, size_t l_size,
+                         size_t r_size,
+                         int (*cmp)(void const *, void const *)) {
+  size_t size = r_size + l_size;
+  size_t l = 0; /* Number of processed elements from the left partition */
+  size_t r = 0; /* NUmber of processed elements from the right partition. */
+
+  Node *l_part = *left;
+  Node *r_part = *right;
+
+  size_t i;
+  for (i = 0; i < size; i++) {
+    int c = cmp(&(l_part->data), &(r_part->data));
+
+    if ((c < 0 || c == 0)) {
+      /* The two partitions are already sorted. */
+      if (i == 0 && size == 2) {
+        break;
+      }
+      /* If all the elements on the left side are in place,
+         all the elements on the right must be as well. */
+      if (l == l_size) {
+        /* Quickly advance the right pointer to the end for
+         * the remainder of r and exit.*/
+        for (; r < r_size - 1; r++)
+          r_part = r_part->next;
+        *right = r_part;
+        break;
+      }
+      l_part = l_part->next;
+      l++;
+    } else {
+      Node *tmp = (r_part)->next;
+      link_behind(l_part, r_part);
+      /* The elements are swapped. Now set head and tail and
+       * exit the loop. */
+      if (i == 0 && size == 2) {
+        *right = l_part;
+        *left = r_part;
+        break;
+      }
+      r++;
+      /* All right partition elements are now behind the left
+       * partition elements.*/
+      if (r == r_size) {
+        /* Quickly advance the left partition pointer and set
+         * the rightmost element as the new head. */
+        for (; l < l_size - 1; l++)
+          l_part = l_part->next;
+        *right = l_part;
+        break;
+      }
+      if (i == 0) {
+        *left = r_part;
+      }
+      r_part = tmp;
+    }
+  }
+}
+
+/**
+ * A 'foreach loop' function that invokes the specified function on each element
+ * in the list.
+ *
+ * @param[in] list list on which this operation is being performed
+ * @param[in] op the operation function that is to be invoked on each list
+ *               element
+ */
+void list_foreach(List *list, void (*op)(void *e)) {
+  Node *n = list->head;
+
+  while (n) {
+    op(n->data);
+    n = n->next;
+  }
+}
+
+/**
+ * Filters the List by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] list list that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the List
+ *
+ * @return CC_OK if the list was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the List is empty.
+ */
+enum cc_stat list_filter_mut(List *list, bool (*pred)(const void *)) {
+  if (list_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  Node *curr = list->head;
+  Node *next = NULL;
+
+  while (curr) {
+    next = curr->next;
+
+    if (!pred(curr->data)) {
+      unlinkn(list, curr);
+    }
+    curr = next;
+  }
+
+  return CC_OK;
+}
+
+/**
+ * Filters the List by creating a new List that contains all elements from the
+ * original List that return true on pred(element) without modifying the
+ * original list.
+ *
+ * @param[in] list list that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the filtered list
+ * @param[out] out pointer to where the new filtered list is to be stored
+ *
+ * @return CC_OK if the list was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the list is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new list failed.
+ */
+enum cc_stat list_filter(List *list, bool (*pred)(const void *), List **out) {
+  if (list_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  List *filtered = NULL;
+  list_new(&filtered);
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  Node *curr = list->head;
+
+  while (curr) {
+    if (pred(curr->data)) {
+      list_add(filtered, curr->data);
+    }
+    curr = curr->next;
+  }
+
+  *out = filtered;
+
+  return CC_OK;
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] list list to iterate over
+ */
+void list_iter_init(ListIter *iter, List *list) {
+  iter->index = 0;
+  iter->list = list;
+  iter->last = NULL;
+  iter->next = list->head;
+}
+
+/**
+ * Removes the last returned element by <code>list_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_iter_remove(ListIter *iter, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(iter->list, iter->last);
+  iter->last = NULL;
+
+  if (out)
+    *out = e;
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the list after the last returned element by
+ * <code>list_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added to the list
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat list_iter_add(ListIter *iter, void *element) {
+  Node *new_node = iter->list->mem_calloc(1, sizeof(Node));
+
+  if (!new_node)
+    return CC_ERR_ALLOC;
+
+  new_node->data = element;
+
+  link_after(iter->last, new_node);
+
+  if (iter->index == iter->list->size)
+    iter->list->tail = new_node;
+
+  iter->list->size++;
+  iter->index++;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element by <code>list_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_iter_replace(ListIter *iter, void *element, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old = iter->last->data;
+  iter->last->data = element;
+
+  if (out)
+    *out = old;
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element by <code>list_iter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is performed
+ *
+ * @return the index.
+ */
+size_t list_iter_index(ListIter *iter) { return iter->index - 1; }
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the list has been reached.
+ */
+enum cc_stat list_iter_next(ListIter *iter, void **out) {
+  if (!iter->next)
+    return CC_ITER_END;
+
+  void *data = iter->next->data;
+  iter->last = iter->next;
+  iter->next = iter->next->next;
+  iter->index++;
+
+  *out = data;
+
+  return CC_OK;
+}
+
+/**
+ * Returns a new descending iterator. A descending iterator or a reverse
+ * iterator, is an iterator that traverses the list from tail to head.
+ *
+ * @param[in] iter the iterator
+ * @param[in] list list on which this iterator will operate
+ */
+void list_diter_init(ListIter *iter, List *list) {
+  iter->index = list->size;
+  iter->list = list;
+  iter->last = NULL;
+  iter->next = list->tail;
+}
+
+/**
+ * Adds a new element to the list after the last returned element by
+ * <code>list_diter_next()</code> function (or before the element in
+ * the list) without invalidating the  iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added to the list
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat list_diter_add(ListIter *iter, void *element) {
+  Node *new_node = iter->list->mem_calloc(1, sizeof(Node));
+
+  if (!new_node)
+    return CC_ERR_ALLOC;
+
+  new_node->data = element;
+
+  if (iter->index == 0)
+    iter->list->head = new_node;
+
+  link_behind(iter->last, new_node);
+
+  iter->list->size++;
+  iter->last = new_node;
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>list_diter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_diter_remove(ListIter *iter, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(iter->list, iter->last);
+  iter->last = NULL;
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element by <code>list_diter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_diter_replace(ListIter *iter, void *element, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old = iter->last->data;
+  iter->last->data = element;
+
+  if (out)
+    *out = old;
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element by <code>list_diter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index.
+ */
+size_t list_diter_index(ListIter *iter) { return iter->index - 1; }
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the list has been reached.
+ */
+enum cc_stat list_diter_next(ListIter *iter, void **out) {
+  if (!iter->next)
+    return CC_ITER_END;
+
+  void *data = iter->next->data;
+  iter->last = iter->next;
+  iter->next = iter->next->prev;
+  iter->index--;
+
+  *out = data;
+
+  return CC_OK;
+}
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] l1   first list
+ * @param[in] l2   second list
+ */
+void list_zip_iter_init(ListZipIter *iter, List *l1, List *l2) {
+  iter->index = 0;
+  iter->l1 = l1;
+  iter->l2 = l2;
+  iter->l1_last = NULL;
+  iter->l2_last = NULL;
+  iter->l1_next = l1->head;
+  iter->l2_next = l2->head;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first list element
+ * @param[out] out2 output of the second list element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the lists has been reached.
+ */
+enum cc_stat list_zip_iter_next(ListZipIter *iter, void **out1, void **out2) {
+  if (!iter->l1_next || !iter->l2_next)
+    return CC_ITER_END;
+
+  void *data1 = iter->l1_next->data;
+  void *data2 = iter->l2_next->data;
+
+  iter->l1_last = iter->l1_next;
+  iter->l2_last = iter->l2_next;
+  iter->l1_next = iter->l1_next->next;
+  iter->l2_next = iter->l2_next->next;
+  iter->index++;
+
+  *out1 = data1;
+  *out2 = data2;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element pair to the lists after the last returned element pair by
+ * <code>list_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>list_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ * @param[in] e1   element added to the first list
+ * @param[in] e2   element added to the second list
+ *
+ * @return CC_OK if the element pair was successfully added to the lists, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat list_zip_iter_add(ListZipIter *iter, void *e1, void *e2) {
+  Node *new_node1 = iter->l1->mem_calloc(1, sizeof(Node));
+
+  if (!new_node1)
+    return CC_ERR_ALLOC;
+
+  Node *new_node2 = iter->l2->mem_calloc(1, sizeof(Node));
+
+  if (!new_node2) {
+    iter->l1->mem_free(new_node1);
+    return CC_ERR_ALLOC;
+  }
+
+  new_node1->data = e1;
+  new_node2->data = e2;
+
+  link_after(iter->l1_last, new_node1);
+  link_after(iter->l2_last, new_node2);
+
+  if (iter->index == iter->l1->size)
+    iter->l1->tail = new_node1;
+
+  if (iter->index == iter->l2->size)
+    iter->l2->tail = new_node2;
+
+  iter->l1->size++;
+  iter->l2->size++;
+  iter->index++;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>list_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[out] out1 output of the removed element from the first List
+ * @param[out] out2 output of the removed element from the second List
+ *
+ * @return CC_OK if the element was removed successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_zip_iter_remove(ListZipIter *iter, void **out1, void **out2) {
+  if (!iter->l1_last || !iter->l2_last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e1 = unlinkn(iter->l1, iter->l1_last);
+  void *e2 = unlinkn(iter->l2, iter->l2_last);
+
+  iter->l1_last = NULL;
+  iter->l2_last = NULL;
+
+  if (out1)
+    *out1 = e1;
+
+  if (out2)
+    *out2 = e2;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>list_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[in]  e1   first list's replacement element
+ * @param[in]  e2   second list's replacement element
+ * @param[out] out1 output of the replaced element from the first list
+ * @param[out] out2 output of the replaced element from the second list
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_zip_iter_replace(ListZipIter *iter, void *e1, void *e2,
+                                   void **out1, void **out2) {
+  if (!iter->l1_last || !iter->l2_last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old1 = iter->l1_last->data;
+  void *old2 = iter->l2_last->data;
+
+  iter->l1_last->data = e1;
+  iter->l2_last->data = e2;
+
+  if (out1)
+    *out1 = old1;
+
+  if (out2)
+    *out2 = old2;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>list_zip_iter_next()</code>.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ *
+ * @return current iterator index.
+ */
+size_t list_zip_iter_index(ListZipIter *iter) { return iter->index - 1; }
+
+/**
+ * Links the <code>ins</code> node behind the <code>base</code> node.
+ *
+ * @param[in] base the node behind which the <code>ins</code> is going to be
+ *                 linked
+ * @param[in] ins  the node that is being linked behind the <code>base</code>
+ *                 node
+ */
+static void link_behind(Node *const base, Node *ins) {
+  /* link the gap */
+  if (ins->next != NULL)
+    ins->next->prev = ins->prev;
+
+  if (ins->prev != NULL)
+    ins->prev->next = ins->next;
+
+  /* link behind */
+  if (base->prev == NULL) {
+    ins->prev = NULL;
+    ins->next = base;
+    base->prev = ins;
+  } else {
+    ins->prev = base->prev;
+    ins->prev->next = ins;
+    ins->next = base;
+    base->prev = ins;
+  }
+}
+
+/**
+ * Links the <code>ins</code> in front of the <code>base</code> node.
+ *
+ * @param[in] base the node in front of which the <code>ins</code> not is going
+ *                 to be linked
+ * @param[in] ins  the node that is being linked in front the <code>base</code>
+ *                 node
+ */
+static void link_after(Node *base, Node *ins) {
+  if (ins->next)
+    ins->next->prev = ins->prev;
+
+  if (ins->prev)
+    ins->prev->next = ins->next;
+
+  if (!base->next) {
+    ins->prev = base;
+    base->next = ins;
+    ins->next = NULL;
+  } else {
+    ins->next = base->next;
+    ins->next->prev = ins;
+    ins->prev = base;
+    base->next = ins;
+  }
+}
+
+/**
+ * Swaps the list positions of the specified nodes.
+ *
+ * @param[in] n1 the first node
+ * @param[in] n2 the second node
+ */
+static void swap(Node *n1, Node *n2) {
+  /* A special case is when the nodes are next to each other */
+  if (n1->next == n2 || n2->next == n1) {
+    swap_adjacent(n1, n2);
+    return;
+  }
+
+  Node *n1_left = n1->prev;
+  Node *n1_right = n1->next;
+  Node *n2_left = n2->prev;
+  Node *n2_right = n2->next;
+
+  if (n1_left)
+    n1_left->next = n2;
+
+  n2->prev = n1_left;
+
+  if (n1_right)
+    n1_right->prev = n2;
+
+  n2->next = n1_right;
+
+  if (n2_left)
+    n2_left->next = n1;
+
+  n1->prev = n2_left;
+
+  if (n2_right)
+    n2_right->prev = n1;
+
+  n1->next = n2_right;
+}
+
+/**
+ * Swaps two adjacent nodes. This handles the special case when the nodes
+ * are adjacent to each other.
+ *
+ * @param[in] n1 the first node
+ * @param[in] n2 the second node
+ */
+static void swap_adjacent(Node *n1, Node *n2) {
+  if (n1->next == n2) {
+    if (n2->next)
+      n2->next->prev = n1;
+
+    n1->next = n2->next;
+
+    if (n1->prev)
+      n1->prev->next = n2;
+
+    n2->prev = n1->prev;
+
+    n1->prev = n2;
+    n2->next = n1;
+    return;
+  }
+
+  if (n2->next == n1) {
+    if (n1->next)
+      n1->next->prev = n2;
+
+    n2->next = n1->next;
+
+    if (n2->prev)
+      n2->prev->next = n1;
+
+    n1->prev = n2->prev;
+
+    n2->prev = n1;
+    n1->next = n2;
+    return;
+  }
+}
+
+/**
+ * Unlinks a node from the list and returns the data that was associated with
+ * it.
+ *
+ * @param[in] list the list from which the node is being unlinked
+ * @param[in] node the node being unlinked
+ *
+ * @return the data that was at this node.
+ */
+static void *unlinkn(List *list, Node *node) {
+  void *data = node->data;
+
+  if (node->prev != NULL)
+    node->prev->next = node->next;
+
+  if (node->prev == NULL)
+    list->head = node->next;
+
+  if (node->next == NULL)
+    list->tail = node->prev;
+
+  if (node->next != NULL)
+    node->next->prev = node->prev;
+
+  list->mem_free(node);
+  list->size--;
+
+  return data;
+}
+
+/**
+ * Unlinks all nodes from the list and optionally frees the data at the nodes.
+ *
+ * @param[in] list the list from which all the nodes are being unlinked
+ * @param[in] freed a bool that determines whether or not the data at the nodes
+ *                  should also be freed
+ *
+ * @return false if the list is already empty, otherwise returns true.
+ */
+static bool unlinkn_all(List *list, void (*cb)(void *)) {
+  if (list->size == 0)
+    return false;
+
+  Node *node = list->head;
+
+  while (node) {
+    Node *tmp = node->next;
+
+    if (cb)
+      cb(node->data);
+
+    unlinkn(list, node);
+    node = tmp;
+  }
+  return true;
+}
+
+/**
+ * Returns the node at the specified index.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] index the index of the node being returned
+ *
+ * @return CC_OK if the node was found, or CC_ERR_OUT_OF_RANGE if not.
+ */
+static enum cc_stat get_node_at(List *list, size_t index, Node **out) {
+  if (!list || index >= list->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i;
+  Node *node = NULL;
+
+  if (index < list->size / 2) {
+    node = list->head;
+    for (i = 0; i < index; i++)
+      node = node->next;
+  } else {
+    node = list->tail;
+    for (i = list->size - 1; i > index; i--)
+      node = node->prev;
+  }
+  *out = node;
+  return CC_OK;
+}
+
+/**
+ * Returns the first node from the beginning of the list that is associated
+ * with the specified element. If no node is associated with the element, NULL
+ * is returned instead.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] element the element whose list node is being returned
+ *
+ * @return the node associated with the specified element.
+ */
+static Node *get_node(List *list, void *element) {
+  Node *node = list->head;
+  while (node) {
+    if (cc_common_cmp_ptr(node->data, element) == 0)
+      return node;
+    node = node->next;
+  }
+  return NULL;
+}

--- a/test/c/collections-c/bugs/src/utils.c
+++ b/test/c/collections-c/bugs/src/utils.c
@@ -1,0 +1,22 @@
+#include "utils.h"
+
+void CHECK_EQUAL_C_STRING(char *s1, char *s2) { owi_assert(strcmp(s1, s2) == 0); }
+
+void *copy(void *e1) {
+  int *cp = (int *)malloc(sizeof(int));
+  *cp = *((int *)e1);
+  return cp;
+}
+
+int cmp(void const *e1, void const *e2) {
+  int i = *((int *)e1);
+  int j = *((int *)e2);
+
+  if (i < j)
+    return -1;
+  if (i == j)
+    return 0;
+  return 1;
+}
+
+int zero_if_ptr_eq(void const *e1, void const *e2) { return !(e1 == e2); }

--- a/test/c/collections-c/bugs/testsuite/array_test_remove.c
+++ b/test/c/collections-c/bugs/testsuite/array_test_remove.c
@@ -1,0 +1,32 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+  int n = owi_i32();
+  owi_assume(n > 2);
+  owi_assume(n < 16);
+
+  int *last;
+  int *next_to_last;
+
+  for (int i = 0; i < n; i++) {
+    int *a = malloc(sizeof(int));
+    array_add(v1, a);
+    next_to_last = last;
+    last = a;
+  }
+
+  array_remove(v1, next_to_last, NULL);
+
+  owi_assert(array_size(v1) < n);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/bugs/testsuite/list_test_zipIterAdd.c
+++ b/test/c/collections-c/bugs/testsuite/list_test_zipIterAdd.c
@@ -1,0 +1,117 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+
+  char str_i[] = {i, '\0'};
+
+  int x = owi_i32();
+
+  char str_x[] = {x, '\0'};
+
+  int y = owi_i32();
+
+  char str_y[] = {y, '\0'};
+
+  owi_assume(a != b && a != c && a != d && a != h && a != x);
+  owi_assume(b != c && b != d && b != h && b != x);
+  owi_assume(c != d && c != h && c != x);
+  owi_assume(d != h && d != x && h != x);
+
+  owi_assume(e != f && e != g && e != i && e != y && f != g && f != i &&
+             f != y && g != i && g != y && i != y);
+
+  list_add(list1, str_a);
+  list_add(list1, str_b);
+  list_add(list1, str_c);
+  list_add(list1, str_d);
+
+  list_add(list2, str_e);
+  list_add(list2, str_f);
+  list_add(list2, str_g);
+
+  ListZipIter zip;
+  list_zip_iter_init(&zip, list1, list2);
+
+  void *e1, *e2;
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      list_zip_iter_add(&zip, str_h, str_i);
+  }
+
+  size_t index;
+  owi_assert(CC_OK == list_index_of(list1, str_h, zero_if_ptr_eq, &index));
+  owi_assert(2 == index);
+
+  owi_assert(CC_OK == list_index_of(list1, str_i, zero_if_ptr_eq, &index));
+  owi_assert(2 == index);
+
+  owi_assert(CC_OK == list_index_of(list1, str_c, zero_if_ptr_eq, &index));
+  owi_assert(3 == index);
+
+  owi_assert(1 == list_contains(list1, str_h));
+  owi_assert(1 == list_contains(list2, str_i));
+  owi_assert(5 == list_size(list1));
+  owi_assert(4 == list_size(list2));
+
+  list_zip_iter_init(&zip, list1, list2);
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e2, str_g) == 0)
+      list_zip_iter_add(&zip, str_x, str_y);
+  }
+
+  char *last;
+  list_get_last(list1, (void *)&last);
+  CHECK_EQUAL_C_STRING(str_d, last);
+
+  list_get_last(list2, (void *)&last);
+  CHECK_EQUAL_C_STRING(str_y, last);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/array_tests.t
+++ b/test/c/collections-c/normal/array_tests.t
@@ -1,0 +1,51 @@
+Array tests:
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_add.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_addAt2.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_contains.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_deepCopy.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_getAt.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_indexOf.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_iterAdd.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_iterRemove.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_iterReplace.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_reduce.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_remove.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_removeAll.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_removeAt.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_replaceAt.c
+  Assert failure: (i32.ne symbol_3 symbol_2)
+  Model:
+    (model
+      (symbol_0 (i32 0))
+      (symbol_1 (i32 0))
+      (symbol_2 (i32 0))
+      (symbol_3 (i32 0)))
+  Reached problem!
+  [1]
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_reverse.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_shallowCopy.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_subarray.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_zipIterAdd.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_zipIterNext.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_zipIterRemove.c
+  All OK
+  $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_zipIterReplace.c
+  All OK

--- a/test/c/collections-c/normal/deque_tests.t
+++ b/test/c/collections-c/normal/deque_tests.t
@@ -1,0 +1,69 @@
+Deque tests:
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_bufferExpansion.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_contains.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_trimCapacity.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_copyShallow.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addLast.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_removeFirst.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filter2.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filter1.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_getFirst.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_getAt.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addFirst.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_size.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filter3.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_zipIterRemove.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filterMut1.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addAt4.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_reverse.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_getLast.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filterMut2.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_iterRemove.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addAt1.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_iterNext.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_removeAll.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_zipIterAdd.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_iterAdd.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_removeLast.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_zipIterNext.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addAt2.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_capacity.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_copyDeep.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addAt3.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_zipIterReplace.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_addAt5.c
+  All OK
+  $ owi c -I include src/deque.c src/common.c src/utils.c testsuite/deque/deque_test_filterMut3.c
+  All OK

--- a/test/c/collections-c/normal/dune
+++ b/test/c/collections-c/normal/dune
@@ -1,0 +1,7 @@
+(cram
+ (deps
+  %{bin:owi}
+  (package owi)
+  (source_tree include)
+  (source_tree src)
+  (source_tree testsuite)))

--- a/test/c/collections-c/normal/include/array.h
+++ b/test/c/collections-c/normal/include/array.h
@@ -1,0 +1,169 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_ARRAY_H
+#define COLLECTIONS_C_ARRAY_H
+
+#include "common.h"
+
+/**
+ * A dynamic array that expands automatically as elements are
+ * added. The array supports amortized constant time insertion
+ * and removal of elements at the end of the array, as well as
+ * constant time access.
+ */
+typedef struct array_s Array;
+
+/**
+ * Array configuration structure. Used to initialize a new Array
+ * with specific values.
+ */
+typedef struct array_conf_s {
+    /**
+     * The initial capacity of the array */
+    size_t capacity;
+
+    /**
+     * The rate at which the buffer expands (capacity * exp_factor). */
+    float  exp_factor;
+
+    /**
+     * Memory allocators used to allocate the Array structure and the
+     * underlying data buffers. */
+    void *(*mem_alloc)  (size_t size);
+    void *(*mem_calloc) (size_t blocks, size_t size);
+    void  (*mem_free)   (void *block);
+} ArrayConf;
+
+/**
+ * Array iterator structure. Used to iterate over the elements of
+ * the array in an ascending order. The iterator also supports
+ * operations for safely adding and removing elements during
+ * iteration.
+ */
+typedef struct array_iter_s {
+    /**
+     * The array associated with this iterator */
+    Array  *ar;
+
+    /**
+     * The current position of the iterator.*/
+    size_t  index;
+
+    /**
+     * Set to true if the last returned element was removed. */
+    bool last_removed;
+} ArrayIter;
+
+/**
+ * Array zip iterator structure. Used to iterate over the elements of two
+ * arrays in lockstep in an ascending order until one of the Arrays is
+ * exhausted. The iterator also supports operations for safely adding
+ * and removing elements during iteration.
+ */
+typedef struct array_zip_iter_s {
+    Array *ar1;
+    Array *ar2;
+    size_t index;
+    bool last_removed;
+} ArrayZipIter;
+
+
+enum cc_stat  array_new             (Array **out);
+enum cc_stat  array_new_conf        (ArrayConf const * const conf, Array **out);
+void          array_conf_init       (ArrayConf *conf);
+
+void          array_destroy         (Array *ar);
+void          array_destroy_cb      (Array *ar, void (*cb) (void*));
+
+enum cc_stat  array_add             (Array *ar, void *element);
+enum cc_stat  array_add_at          (Array *ar, void *element, size_t index);
+enum cc_stat  array_replace_at      (Array *ar, void *element, size_t index, void **out);
+enum cc_stat  array_swap_at         (Array *ar, size_t index1, size_t index2);
+
+enum cc_stat  array_remove          (Array *ar, void *element, void **out);
+enum cc_stat  array_remove_at       (Array *ar, size_t index, void **out);
+enum cc_stat  array_remove_last     (Array *ar, void **out);
+void          array_remove_all      (Array *ar);
+void          array_remove_all_free (Array *ar);
+
+enum cc_stat  array_get_at          (Array *ar, size_t index, void **out);
+enum cc_stat  array_get_last        (Array *ar, void **out);
+
+enum cc_stat  array_subarray        (Array *ar, size_t from, size_t to, Array **out);
+enum cc_stat  array_copy_shallow    (Array *ar, Array **out);
+enum cc_stat  array_copy_deep       (Array *ar, void *(*cp) (void*), Array **out);
+
+void          array_reverse         (Array *ar);
+enum cc_stat  array_trim_capacity   (Array *ar);
+
+size_t        array_contains        (Array *ar, void *element);
+size_t        array_contains_value  (Array *ar, void *element, int (*cmp) (const void*, const void*));
+size_t        array_size            (Array *ar);
+size_t        array_capacity        (Array *ar);
+
+enum cc_stat  array_index_of        (Array *ar, void *element, size_t *index);
+void          array_sort            (Array *ar, int (*cmp) (const void*, const void*));
+
+void          array_map             (Array *ar, void (*fn) (void*));
+void          array_reduce          (Array *ar, void (*fn) (void*, void*, void*), void *result);
+
+enum cc_stat  array_filter_mut      (Array *ar, bool (*predicate) (const void*));
+enum cc_stat  array_filter          (Array *ar, bool (*predicate) (const void*), Array **out);
+
+void          array_iter_init       (ArrayIter *iter, Array *ar);
+enum cc_stat  array_iter_next       (ArrayIter *iter, void **out);
+enum cc_stat  array_iter_remove     (ArrayIter *iter, void **out);
+enum cc_stat  array_iter_add        (ArrayIter *iter, void *element);
+enum cc_stat  array_iter_replace    (ArrayIter *iter, void *element, void **out);
+size_t        array_iter_index      (ArrayIter *iter);
+
+
+void          array_zip_iter_init   (ArrayZipIter *iter, Array *a1, Array *a2);
+enum cc_stat  array_zip_iter_next   (ArrayZipIter *iter, void **out1, void **out2);
+enum cc_stat  array_zip_iter_add    (ArrayZipIter *iter, void *e1, void *e2);
+enum cc_stat  array_zip_iter_remove (ArrayZipIter *iter, void **out1, void **out2);
+enum cc_stat  array_zip_iter_replace(ArrayZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+size_t        array_zip_iter_index  (ArrayZipIter *iter);
+
+const void* const* array_get_buffer(Array *ar);
+
+
+#define ARRAY_FOREACH(val, array, body)         \
+    {                                           \
+        ArrayIter array_iter_53d46d2a04458e7b;  \
+        array_iter_init(&array_iter_53d46d2a04458e7b, array);   \
+        void *val;                                              \
+        while (array_iter_next(&array_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define ARRAY_FOREACH_ZIP(val1, val2, array1, array2, body)     \
+    {                                                           \
+        ArrayZipIter array_zip_iter_ea08d3e52f25883b3;                 \
+        array_zip_iter_init(&array_zip_iter_ea08d3e52f25883b, array1, array2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (array_zip_iter_next(&array_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_ARRAY_H */

--- a/test/c/collections-c/normal/include/common.h
+++ b/test/c/collections-c/normal/include/common.h
@@ -1,0 +1,67 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_COMMON_H
+#define COLLECTIONS_C_COMMON_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef ARCH_64
+#define MAX_POW_TWO (((size_t)1) << 63)
+#else
+#define MAX_POW_TWO (((size_t)1) << 31)
+#endif /* ARCH_64 */
+
+enum cc_stat {
+  CC_OK = 0,
+
+  CC_ERR_ALLOC = 1,
+  CC_ERR_INVALID_CAPACITY = 2,
+  CC_ERR_INVALID_RANGE = 3,
+  CC_ERR_MAX_CAPACITY = 4,
+  CC_ERR_KEY_NOT_FOUND = 6,
+  CC_ERR_VALUE_NOT_FOUND = 7,
+  CC_ERR_OUT_OF_RANGE = 8,
+
+  CC_ITER_END = 9,
+};
+
+#define CC_MAX_ELEMENTS 16777216LU
+
+#if defined(_MSC_VER)
+
+#define INLINE __inline
+#define FORCE_INLINE __forceinline
+
+#else
+
+#define INLINE inline
+#define FORCE_INLINE inline __attribute__((always_inline))
+
+#endif /* _MSC_VER */
+
+int cc_common_cmp_str(const void *key1, const void *key2);
+
+#define CC_CMP_STRING cc_common_cmp_str
+
+#endif /* COLLECTIONS_C_COMMON_H */

--- a/test/c/collections-c/normal/include/deque.h
+++ b/test/c/collections-c/normal/include/deque.h
@@ -1,0 +1,163 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_DEQUE_H
+#define COLLECTIONS_C_DEQUE_H
+
+#include "common.h"
+
+/**
+ * A dynamic array that supports amortized constant time insertion
+ * and removal at both ends and constant time access.
+ */
+typedef struct deque_s Deque;
+
+/**
+ * Deque configuration structure. Used to initialize a new Deque
+ * with specific values.
+ */
+typedef struct deque_conf_s {
+    /**
+     * The initial capacity of the deque. Must be a power of two.
+     * if a non power of two is passed, it will be rounded to the
+     * closest upper power of two */
+    size_t capacity;
+
+    /**
+     * Memory allocators used to allocate the Vector structure and the
+     * underlying data buffers. */
+    void *(*mem_alloc)  (size_t size);
+    void *(*mem_calloc) (size_t blocks, size_t size);
+    void  (*mem_free)   (void *block);
+} DequeConf;
+
+/**
+ * Deque iterator object. Used to iterate over the elements of
+ * a deque in an ascending order. The iterator also supports
+ * operations for safely  removing and adding elements during
+ * iteration.
+ */
+typedef struct deque_iter_s {
+    /**
+     * The deque associated with this iterator.*/
+    Deque *deque;
+
+    /**
+     * The current logical position of the iterator. */
+    size_t index;
+
+    bool last_removed;
+} DequeIter;
+
+/**
+ * Deque zip iterator structure. Used to iterate over two Deques in
+ * lockstep in an ascending order until one of the deques is exhausted.
+ * The iterator also supports operations for safely adding and removing
+ * elements during iteration.
+ */
+typedef struct deque_zip_iter_s {
+    Deque *d1;
+    Deque *d2;
+    size_t index;
+    bool last_removed;
+} DequeZipIter;
+
+
+enum cc_stat  deque_new             (Deque **deque);
+enum cc_stat  deque_new_conf        (DequeConf const * const conf, Deque **deque);
+void          deque_conf_init       (DequeConf *conf);
+
+void          deque_destroy         (Deque *deque);
+void          deque_destroy_cb      (Deque *deque, void (*cb) (void*));
+
+enum cc_stat  deque_add             (Deque *deque, void *element);
+enum cc_stat  deque_add_first       (Deque *deque, void *element);
+enum cc_stat  deque_add_last        (Deque *deque, void *element);
+enum cc_stat  deque_add_at          (Deque *deque, void *element, size_t index);
+enum cc_stat  deque_replace_at      (Deque *deque, void *element, size_t index, void **out);
+
+enum cc_stat  deque_remove          (Deque *deque, void *element, void **out);
+enum cc_stat  deque_remove_at       (Deque *deque, size_t index, void **out);
+enum cc_stat  deque_remove_first    (Deque *deque, void **out);
+enum cc_stat  deque_remove_last     (Deque *deque, void **out);
+void          deque_remove_all      (Deque *deque);
+void          deque_remove_all_cb   (Deque *deque, void (*cb) (void*));
+
+enum cc_stat  deque_get_at          (Deque const * const deque, size_t index, void **out);
+enum cc_stat  deque_get_first       (Deque const * const deque, void **out);
+enum cc_stat  deque_get_last        (Deque const * const deque, void **out);
+
+enum cc_stat  deque_copy_shallow    (Deque const * const deque, Deque **out);
+enum cc_stat  deque_copy_deep       (Deque const * const deque, void *(*cp) (void*), Deque **out);
+
+void          deque_reverse         (Deque *deque);
+enum cc_stat  deque_trim_capacity   (Deque *deque);
+
+size_t        deque_contains        (Deque const * const deque, const void *element);
+size_t        deque_contains_value  (Deque const * const deque, const void *element, int (*cmp)(const void*, const void*));
+size_t        deque_size            (Deque const * const deque);
+size_t        deque_capacity        (Deque const * const deque);
+
+enum cc_stat  deque_index_of        (Deque const * const deque, const void *element, size_t *i);
+
+void          deque_foreach         (Deque *deque, void (*fn) (void *));
+
+enum cc_stat  deque_filter_mut      (Deque *deque, bool (*predicate) (const void*));
+enum cc_stat  deque_filter          (Deque *deque, bool (*predicate) (const void*), Deque **out);
+
+void          deque_iter_init       (DequeIter *iter, Deque *deque);
+enum cc_stat  deque_iter_next       (DequeIter *iter, void **out);
+enum cc_stat  deque_iter_remove     (DequeIter *iter, void **out);
+enum cc_stat  deque_iter_add        (DequeIter *iter, void *element);
+enum cc_stat  deque_iter_replace    (DequeIter *iter, void *replacement, void **out);
+size_t        deque_iter_index      (DequeIter *iter);
+
+void          deque_zip_iter_init   (DequeZipIter *iter, Deque *d1, Deque *d2);
+enum cc_stat  deque_zip_iter_next   (DequeZipIter *iter, void **out1, void **out2);
+enum cc_stat  deque_zip_iter_add    (DequeZipIter *iter, void *e1, void *e2);
+enum cc_stat  deque_zip_iter_remove (DequeZipIter *iter, void **out1, void **out2);
+enum cc_stat  deque_zip_iter_replace(DequeZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+size_t        deque_zip_iter_index  (DequeZipIter *iter);
+
+const void* const* deque_get_buffer (Deque const * const deque);
+
+
+#define DEQUE_FOREACH(val, deque, body)                                 \
+    {                                                                   \
+        DequeIter deque_iter_53d46d2a04458e7b;                          \
+        deque_iter_init(&deque_iter_53d46d2a04458e7b, deque);           \
+        void *val;                                                      \
+        while (deque_iter_next(&deque_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define DEQUE_FOREACH_ZIP(val1, val2, deque1, deque2, body)             \
+    {                                                                   \
+        DequeZipIter deque_zip_iter_ea08d3e52f25883b3;                  \
+        deque_zip_iter_init(&deque_zip_iter_ea08d3e52f25883b, deque1, deque2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (deque_zip_iter_next(&deque_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#endif /* COLLECTIONS_C_DEQUE_H */

--- a/test/c/collections-c/normal/include/hashset.h
+++ b/test/c/collections-c/normal/include/hashset.h
@@ -1,0 +1,78 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_HASHSET_H
+#define COLLECTIONS_C_HASHSET_H
+
+#include "common.h"
+#include "hashtable.h"
+
+/**
+ * An unordered set. The lookup, deletion, and insertion are
+ * performed in amortized constant time and in the worst case
+ * in amortized linear time.
+ */
+typedef struct hashset_s HashSet;
+
+/**
+ * HashSet configuration object.
+ */
+typedef HashTableConf HashSetConf;
+
+/**
+ * HashSet iterator structure. Used to iterate over the elements
+ * of the HashSet. The iterator also supports operations for safely
+ * removing elements during iteration.
+ */
+typedef struct hashset_iter_s {
+    HashTableIter iter;
+} HashSetIter;
+
+void          hashset_conf_init     (HashSetConf *conf);
+
+enum cc_stat  hashset_new           (HashSet **hs);
+enum cc_stat  hashset_new_conf      (HashSetConf const * const conf, HashSet **hs);
+void          hashset_destroy       (HashSet *set);
+
+enum cc_stat  hashset_add           (HashSet *set, void *element);
+enum cc_stat  hashset_remove        (HashSet *set, void *element, void **out);
+void          hashset_remove_all    (HashSet *set);
+
+bool          hashset_contains      (HashSet *set, void *element);
+size_t        hashset_size          (HashSet *set);
+size_t        hashset_capacity      (HashSet *set);
+
+void          hashset_foreach       (HashSet *set, void (*op) (const void*));
+
+void          hashset_iter_init     (HashSetIter *iter, HashSet *set);
+enum cc_stat  hashset_iter_next     (HashSetIter *iter, void **out);
+enum cc_stat  hashset_iter_remove   (HashSetIter *iter, void **out);
+
+
+#define HASHSET_FOREACH(val, hashset, body)                             \
+    {                                                                   \
+        HashsetIter hashset_iter_53d46d2a04458e7b;                      \
+        hashset_iter_init(&hashset_iter_53d46d2a04458e7b, hashset);     \
+        void *val;                                                      \
+        while (hashset_iter_next(&hashset_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_HASHSET_H */

--- a/test/c/collections-c/normal/include/hashtable.h
+++ b/test/c/collections-c/normal/include/hashtable.h
@@ -1,0 +1,163 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_HASHTABLE_H
+#define COLLECTIONS_C_HASHTABLE_H
+
+#include "array.h"
+#include "common.h"
+
+#define KEY_LENGTH_VARIABLE  -1
+#define KEY_LENGTH_POINTER   sizeof(void*)
+
+/**
+ * An unordered key-value map. HashTable supports best case amortized
+ * constant time insertion, removal, and lookup of values. The worst
+ * case complexity for these operations is amortized linear time.
+ * The performance of the table depends greatly on the quality of the
+ * hash function being used.
+ */
+typedef struct hashtable_s HashTable;
+
+/**
+ * A HashTable table entry.
+ *
+ * @note modifying this structure may invalidate the table.
+ */
+typedef struct table_entry_s {
+    /**
+     * A key in the table */
+    void     *key;
+
+    /**
+     * Value associated with the key */
+    void     *value;
+
+    /**
+     * Hash of the key */
+    size_t    hash;
+
+    /**
+     * Pointer the next entry in the list. */
+    struct table_entry_s *next;
+} TableEntry;
+
+/**
+ * HashTable iterator object. Used to iterate over the entries of
+ * the table in an undefined order. The iterator also supports operations
+ * for safely removing elements during iteration.
+ *
+ * @note This structure should only be modified through the iterator functions.
+ */
+typedef struct hashtable_iter {
+    HashTable  *table;
+    size_t      bucket_index;
+    TableEntry *prev_entry;
+    TableEntry *next_entry;
+} HashTableIter;
+
+/**
+ * HashTable configuration object. Used to initialize a new HashTable
+ * with specific values.
+ */
+typedef struct hashtable_conf_s {
+    /**
+     * The load factor determines how the underlying
+     * table array grows. For example if the load factor
+     * is 0.5 and the arrays capacity is 100, the resize will
+     * be triggered once the 50th entry is added. */
+    float    load_factor;
+
+    /**
+     * The initial capacity of the table array. */
+    size_t   initial_capacity;
+
+    /**
+     * Length of the key or -1 if the key length is
+     * variable */
+    int      key_length;
+
+    /**
+     * The hash seed passed to the hash function for
+     * extra 'randomness'.*/
+    uint32_t hash_seed;
+
+    /**
+     * Hash function used for hashing table keys */
+    size_t (*hash)        (const void *key, int l, uint32_t seed);
+
+    /**
+     * The key comparator function */
+    int    (*key_compare) (const void *key1, const void *key2);
+
+    /**
+     * Memory allocators used to allocate the HashTable structure
+     * and for all internal memory allocations. */
+    void  *(*mem_alloc)   (size_t size);
+    void  *(*mem_calloc)  (size_t blocks, size_t size);
+    void   (*mem_free)    (void *block);
+} HashTableConf;
+
+
+void          hashtable_conf_init       (HashTableConf *conf);
+enum cc_stat  hashtable_new             (HashTable **out);
+enum cc_stat  hashtable_new_conf        (HashTableConf const * const conf, HashTable **out);
+
+void          hashtable_destroy         (HashTable *table);
+enum cc_stat  hashtable_add             (HashTable *table, void *key, void *val);
+enum cc_stat  hashtable_get             (HashTable *table, void *key, void **out);
+enum cc_stat  hashtable_remove          (HashTable *table, void *key, void **out);
+void          hashtable_remove_all      (HashTable *table);
+bool          hashtable_contains_key    (HashTable *table, void *key);
+
+size_t        hashtable_size            (HashTable *table);
+size_t        hashtable_capacity        (HashTable *table);
+
+enum cc_stat  hashtable_get_keys        (HashTable *table, Array **out);
+enum cc_stat  hashtable_get_values      (HashTable *table, Array **out);
+
+size_t        hashtable_hash_string     (const void *key, int len, uint32_t seed);
+size_t        hashtable_hash            (const void *key, int len, uint32_t seed);
+size_t        hashtable_hash_ptr        (const void *key, int len, uint32_t seed);
+
+void          hashtable_foreach_key     (HashTable *table, void (*op) (const void *));
+void          hashtable_foreach_value   (HashTable *table, void (*op) (void *));
+
+void          hashtable_iter_init       (HashTableIter *iter, HashTable *table);
+enum cc_stat  hashtable_iter_next       (HashTableIter *iter, TableEntry **out);
+enum cc_stat  hashtable_iter_remove     (HashTableIter *iter, void **out);
+
+
+#define HASHTABLE_FOREACH(entry, hashtable, body)                       \
+    {                                                                   \
+        HashTableIter hashtable_iter_53d46d2a04458e7b;                  \
+        hashtable_iter_init(&hashtable_iter_53d46d2a04458e7b, hashtable); \
+        TableEntry *val;                                                \
+        while (hashtable_iter_next(&hashtable_iter_53d46d2a04458e7b, &entry) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define GENERAL_HASH hashtable_hash
+#define STRING_HASH  hashtable_hash_string
+#define POINTER_HASH hashtable_hash_ptr
+
+
+#endif /* COLLECTIONS_C_HASHTABLE_H */

--- a/test/c/collections-c/normal/include/list.h
+++ b/test/c/collections-c/normal/include/list.h
@@ -1,0 +1,188 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_LIST_H
+#define COLLECTIONS_C_LIST_H
+
+#include "common.h"
+
+/**
+ * A doubly linked list. List is a sequential structure that
+ * supports insertion, deletion and lookup from both ends in
+ * constant time, while the worst case is O(n/2) at the middle
+ * of the list.
+ */
+typedef struct list_s List;
+
+/**
+ * List node.
+ *
+ * @note Modifying the links may invalidate the list structure.
+ */
+typedef struct node_s {
+    void          *data;
+    struct node_s *next;
+    struct node_s *prev;
+} Node;
+
+/**
+ * List iterator structure. Used to iterate over the elements of the
+ * list in an ascending or descending order. The iterator also supports
+ * operations for safely adding and removing elements during iteration.
+ */
+typedef struct list_iter_s {
+    /**
+     * The current position of the iterator.*/
+    size_t  index;
+
+    /**
+     * The list associated with this iterator */
+    List   *list;
+
+    /**
+     * Last returned node */
+    Node   *last;
+
+    /**
+     * Next node in the sequence. */
+    Node   *next;
+} ListIter;
+
+/**
+ * List zip iterator structure. Used to iterate over two Lists in
+ * lockstep in an ascending order until one of the lists is exhausted.
+ * The iterator also supports operations for safely adding and
+ * removing elements during iteration.
+ */
+typedef struct list_zip_iter_s {
+    List *l1;
+    List *l2;
+    Node *l1_last;
+    Node *l2_last;
+    Node *l1_next;
+    Node *l2_next;
+    size_t index;
+} ListZipIter;
+
+
+/**
+ * List configuration structure. Used to initialize a new List with specific
+ * values.
+ */
+typedef struct list_conf_s {
+    void  *(*mem_alloc)  (size_t size);
+    void  *(*mem_calloc) (size_t blocks, size_t size);
+    void   (*mem_free)   (void *block);
+} ListConf;
+
+
+void          list_conf_init       (ListConf *conf);
+enum cc_stat  list_new             (List **list);
+enum cc_stat  list_new_conf        (ListConf const * const conf, List **list);
+void          list_destroy         (List *list);
+void          list_destroy_cb      (List *list, void (*cb) (void*));
+
+enum cc_stat  list_splice          (List *list1, List *list2);
+enum cc_stat  list_splice_at       (List *list, List *list2, size_t index);
+
+enum cc_stat  list_add             (List *list, void *element);
+enum cc_stat  list_add_at          (List *list, void *element, size_t index);
+enum cc_stat  list_add_all         (List *list1, List *list2);
+enum cc_stat  list_add_all_at      (List *list, List *list2, size_t index);
+enum cc_stat  list_add_first       (List *list, void *element);
+enum cc_stat  list_add_last        (List *list, void *element);
+
+enum cc_stat  list_remove          (List *list, void *element, void **out);
+enum cc_stat  list_remove_first    (List *list, void **out);
+enum cc_stat  list_remove_last     (List *list, void **out);
+enum cc_stat  list_remove_at       (List *list, size_t index, void **out);
+
+enum cc_stat  list_remove_all      (List *list);
+enum cc_stat  list_remove_all_cb   (List *list, void (*cb) (void*));
+
+enum cc_stat  list_get_at          (List *list, size_t index, void **out);
+enum cc_stat  list_get_first       (List *list, void **out);
+enum cc_stat  list_get_last        (List *list, void **out);
+
+enum cc_stat  list_sublist         (List *list, size_t from, size_t to, List **out);
+enum cc_stat  list_copy_shallow    (List *list, List **out);
+enum cc_stat  list_copy_deep       (List *list, void *(*cp) (void*), List **out);
+
+enum cc_stat  list_replace_at      (List *list, void *element, size_t index, void **out);
+
+size_t        list_contains        (List *list, void *element);
+size_t        list_contains_value  (List *list, void *element, int (*cmp) (const void*, const void*));
+enum cc_stat  list_index_of        (List *list, void *element, int (*cmp) (const void*, const void*), size_t *index);
+enum cc_stat  list_to_array        (List *list, void ***out);
+
+void          list_reverse         (List *list);
+enum cc_stat  list_sort            (List *list, int (*cmp) (void const*, void const*));
+void          list_sort_in_place   (List *list, int (*cmp) (void const*, void const*));
+size_t        list_size            (List *list);
+
+void          list_foreach         (List *list, void (*op) (void *));
+
+enum cc_stat  list_filter_mut      (List *list, bool (*predicate) (const void*));
+enum cc_stat  list_filter          (List *list, bool (*predicate) (const void*), List **out);
+
+void          list_iter_init       (ListIter *iter, List *list);
+enum cc_stat  list_iter_remove     (ListIter *iter, void **out);
+enum cc_stat  list_iter_add        (ListIter *iter,  void *element);
+enum cc_stat  list_iter_replace    (ListIter *iter, void *element, void **out);
+size_t        list_iter_index      (ListIter *iter);
+enum cc_stat  list_iter_next       (ListIter *iter, void **out);
+
+void          list_diter_init      (ListIter *iter, List *list);
+enum cc_stat  list_diter_remove    (ListIter *iter, void **out);
+enum cc_stat  list_diter_add       (ListIter *iter, void *element);
+enum cc_stat  list_diter_replace   (ListIter *iter, void *element, void **out);
+size_t        list_diter_index     (ListIter *iter);
+enum cc_stat  list_diter_next      (ListIter *iter, void **out);
+
+void          list_zip_iter_init   (ListZipIter *iter, List *l1, List *l2);
+enum cc_stat  list_zip_iter_next   (ListZipIter *iter, void **out1, void **out2);
+enum cc_stat  list_zip_iter_add    (ListZipIter *iter, void *e1, void *e2);
+enum cc_stat  list_zip_iter_remove (ListZipIter *iter, void **out1, void **out2);
+enum cc_stat  list_zip_iter_replace(ListZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+size_t        list_zip_iter_index  (ListZipIter *iter);
+
+
+#define LIST_FOREACH(val, list, body)                                   \
+    {                                                                   \
+        ListIter list_iter_53d46d2a04458e7b;                            \
+        list_iter_init(&list_iter_53d46d2a04458e7b, list);              \
+        void *val;                                                      \
+        while (list_iter_next(&list_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define LIST_FOREACH_ZIP(val1, val2, list1, list2, body)                \
+    {                                                                   \
+        ListZipIter list_zip_iter_ea08d3e52f25883b3;                    \
+        list_zip_iter_init(&list_zip_iter_ea08d3e52f25883b, list1, list2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (list_zip_iter_next(&list_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#endif /* COLLECTIONS_C_LIST_H */

--- a/test/c/collections-c/normal/include/pqueue.h
+++ b/test/c/collections-c/normal/include/pqueue.h
@@ -1,0 +1,74 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_PQUEUE_H
+#define COLLECTIONS_C_PQUEUE_H
+
+#include "common.h"
+#include "array.h"
+
+/**
+ * A Priority Queue data structure. Stores the elements and according to
+ * some property associated with the element stored in the pqueue, the elements
+ * can be retrieved in a specific order
+ **/
+
+typedef struct pqueue_s PQueue;
+
+/**
+ * The pqueue initialization configuration structure. Used to initialize the
+ * PQueue with the specified attributes
+ **/
+
+typedef struct pqueue_conf_s {
+    /**
+     * The initial capacity of the array */
+    size_t capacity;
+
+    /**
+     * The rate at which the buffer expands (capacity * exp_factor). */
+    float  exp_factor;
+
+    /**
+     * comparator, used to hold the address of the function which will
+     * be used to compare the elements of the PQueue
+     */
+    int (*cmp) (const void *a, const void *b);
+
+    /**
+     * Memory allocators used to allocate the Array structure and the
+     * underlying data buffers. */
+    void *(*mem_alloc)  (size_t size);
+    void *(*mem_calloc) (size_t blocks, size_t size);
+    void  (*mem_free)   (void *block);
+} PQueueConf;
+
+void          pqueue_conf_init       (PQueueConf *conf, int (*)(const void *, const void *));
+enum cc_stat  pqueue_new             (PQueue **out, int (*)(const void *, const void *));
+enum cc_stat  pqueue_new_conf        (PQueueConf const * const conf, PQueue **out);
+void          pqueue_destroy         (PQueue *pqueue);
+void          pqueue_destroy_cb      (PQueue *pqueue, void (*cb) (void*));
+
+enum cc_stat  pqueue_push            (PQueue *pqueue, void *element);
+enum cc_stat  pqueue_top             (PQueue *pqueue, void **out);
+enum cc_stat  pqueue_pop             (PQueue *pqueue, void **out);
+
+
+#endif

--- a/test/c/collections-c/normal/include/queue.h
+++ b/test/c/collections-c/normal/include/queue.h
@@ -1,0 +1,99 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_QUEUE_H
+#define COLLECTIONS_C_QUEUE_H
+
+#include "common.h"
+#include "deque.h"
+
+/**
+ * A FIFO (first in first out) structure. Supports constant time
+ * insertion, removal and lookup.
+ */
+typedef struct queue_s Queue;
+
+/**
+ * Queue configuration object.
+ */
+typedef DequeConf QueueConf;
+
+/**
+ * Queue iterator object. Used to iterate over the elements of a
+ * queue in an ascending order.
+ */
+typedef struct queue_iter_s {
+    DequeIter i;
+} QueueIter;
+
+/**
+ * Queue zip iterator structure. Used to iterate over the elements of two
+ * queues in lockstep in an ascending order until one of the queues is
+ * exhausted. The iterator also supports operations for safely adding
+ * and removing elements during iteration.
+ */
+typedef struct queue_zip_iter_s {
+    DequeZipIter i;
+} QueueZipIter;
+
+
+void         queue_conf_init       (QueueConf *conf);
+enum cc_stat queue_new             (Queue **q);
+enum cc_stat queue_new_conf        (QueueConf const * const conf, Queue **q);
+void         queue_destroy         (Queue *queue);
+void         queue_destroy_cb      (Queue *queue, void (*cb) (void*));
+
+enum cc_stat queue_peek            (Queue const * const queue, void **out);
+enum cc_stat queue_poll            (Queue *queue, void **out);
+enum cc_stat queue_enqueue         (Queue *queue, void *element);
+
+size_t       queue_size            (Queue const * const queue);
+void         queue_foreach         (Queue *queue, void (*op) (void*));
+
+void         queue_iter_init       (QueueIter *iter, Queue *queue);
+enum cc_stat queue_iter_next       (QueueIter *iter, void **out);
+enum cc_stat queue_iter_replace    (QueueIter *iter, void *replacement, void **out);
+
+void         queue_zip_iter_init   (QueueZipIter *iter, Queue *q1, Queue *q2);
+enum cc_stat queue_zip_iter_next   (QueueZipIter *iter, void **out1, void **out2);
+enum cc_stat queue_zip_iter_replace(QueueZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+
+
+#define QUEUE_FOREACH(val, queue, body)                                 \
+    {                                                                   \
+        QueueIter queue_iter_53d46d2a04458e7b;                          \
+        queue_iter_init(&queue_iter_53d46d2a04458e7b, queue);           \
+        void *val;                                                      \
+        while (queue_iter_next(&queue_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define QUEUE_FOREACH_ZIP(val1, val2, queue1, queue2, body)             \
+    {                                                                   \
+        QueueZipIter queue_zip_iter_ea08d3e52f25883b3;                  \
+        queue_zip_iter_init(&queue_zip_iter_ea08d3e52f25883b, queue1, queue2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (queue_zip_iter_next(&queue_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_QUEUE_H */

--- a/test/c/collections-c/normal/include/ring_buffer.h
+++ b/test/c/collections-c/normal/include/ring_buffer.h
@@ -1,0 +1,30 @@
+/**
+ * @Author: S. Sharma <silentcat>
+ * @Date:   2019-03-07T10:32:52-06:00
+ * @Email:  silentcat@protonmail.com
+ * @Last modified by:   silentcat
+ * @Last modified time: 2019-03-09T15:14:36-06:00
+ */
+
+#ifndef COLLECTIONS_C_RBUF_H
+#define COLLECTIONS_C_RBUF_H
+
+#include "common.h"
+
+#define DEFAULT_RBUF_CAPACITY 10
+
+typedef struct ring_buffer_conf RbufConf;
+typedef struct ring_buffer Rbuf;
+
+enum cc_stat  rbuf_new           (Rbuf **rbuf);
+void          rbuf_conf_init     (RbufConf *rconf);
+enum cc_stat  rbuf_conf_new      (RbufConf *rconf, Rbuf **rbuf);
+void          rbuf_enqueue       (Rbuf *rbuf, uint64_t item);
+enum cc_stat  rbuf_dequeue       (Rbuf *rbuf, uint64_t *out);
+bool          rbuf_is_empty      (Rbuf *rbuf);
+size_t        rbuf_size          (Rbuf *rbuf);
+void          rbuf_destroy       (Rbuf *rbuf);
+uint64_t      rbuf_peek          (Rbuf *rbuf, int index);
+
+
+#endif

--- a/test/c/collections-c/normal/include/slist.h
+++ b/test/c/collections-c/normal/include/slist.h
@@ -1,0 +1,170 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_SLIST_H
+#define COLLECTIONS_C_SLIST_H
+
+#include "common.h"
+
+/**
+ * A singly linked list. List is a sequential structure that
+ * supports constant time insertion, deletion  and lookup at
+ * the beginning of the list, while the worst case for these
+ * operations is linear time.
+ */
+typedef struct slist_s SList;
+
+/**
+ * SList node.
+ *
+ * @note Modifying the links may invalidate the list structure.
+ */
+typedef struct snode_s {
+    void           *data;
+    struct snode_s *next;
+} SNode;
+
+/**
+ * SList iterator structure. Used to iterate over the elements
+ * of the list in an ascending order. The iterator also supports
+ * operations for safely adding and removing elements during iteration.
+ */
+typedef struct slist_iter_s {
+    size_t  index;
+    SList  *list;
+    SNode   *next;
+    SNode   *current;
+    SNode   *prev;
+} SListIter;
+
+/**
+ * SList zip iterator structure. Used to iterate over two SLists in
+ * lockstep in an ascending order until one of the lists is exhausted.
+ * The iterator also supports operations for safely adding and
+ * removing elements during iteration.
+ */
+typedef struct slist_zip_iter_s {
+    size_t index;
+    SList *l1;
+    SList *l2;
+    SNode *l1_next;
+    SNode *l2_next;
+    SNode *l1_current;
+    SNode *l2_current;
+    SNode *l1_prev;
+    SNode *l2_prev;
+} SListZipIter;
+
+
+/**
+ * SList configuration structure. Used to initialize a new SList with
+ * specific values.
+ */
+typedef struct slist_conf_s {
+    void  *(*mem_alloc)  (size_t size);
+    void  *(*mem_calloc) (size_t blocks, size_t size);
+    void   (*mem_free)   (void *block);
+} SListConf;
+
+
+void          slist_conf_init       (SListConf *conf);
+enum cc_stat  slist_new             (SList **list);
+enum cc_stat  slist_new_conf        (SListConf const * const conf, SList **list);
+void          slist_destroy         (SList *list);
+void          slist_destroy_cb      (SList *list, void (*cb) (void*));
+
+enum cc_stat  slist_splice          (SList *list1, SList *list2);
+enum cc_stat  slist_splice_at       (SList *list1, SList *list2, size_t index);
+
+enum cc_stat  slist_add             (SList *list, void *element);
+enum cc_stat  slist_add_at          (SList *list, void *element, size_t index);
+enum cc_stat  slist_add_all         (SList *list1, SList *list2);
+enum cc_stat  slist_add_all_at      (SList *list1, SList *list2, size_t index);
+enum cc_stat  slist_add_first       (SList *list, void *element);
+enum cc_stat  slist_add_last        (SList *list, void *element);
+
+enum cc_stat  slist_remove          (SList *list, void *element, void **out);
+enum cc_stat  slist_remove_first    (SList *list, void **out);
+enum cc_stat  slist_remove_last     (SList *list, void **out);
+enum cc_stat  slist_remove_at       (SList *list, size_t index, void **out);
+
+enum cc_stat  slist_remove_all      (SList *list);
+enum cc_stat  slist_remove_all_cb   (SList *list, void (*cb) (void*));
+
+enum cc_stat  slist_get_at          (SList *list, size_t index, void **out);
+enum cc_stat  slist_get_first       (SList *list, void **out);
+enum cc_stat  slist_get_last        (SList *list, void **out);
+
+enum cc_stat  slist_sublist         (SList *list, size_t from, size_t to, SList **out);
+enum cc_stat  slist_copy_shallow    (SList *list, SList **out);
+enum cc_stat  slist_copy_deep       (SList *list, void *(*cp) (void*), SList **out);
+
+enum cc_stat  slist_replace_at      (SList *list, void *element, size_t index, void **out);
+
+size_t        slist_contains        (SList *list, void *element);
+size_t        slist_contains_value  (SList *list, void *element, int (*cmp) (const void*, const void*));
+enum cc_stat  slist_index_of        (SList *list, void *element, size_t *index);
+enum cc_stat  slist_to_array        (SList *list, void ***out);
+
+void          slist_reverse         (SList *list);
+enum cc_stat  slist_sort            (SList *list, int (*cmp) (void const*, void const*));
+size_t        slist_size            (SList *list);
+
+void          slist_foreach         (SList *list, void (*op) (void *));
+
+enum cc_stat  slist_filter          (SList *list, bool (*predicate) (const void*), SList **out);
+enum cc_stat  slist_filter_mut      (SList *list, bool (*predicate) (const void*));
+
+void          slist_iter_init       (SListIter *iter, SList *list);
+enum cc_stat  slist_iter_remove     (SListIter *iter, void **out);
+enum cc_stat  slist_iter_add        (SListIter *iter, void *element);
+enum cc_stat  slist_iter_replace    (SListIter *iter, void *element, void **out);
+enum cc_stat  slist_iter_next       (SListIter *iter, void **out);
+size_t        slist_iter_index      (SListIter *iter);
+
+void          slist_zip_iter_init   (SListZipIter *iter, SList *l1, SList *l2);
+enum cc_stat  slist_zip_iter_next   (SListZipIter *iter, void **out1, void **out2);
+enum cc_stat  slist_zip_iter_add    (SListZipIter *iter, void *e1, void *e2);
+enum cc_stat  slist_zip_iter_remove (SListZipIter *iter, void **out1, void **out2);
+enum cc_stat  slist_zip_iter_replace(SListZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+size_t        slist_zip_iter_index  (SListZipIter *iter);
+
+
+#define SLIST_FOREACH(val, slist, body)                                 \
+    {                                                                   \
+        SListIter slist_iter_53d46d2a04458e7b;                          \
+        slist_iter_init(&slist_iter_53d46d2a04458e7b, slist);           \
+        void *val;                                                      \
+        while (slist_iter_next(&slist_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define SLIST_FOREACH_ZIP(val1, val2, slist1, slist2, body)             \
+    {                                                                   \
+        SListZipIter slist_zip_iter_ea08d3e52f25883b3;                  \
+        slist_zip_iter_init(&slist_zip_iter_ea08d3e52f25883b, slist1, slist2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (slist_zip_iter_next(&slist_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_SLIST_H */

--- a/test/c/collections-c/normal/include/stack.h
+++ b/test/c/collections-c/normal/include/stack.h
@@ -1,0 +1,102 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_STACK_H
+#define COLLECTIONS_C_STACK_H
+
+#include "common.h"
+#include "array.h"
+
+/**
+ * A LIFO (last in first out) structure. Supports constant time
+ * insertion, removal and lookup.
+ */
+typedef struct stack_s Stack;
+
+/**
+ * Stack configuration structure. Used to initialize a new Stack
+ * with specific attributes.
+ */
+typedef ArrayConf StackConf;
+
+/**
+ * Stack iterator structure. Used to iterate over the elements of
+ * the Stack in an ascending order. The iterator also supports
+ * operations for safely adding and removing elements during
+ * iteration.
+ */
+typedef struct stack_iter_s {
+    ArrayIter i;
+} StackIter;
+
+/**
+ * Stack zip iterator structure. Used to iterate over the elements
+ * of two Stacks in lockstep in an ascending order until one of the
+ * Stacks is exhausted. The iterator also supports operations for
+ * safely adding and removing elements during iteration.
+ */
+typedef struct stack_zip_iter_s {
+    ArrayZipIter i;
+} StackZipIter;
+
+
+void          stack_conf_init       (StackConf *conf);
+enum cc_stat  stack_new             (Stack **out);
+enum cc_stat  stack_new_conf        (StackConf const * const conf, Stack **out);
+void          stack_destroy         (Stack *stack);
+void          stack_destroy_cb      (Stack *stack, void (*cb) (void*));
+
+enum cc_stat  stack_push            (Stack *stack, void *element);
+enum cc_stat  stack_peek            (Stack *stack, void **out);
+enum cc_stat  stack_pop             (Stack *stack, void **out);
+
+size_t        stack_size            (Stack *stack);
+void          stack_map             (Stack *stack, void (*fn) (void *));
+
+void          stack_iter_init       (StackIter *iter, Stack *s);
+enum cc_stat  stack_iter_next       (StackIter *iter, void **out);
+enum cc_stat  stack_iter_replace    (StackIter *iter, void *element, void **out);
+
+void          stack_zip_iter_init   (StackZipIter *iter, Stack *a1, Stack *a2);
+enum cc_stat  stack_zip_iter_next   (StackZipIter *iter, void **out1, void **out2);
+enum cc_stat  stack_zip_iter_replace(StackZipIter *iter, void *e1, void *e2, void **out1, void **out2);
+
+
+#define STACK_FOREACH(val, stack, body)                                 \
+    {                                                                   \
+        StackIter stack_iter_53d46d2a04458e7b;                          \
+        stack_iter_init(&stack_iter_53d46d2a04458e7b, stack);           \
+        void *val;                                                      \
+        while (stack_iter_next(&stack_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#define STACK_FOREACH_ZIP(val1, val2, stack1, stack2, body)             \
+    {                                                                   \
+        StackZipIter stack_zip_iter_ea08d3e52f25883b3;                  \
+        stack_zip_iter_init(&stack_zip_iter_ea08d3e52f25883b, stack1, stack2); \
+        void *val1;                                                     \
+        void *val2;                                                     \
+        while (stack_zip_iter_next(&stack_zip_iter_ea08d3e52f25883b3, &val1, &val2) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_STACK_H */

--- a/test/c/collections-c/normal/include/treeset.h
+++ b/test/c/collections-c/normal/include/treeset.h
@@ -1,0 +1,82 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_TREESET_H
+#define COLLECTIONS_C_TREESET_H
+
+#include "common.h"
+#include "treetable.h"
+
+/**
+ * An ordered set. The lookup, deletion, and insertion are
+ * performed in logarithmic time.
+ */
+typedef struct treeset_s TreeSet;
+
+/**
+ * TreeSet configuration structure.
+ */
+typedef TreeTableConf TreeSetConf;
+
+/**
+ * TreeSet iterator structure. Used to iterate over the elements of the set.
+ * The iterator also supports operations for safely removing elements
+ * during iteration.
+ */
+typedef struct treeset_iter_s {
+    TreeTableIter i;
+} TreeSetIter;
+
+
+void          treeset_conf_init        (TreeSetConf *conf);
+enum cc_stat  treeset_new              (int (*cmp) (const void*, const void*), TreeSet **set);
+enum cc_stat  treeset_new_conf         (TreeSetConf const * const conf, TreeSet **set);
+
+void          treeset_destroy          (TreeSet *set);
+
+enum cc_stat  treeset_add              (TreeSet *set, void *element);
+enum cc_stat  treeset_remove           (TreeSet *set, void *element, void **out);
+void          treeset_remove_all       (TreeSet *set);
+
+enum cc_stat  treeset_get_first        (TreeSet *set, void **out);
+enum cc_stat  treeset_get_last         (TreeSet *set, void **out);
+enum cc_stat  treeset_get_greater_than (TreeSet *set, void *element, void **out);
+enum cc_stat  treeset_get_lesser_than  (TreeSet *set, void *element, void **out);
+
+bool          treeset_contains         (TreeSet *set, void *element);
+size_t        treeset_size             (TreeSet *set);
+
+void          treeset_foreach          (TreeSet *set, void (*op) (const void*));
+
+void          treeset_iter_init        (TreeSetIter *iter, TreeSet *set);
+enum cc_stat  treeset_iter_next        (TreeSetIter *iter, void **element);
+enum cc_stat  treeset_iter_remove      (TreeSetIter *iter, void **out);
+
+
+#define TREESET_FOREACH(val, treeset, body)                             \
+    {                                                                   \
+        TreeSetIter treeset_iter_53d46d2a04458e7b;                      \
+        treeset_iter_init(&treeset_iter_53d46d2a04458e7b, treeset);     \
+        void *val;                                                      \
+        while (treeset_iter_next(&treeset_iter_53d46d2a04458e7b, &val) != CC_ITER_END) \
+            body                                                        \
+                }
+
+#endif /* COLLECTIONS_C_TREESET_H */

--- a/test/c/collections-c/normal/include/treetable.h
+++ b/test/c/collections-c/normal/include/treetable.h
@@ -1,0 +1,148 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COLLECTIONS_C_TREETABLE_H
+#define COLLECTIONS_C_TREETABLE_H
+
+#include "common.h"
+
+/**
+ * An ordered key-value map. TreeTable supports logarithmic time
+ * insertion, removal and lookup of values.
+ */
+typedef struct treetable_s TreeTable;
+
+/**
+ * Red-Black tree node.
+ *
+ * @note Modifying this structure may invalidate the table.
+ */
+typedef struct rbnode_s {
+    /**
+     * Key in the table. */
+    void *key;
+
+    /**
+     * Value associated with the key */
+    void *value;
+
+    /**
+     * The color of this node */
+    char  color;
+
+    /**
+     * Parent of this node */
+    struct rbnode_s *parent;
+
+    /**
+     * Left child node */
+    struct rbnode_s *left;
+
+    /**
+     * Right child node */
+    struct rbnode_s *right;
+} RBNode;
+
+/**
+ * TreeTable table entry.
+ */
+typedef struct tree_table_entry_s {
+    void *key;
+    void *value;
+} TreeTableEntry;
+
+/**
+ * TreeTable iterator structure. Used to iterate over the entries
+ * of the table. The iterator also supports operations for safely
+ * removing elements during iteration.
+ *
+ * @note This structure should only be modified through the
+ * iterator functions.
+ */
+typedef struct tree_table_iter_s {
+    TreeTable *table;
+    RBNode    *current;
+    RBNode    *next;
+} TreeTableIter;
+
+/**
+ * TreeTable configuration structure. Used to initialize a new
+ * TreeTable with specific attributes.
+ */
+typedef struct treetable_conf_s {
+    int    (*cmp)         (const void *k1, const void *k2);
+    void  *(*mem_alloc)   (size_t size);
+    void  *(*mem_calloc)  (size_t blocks, size_t size);
+    void   (*mem_free)    (void *block);
+} TreeTableConf;
+
+
+void          treetable_conf_init        (TreeTableConf *conf);
+enum cc_stat  treetable_new              (int (*cmp) (const void*, const void*), TreeTable **tt);
+enum cc_stat  treetable_new_conf         (TreeTableConf const * const conf, TreeTable **tt);
+
+void          treetable_destroy          (TreeTable *table);
+enum cc_stat  treetable_add              (TreeTable *table, void *key, void *val);
+
+enum cc_stat  treetable_remove           (TreeTable *table, void *key, void **out);
+void          treetable_remove_all       (TreeTable *table);
+enum cc_stat  treetable_remove_first     (TreeTable *table, void **out);
+enum cc_stat  treetable_remove_last      (TreeTable *table, void **out);
+
+enum cc_stat  treetable_get              (TreeTable const * const table, const void *key, void **out);
+enum cc_stat  treetable_get_first_value  (TreeTable const * const table, void **out);
+enum cc_stat  treetable_get_first_key    (TreeTable const * const table, void **out);
+enum cc_stat  treetable_get_last_value   (TreeTable const * const table, void **out);
+enum cc_stat  treetable_get_last_key     (TreeTable const * const table, void **out);
+enum cc_stat  treetable_get_greater_than (TreeTable const * const table, const void *key, void **out);
+enum cc_stat  treetable_get_lesser_than  (TreeTable const * const table, const void *key, void **out);
+
+size_t        treetable_size             (TreeTable const * const table);
+bool          treetable_contains_key     (TreeTable const * const table, const void *key);
+size_t        treetable_contains_value   (TreeTable const * const table, const void *value);
+
+void          treetable_foreach_key      (TreeTable *table, void (*op) (const void*));
+void          treetable_foreach_value    (TreeTable *table, void (*op) (void*));
+
+void          treetable_iter_init        (TreeTableIter *iter, TreeTable *table);
+enum cc_stat  treetable_iter_next        (TreeTableIter *iter, TreeTableEntry *entry);
+enum cc_stat  treetable_iter_remove      (TreeTableIter *iter, void **out);
+
+
+#define TREETABLE_FOREACH(entry, treetable, body)                       \
+    {                                                                   \
+        TreetableIter treetable_iter_53d46d2a04458e7b;                  \
+        treetable_iter_init(&treetable_iter_53d46d2a04458e7b, treetable); \
+        TreeTableEntry *val;                                            \
+        while (treetable_iter_next(&treetable_iter_53d46d2a04458e7b, &entry) != CC_ITER_END) \
+            body                                                        \
+                }
+
+
+#ifdef DEBUG
+#define RB_ERROR_CONSECUTIVE_RED 0
+#define RB_ERROR_BLACK_HEIGHT    1
+#define RB_ERROR_TREE_STRUCTURE  2
+#define RB_ERROR_OK              4
+
+int treetable_assert_rb_rules(TreeTable *table);
+#endif /* DEBUG */
+
+#endif /* COLLECTIONS_C_TREETABLE_H */

--- a/test/c/collections-c/normal/include/utils.h
+++ b/test/c/collections-c/normal/include/utils.h
@@ -1,0 +1,18 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include "owi.h"
+
+#define symb_str(X)                          \
+    int X = owi_i32();                      \
+    char str_##X[] = {X, '\0'}
+
+void CHECK_EQUAL_C_STRING(char *s1, char *s2);
+
+void *copy(void *e1);
+
+int cmp(void const *e1, void const *e2);
+
+int zero_if_ptr_eq(void const *e1, void const *e2);
+
+#endif /* TEST_UTILS_H */

--- a/test/c/collections-c/normal/list_tests.t
+++ b/test/c/collections-c/normal/list_tests.t
@@ -1,0 +1,75 @@
+List tests:
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_zipIterAdd.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_add.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_indexOf.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_removeAll.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_copyShallow.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_zipIterNext.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_removeLast.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_addFirst.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_splice.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_new.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_copyDeep.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_mutFilter2.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_spliceAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_filter2.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_addLast.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_iterDescAdd.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_iterDescRemove.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_replaceAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_getLast.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_zipIterReplace.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_filter1.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_removeFirst.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_sort.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_zipIterRemove.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_addAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_sublist.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_iterAdd.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_iterRemove.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_mutFilter1.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_addAll.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_getAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_remove.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_contains.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_removeAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_addAllAt.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_toArray.c
+  All OK
+  $ owi c -I include src/list.c src/common.c src/utils.c testsuite/list/list_test_reverse.c
+  All OK

--- a/test/c/collections-c/normal/pqueue_tests.t
+++ b/test/c/collections-c/normal/pqueue_tests.t
@@ -1,0 +1,28 @@
+Pqueue tests:
+  $ owi c -I include src/pqueue.c src/common.c src/utils.c testsuite/pqueue/pqueue_test_enqueue.c --no-value
+  Trap: memory heap buffer overflow
+  Model:
+    (model
+      (symbol_0 i32)
+      (symbol_1 i32)
+      (symbol_2 i32)
+      (symbol_3 i32)
+      (symbol_4 i32)
+      (symbol_5 i32))
+  Reached problem!
+  [1]
+  $ owi c -I include src/pqueue.c src/common.c src/utils.c testsuite/pqueue/pqueue_test_pop.c --no-value
+  Trap: memory heap buffer overflow
+  Model:
+    (model
+      (symbol_0 i32)
+      (symbol_1 i32)
+      (symbol_2 i32)
+      (symbol_3 i32)
+      (symbol_4 i32)
+      (symbol_5 i32)
+      (symbol_6 i32)
+      (symbol_7 i32)
+      (symbol_8 i32))
+  Reached problem!
+  [1]

--- a/test/c/collections-c/normal/queue_tests.t
+++ b/test/c/collections-c/normal/queue_tests.t
@@ -1,0 +1,9 @@
+Queue tests:
+  $ owi c -I include src/queue.c src/deque.c src/common.c src/utils.c testsuite/queue/queue_test_enqueue.c
+  All OK
+  $ owi c -I include src/queue.c src/deque.c src/common.c src/utils.c testsuite/queue/queue_test_poll.c
+  All OK
+  $ owi c -I include src/queue.c src/deque.c src/common.c src/utils.c testsuite/queue/queue_test_iter.c
+  All OK
+  $ owi c -I include src/queue.c src/deque.c src/common.c src/utils.c testsuite/queue/queue_test_zipIterNext.c
+  All OK

--- a/test/c/collections-c/normal/ring_buffer_tests.t
+++ b/test/c/collections-c/normal/ring_buffer_tests.t
@@ -1,0 +1,7 @@
+Ring-buffer tests:
+  $ owi c -I include src/ring_buffer.c src/common.c src/utils.c testsuite/ring_buffer/ring_buffer_test_enqueue.c
+  All OK
+  $ owi c -I include src/ring_buffer.c src/common.c src/utils.c testsuite/ring_buffer/ring_buffer_test_dequeue.c
+  All OK
+  $ owi c -I include src/ring_buffer.c src/common.c src/utils.c testsuite/ring_buffer/ring_buffer_test_capacity.c
+  All OK

--- a/test/c/collections-c/normal/slist_tests.t
+++ b/test/c/collections-c/normal/slist_tests.t
@@ -1,0 +1,75 @@
+Slist tests:
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_addAll.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filterMut3.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_removeAll.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_toArray.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_removeAt.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_copyDeep.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_get.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_remove.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_addFirst.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_addAt.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_contains.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_spliceAt.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_iterAdd.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_zipIterNext.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_getFirst.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_removeLast.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_removeFirst.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_new.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_add.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_addLast.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_zipIterAdd.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filter3.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_copyShallow.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_indexOf.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_getLast.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_sublist.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filter2.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filter1.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_zipIterReplace.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_splice.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_zipIterRemove.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filterMut2.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_reverse.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_addAllAt.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_replaceAt.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_filterMut1.c
+  All OK
+  $ owi c -I include src/slist.c src/common.c src/utils.c testsuite/slist/slist_test_iterRemove.c
+  All OK

--- a/test/c/collections-c/normal/src/array.c
+++ b/test/c/collections-c/normal/src/array.c
@@ -1,0 +1,1090 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "array.h"
+
+#define DEFAULT_CAPACITY 8
+#define DEFAULT_EXPANSION_FACTOR 2
+
+struct array_s {
+  size_t size;
+  size_t capacity;
+  float exp_factor;
+  void **buffer;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static enum cc_stat expand_capacity(Array *ar);
+
+/**
+ * Creates a new empty array and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created Array is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new Array structure failed.
+ */
+enum cc_stat array_new(Array **out) {
+  ArrayConf c;
+  array_conf_init(&c);
+  return array_new_conf(&c, out);
+}
+
+/**
+ * Creates a new empty Array based on the specified ArrayConf struct and
+ * returns a status code.
+ *
+ * The Array is allocated using the allocators specified in the ArrayConf
+ * struct. The allocation may fail if underlying allocator fails. It may also
+ * fail if the values of exp_factor and capacity in the ArrayConf do not meet
+ * the following condition: <code>exp_factor < (CC_MAX_ELEMENTS /
+ * capacity)</code>.
+ *
+ * @param[in] conf array configuration structure
+ * @param[out] out pointer to where the newly created Array is to be stored
+ *
+ * @return CC_OK if the creation was successful, CC_ERR_INVALID_CAPACITY if
+ * the above mentioned condition is not met, or CC_ERR_ALLOC if the memory
+ * allocation for the new Array structure failed.
+ */
+enum cc_stat array_new_conf(ArrayConf const *const conf, Array **out) {
+  float ex;
+
+  /* The expansion factor must be greater than one for the
+   * array to grow */
+  if (conf->exp_factor <= 1)
+    ex = DEFAULT_EXPANSION_FACTOR;
+  else
+    ex = conf->exp_factor;
+
+  /* Needed to avoid an integer overflow on the first resize and
+   * to easily check for any future overflows. */
+  if (!conf->capacity || ex >= CC_MAX_ELEMENTS / conf->capacity)
+    return CC_ERR_INVALID_CAPACITY;
+
+  Array *ar = conf->mem_calloc(1, sizeof(Array));
+
+  if (!ar)
+    return CC_ERR_ALLOC;
+
+  void **buff = conf->mem_alloc(conf->capacity * sizeof(void *));
+
+  if (!buff) {
+    conf->mem_free(ar);
+    return CC_ERR_ALLOC;
+  }
+
+  ar->buffer = buff;
+  ar->exp_factor = ex;
+  ar->capacity = conf->capacity;
+  ar->mem_alloc = conf->mem_alloc;
+  ar->mem_calloc = conf->mem_calloc;
+  ar->mem_free = conf->mem_free;
+
+  *out = ar;
+  return CC_OK;
+}
+
+/**
+ * Initializes the fields of the ArrayConf struct to default values.
+ *
+ * @param[in, out] conf ArrayConf structure that is being initialized
+ */
+void array_conf_init(ArrayConf *conf) {
+  conf->exp_factor = DEFAULT_EXPANSION_FACTOR;
+  conf->capacity = DEFAULT_CAPACITY;
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Destroys the Array structure, but leaves the data it used to hold intact.
+ *
+ * @param[in] ar the array that is to be destroyed
+ */
+void array_destroy(Array *ar) {
+  ar->mem_free(ar->buffer);
+  ar->mem_free(ar);
+}
+
+/**
+ * Destroys the Array structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a array that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] ar the array that is being destroyed
+ */
+void array_destroy_cb(Array *ar, void (*cb)(void *)) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    cb(ar->buffer[i]);
+
+  array_destroy(ar);
+}
+
+/**
+ * Adds a new element to the Array. The element is appended to the array making
+ * it the last element (the one with the highest index) of the Array.
+ *
+ * @param[in] ar the array to which the element is being added
+ * @param[in] element the element that is being added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_ALLOC if the
+ * memory allocation for the new element failed, or CC_ERR_MAX_CAPACITY if the
+ * array is already at maximum capacity.
+ */
+enum cc_stat array_add(Array *ar, void *element) {
+  if (ar->size >= ar->capacity) {
+    enum cc_stat status = expand_capacity(ar);
+    if (status != CC_OK)
+      return status;
+  }
+
+  ar->buffer[ar->size] = element;
+  ar->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the array at a specified position by shifting all
+ * subsequent elements by one. The specified index must be within the bounds
+ * of the array. This function may also fail if the memory allocation for
+ * the new element was unsuccessful.
+ *
+ * @param[in] ar the array to which the element is being added
+ * @param[in] element the element that is being added
+ * @param[in] index the position in the array at which the element is being
+ *            added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, CC_ERR_ALLOC if the memory
+ * allocation for the new element failed, or CC_ERR_MAX_CAPACITY if the
+ * array is already at maximum capacity.
+ */
+enum cc_stat array_add_at(Array *ar, void *element, size_t index) {
+  if (index == ar->size)
+    return array_add(ar, element);
+
+  if ((ar->size == 0 && index != 0) || index > (ar->size - 1))
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (ar->size >= ar->capacity) {
+    enum cc_stat status = expand_capacity(ar);
+    if (status != CC_OK)
+      return status;
+  }
+
+  size_t shift = (ar->size - index) * sizeof(void *);
+
+  memmove(&(ar->buffer[index + 1]), &(ar->buffer[index]), shift);
+
+  ar->buffer[index] = element;
+  ar->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces an array element at the specified index and optionally sets the out
+ * parameter to the value of the replaced element. The specified index must be
+ * within the bounds of the Array.
+ *
+ * @param[in]  ar      array whose element is being replaced
+ * @param[in]  element replacement element
+ * @param[in]  index   index at which the replacement element should be inserted
+ * @param[out] out     pointer to where the replaced element is stored, or NULL
+ * if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat array_replace_at(Array *ar, void *element, size_t index,
+                              void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (out)
+    *out = ar->buffer[index];
+
+  ar->buffer[index] = element;
+
+  return CC_OK;
+}
+
+enum cc_stat array_swap_at(Array *ar, size_t index1, size_t index2) {
+  void *tmp;
+  if (index1 >= ar->size || index2 >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+  tmp = ar->buffer[index1];
+  ar->buffer[index1] = ar->buffer[index2];
+  ar->buffer[index2] = tmp;
+  return CC_OK;
+}
+
+/**
+ * Removes the specified element from the Array if such element exists and
+ * optionally sets the out parameter to the value of the removed element.
+ *
+ * @param[in] ar array from which the element is being removed
+ * @param[in] element element being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat array_remove(Array *ar, void *element, void **out) {
+  size_t index;
+  enum cc_stat status = array_index_of(ar, element, &index);
+
+  if (status == CC_ERR_OUT_OF_RANGE)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  if (index != ar->size - 1) {
+    size_t block_size = (ar->size - 1 - index) * sizeof(void *);
+
+    memmove(&(ar->buffer[index]), &(ar->buffer[index + 1]), block_size);
+  }
+  ar->size--;
+
+  if (out)
+    *out = element;
+
+  return CC_OK;
+}
+
+/**
+ * Removes an Array element from the specified index and optionally sets the
+ * out parameter to the value of the removed element. The index must be within
+ * the bounds of the array.
+ *
+ * @param[in] ar the array from which the element is being removed
+ * @param[in] index the index of the element being removed.
+ * @param[out] out  pointer to where the removed value is stored,
+ *                  or NULL if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the index was out of range.
+ */
+enum cc_stat array_remove_at(Array *ar, size_t index, void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (out)
+    *out = ar->buffer[index];
+
+  if (index != ar->size - 1) {
+    size_t block_size = (ar->size - 1 - index) * sizeof(void *);
+
+    memmove(&(ar->buffer[index]), &(ar->buffer[index + 1]), block_size);
+  }
+  ar->size--;
+
+  return CC_OK;
+}
+
+/**
+ * Removes an Array element from the end of the array and optionally sets the
+ * out parameter to the value of the removed element.
+ *
+ * @param[in] ar the array whose last element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the Array is already empty.
+ */
+enum cc_stat array_remove_last(Array *ar, void **out) {
+  return array_remove_at(ar, ar->size - 1, out);
+}
+
+/**
+ * Removes all elements from the specified array. This function does not shrink
+ * the array capacity.
+ *
+ * @param[in] ar array from which all elements are to be removed
+ */
+void array_remove_all(Array *ar) { ar->size = 0; }
+
+/**
+ * Removes and frees all elements from the specified array. This function does
+ * not shrink the array capacity.
+ *
+ * @param[in] ar array from which all elements are to be removed
+ */
+void array_remove_all_free(Array *ar) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    free(ar->buffer[i]);
+
+  array_remove_all(ar);
+}
+
+/**
+ * Gets an Array element from the specified index and sets the out parameter to
+ * its value. The specified index must be within the bounds of the array.
+ *
+ * @param[in] ar the array from which the element is being retrieved
+ * @param[in] index the index of the array element
+ * @param[out] out pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat array_get_at(Array *ar, size_t index, void **out) {
+  if (index >= ar->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  *out = ar->buffer[index];
+  return CC_OK;
+}
+
+/**
+ * Gets the last element of the array or the element at the highest index
+ * and sets the out parameter to its value.
+ *
+ * @param[in] ar the array whose last element is being returned
+ * @param[out] out pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if the
+ * Array is empty.
+ */
+enum cc_stat array_get_last(Array *ar, void **out) {
+  if (ar->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return array_get_at(ar, ar->size - 1, out);
+}
+
+/**
+ * Returns the underlying array buffer.
+ *
+ * @note Any direct modification of the buffer may invalidate the Array.
+ *
+ * @param[in] ar array whose underlying buffer is being returned
+ *
+ * @return array's internal buffer.
+ */
+const void *const *array_get_buffer(Array *ar) {
+  return (const void *const *)ar->buffer;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of the
+ * Array.
+ *
+ * @param[in] ar array being searched
+ * @param[in] element the element whose index is being looked up
+ * @param[out] index  pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat array_index_of(Array *ar, void *element, size_t *index) {
+  size_t i;
+  for (i = 0; i < ar->size; i++) {
+    if (ar->buffer[i] == element) {
+      *index = i;
+      return CC_OK;
+    }
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Creates a subarray of the specified Array, ranging from <code>b</code>
+ * index (inclusive) to <code>e</code> index (inclusive). The range indices
+ * must be within the bounds of the Array, while the <code>e</code> index
+ * must be greater or equal to the <code>b</code> index.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original Array.
+ *
+ * @param[in] ar array from which the subarray is being created
+ * @param[in] b the beginning index (inclusive) of the subarray that must be
+ *              within the bounds of the array and must not exceed the
+ *              the end index
+ * @param[in] e the end index (inclusive) of the subarray that must be within
+ *              the bounds of the array and must be greater or equal to the
+ *              beginning index
+ * @param[out] out pointer to where the new sublist is stored
+ *
+ * @return CC_OK if the subarray was successfully created, CC_ERR_INVALID_RANGE
+ * if the specified index range is invalid, or CC_ERR_ALLOC if the memory
+ * allocation for the new subarray failed.
+ */
+enum cc_stat array_subarray(Array *ar, size_t b, size_t e, Array **out) {
+  if (b > e || e >= ar->size)
+    return CC_ERR_INVALID_RANGE;
+
+  Array *sub_ar = ar->mem_calloc(1, sizeof(Array));
+
+  if (!sub_ar)
+    return CC_ERR_ALLOC;
+
+  /* Try to allocate the buffer */
+  if (!(sub_ar->buffer = ar->mem_alloc(ar->capacity * sizeof(void *)))) {
+    ar->mem_free(sub_ar);
+    return CC_ERR_ALLOC;
+  }
+
+  sub_ar->mem_alloc = ar->mem_alloc;
+  sub_ar->mem_calloc = ar->mem_calloc;
+  sub_ar->mem_free = ar->mem_free;
+  sub_ar->size = e - b + 1;
+  sub_ar->capacity = sub_ar->size;
+
+  memcpy(sub_ar->buffer, &(ar->buffer[b]), sub_ar->size * sizeof(void *));
+
+  *out = sub_ar;
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified Array. A shallow copy is a copy of
+ * the Array structure, but not the elements it holds.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original array.
+ *
+ * @param[in] ar the array to be copied
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat array_copy_shallow(Array *ar, Array **out) {
+  Array *copy = ar->mem_alloc(sizeof(Array));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+  copy->exp_factor = ar->exp_factor;
+  copy->size = ar->size;
+  copy->capacity = ar->capacity;
+  copy->mem_alloc = ar->mem_alloc;
+  copy->mem_calloc = ar->mem_calloc;
+  copy->mem_free = ar->mem_free;
+
+  memcpy(copy->buffer, ar->buffer, copy->size * sizeof(void *));
+
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified Array. A deep copy is a copy of
+ * both the Array structure and the data it holds.
+ *
+ * @note The new Array is allocated using the original Array's allocators
+ *       and it also inherits the configuration of the original Array.
+ *
+ * @param[in] ar   array to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat array_copy_deep(Array *ar, void *(*cp)(void *), Array **out) {
+  Array *copy = ar->mem_alloc(sizeof(Array));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+
+  copy->exp_factor = ar->exp_factor;
+  copy->size = ar->size;
+  copy->capacity = ar->capacity;
+  copy->mem_alloc = ar->mem_alloc;
+  copy->mem_calloc = ar->mem_calloc;
+  copy->mem_free = ar->mem_free;
+
+  size_t i;
+  for (i = 0; i < copy->size; i++)
+    copy->buffer[i] = cp(ar->buffer[i]);
+
+  *out = copy;
+
+  return CC_OK;
+}
+
+/**
+ * Filters the Array by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] ar   array that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the Array
+ *
+ * @return CC_OK if the Array was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the Array is empty.
+ */
+enum cc_stat array_filter_mut(Array *ar, bool (*pred)(const void *)) {
+  if (ar->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t rm = 0;
+  size_t keep = 0;
+
+  /* Look for clusters of non matching elements before moving
+   * in order to minimize the number of memmoves */
+  for (size_t i = ar->size - 1; i != ((size_t)-1); i--) {
+    if (!pred(ar->buffer[i])) {
+      rm++;
+      continue;
+    }
+    if (rm > 0) {
+      if (keep > 0) {
+        size_t block_size = keep * sizeof(void *);
+        memmove(&(ar->buffer[i + 1]), &(ar->buffer[i + 1 + rm]), block_size);
+      }
+      ar->size -= rm;
+      rm = 0;
+    }
+    keep++;
+  }
+  /* Remove any remaining elements*/
+  if (rm > 0) {
+    size_t block_size = keep * sizeof(void *);
+    memmove(&(ar->buffer[0]), &(ar->buffer[rm]), block_size);
+
+    ar->size -= rm;
+  }
+  return CC_OK;
+}
+
+/**
+ * Filters the Array by creating a new Array that contains all elements from the
+ * original Array that return true on pred(element) without modifying the
+ * original Array.
+ *
+ * @param[in] ar   array that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the filtered array
+ * @param[out] out pointer to where the new filtered Array is to be stored
+ *
+ * @return CC_OK if the Array was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the Array is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new Array failed.
+ */
+enum cc_stat array_filter(Array *ar, bool (*pred)(const void *), Array **out) {
+  if (ar->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  Array *filtered = ar->mem_alloc(sizeof(Array));
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  if (!(filtered->buffer = ar->mem_calloc(ar->capacity, sizeof(void *)))) {
+    ar->mem_free(filtered);
+    return CC_ERR_ALLOC;
+  }
+
+  filtered->exp_factor = ar->exp_factor;
+  filtered->size = 0;
+  filtered->capacity = ar->capacity;
+  filtered->mem_alloc = ar->mem_alloc;
+  filtered->mem_calloc = ar->mem_calloc;
+  filtered->mem_free = ar->mem_free;
+
+  size_t f = 0;
+  for (size_t i = 0; i < ar->size; i++) {
+    if (pred(ar->buffer[i])) {
+      filtered->buffer[f++] = ar->buffer[i];
+      filtered->size++;
+    }
+  }
+  *out = filtered;
+
+  return CC_OK;
+}
+
+/**
+ * Reverses the order of elements in the specified array.
+ *
+ * @param[in] ar array that is being reversed
+ */
+void array_reverse(Array *ar) {
+  size_t i;
+  size_t j;
+  for (i = 0, j = ar->size - 1; i < (ar->size - 1) / 2; i++, j--) {
+    void *tmp = ar->buffer[i];
+    ar->buffer[i] = ar->buffer[j];
+    ar->buffer[j] = tmp;
+  }
+}
+
+/**
+ * Trims the array's capacity, in other words, it shrinks the capacity to match
+ * the number of elements in the Array, however the capacity will never shrink
+ * below 1.
+ *
+ * @param[in] ar array whose capacity is being trimmed
+ *
+ * @return CC_OK if the capacity was trimmed successfully, or CC_ERR_ALLOC if
+ * the reallocation failed.
+ */
+enum cc_stat array_trim_capacity(Array *ar) {
+  if (ar->size == ar->capacity)
+    return CC_OK;
+
+  void **new_buff = ar->mem_calloc(ar->size, sizeof(void *));
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  size_t size = ar->size < 1 ? 1 : ar->size;
+
+  memcpy(new_buff, ar->buffer, size * sizeof(void *));
+  ar->mem_free(ar->buffer);
+
+  ar->buffer = new_buff;
+  ar->capacity = ar->size;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the number of occurrences of the element within the specified Array.
+ *
+ * @param[in] ar array that is being searched
+ * @param[in] element the element that is being searched for
+ *
+ * @return the number of occurrences of the element.
+ */
+size_t array_contains(Array *ar, void *element) {
+  size_t o = 0;
+  size_t i;
+  for (i = 0; i < ar->size; i++) {
+    if (ar->buffer[i] == element)
+      o++;
+  }
+  return o;
+}
+
+/**
+ * Returns the number of occurrences of the value pointed to by <code>e</code>
+ * within the specified Array.
+ *
+ * @param[in] ar array that is being searched
+ * @param[in] element the element that is being searched for
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ * are equal
+ *
+ * @return the number of occurrences of the value.
+ */
+size_t array_contains_value(Array *ar, void *element,
+                            int (*cmp)(const void *, const void *)) {
+  size_t o = 0;
+  size_t i;
+  for (i = 0; i < ar->size; i++) {
+    if (cmp(element, ar->buffer[i]) == 0)
+      o++;
+  }
+  return o;
+}
+
+/**
+ * Returns the size of the specified Array. The size of the array is the
+ * number of elements contained within the Array.
+ *
+ * @param[in] ar array whose size is being returned
+ *
+ * @return the the number of element within the Array.
+ */
+size_t array_size(Array *ar) { return ar->size; }
+
+/**
+ * Returns the capacity of the specified Array. The capacity of the Array is
+ * the maximum number of elements an Array can hold before it has to be resized.
+ *
+ * @param[in] ar array whose capacity is being returned
+ *
+ * @return the capacity of the Array.
+ */
+size_t array_capacity(Array *ar) { return ar->capacity; }
+
+/**
+ * Sorts the specified array.
+ *
+ * @note
+ * Pointers passed to the comparator function will be pointers to the array
+ * elements that are of type (void*) ie. void**. So an extra step of
+ * dereferencing will be required before the data can be used for comparison:
+ * eg. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @code
+ * enum cc_stat mycmp(const void *e1, const void *e2) {
+ *     MyType el1 = *(*((enum cc_stat**) e1));
+ *     MyType el2 = *(*((enum cc_stat**) e2));
+ *
+ *     if (el1 < el2) return -1;
+ *     if (el1 > el2) return 1;
+ *     return 0;
+ * }
+ *
+ * ...
+ *
+ * array_sort(array, mycmp);
+ * @endcode
+ *
+ * @param[in] ar  array to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                enum cc_stat cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ */
+void array_sort(Array *ar, int (*cmp)(const void *, const void *)) {
+  qsort(ar->buffer, ar->size, sizeof(void *), cmp);
+}
+
+/**
+ * Expands the Array capacity. This might fail if the the new buffer
+ * cannot be allocated. In case the expansion would overflow the index
+ * range, a maximum capacity buffer is allocated instead. If the capacity
+ * is already at the maximum capacity, no new buffer is allocated.
+ *
+ * @param[in] ar array whose capacity is being expanded
+ *
+ * @return CC_OK if the buffer was expanded successfully, CC_ERR_ALLOC if
+ * the memory allocation for the new buffer failed, or CC_ERR_MAX_CAPACITY
+ * if the array is already at maximum capacity.
+ */
+static enum cc_stat expand_capacity(Array *ar) {
+  if (ar->capacity == CC_MAX_ELEMENTS)
+    return CC_ERR_MAX_CAPACITY;
+
+  size_t new_capacity = ar->capacity * ar->exp_factor;
+
+  /* As long as the capacity is greater that the expansion factor
+   * at the point of overflow, this is check is valid. */
+  if (new_capacity <= ar->capacity)
+    ar->capacity = CC_MAX_ELEMENTS;
+  else
+    ar->capacity = new_capacity;
+
+  void **new_buff = ar->mem_alloc(new_capacity * sizeof(void *));
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  memcpy(new_buff, ar->buffer, ar->size * sizeof(void *));
+
+  ar->mem_free(ar->buffer);
+  ar->buffer = new_buff;
+
+  return CC_OK;
+}
+
+/**
+ * Applies the function fn to each element of the Array.
+ *
+ * @param[in] ar array on which this operation is performed
+ * @param[in] fn operation function that is to be invoked on each Array
+ *               element
+ */
+void array_map(Array *ar, void (*fn)(void *e)) {
+  size_t i;
+  for (i = 0; i < ar->size; i++)
+    fn(ar->buffer[i]);
+}
+
+/**
+ * A fold/reduce function that collects all of the elements in the array
+ * together. For example, if we have an array of [a,b,c...] the end result
+ * will be (...((a+b)+c)+...).
+ *
+ * @param[in] ar the array on which this operation is performed
+ * @param[in] fn the operation function that is to be invoked on each array
+ *               element
+ * @param[in] result the pointer which will collect the end result
+ */
+void array_reduce(Array *ar, void (*fn)(void *, void *, void *), void *result) {
+  if (ar->size == 1) {
+    fn(ar->buffer[0], NULL, result);
+    return;
+  }
+  if (ar->size > 1)
+    fn(ar->buffer[0], ar->buffer[1], result);
+
+  for (size_t i = 2; i < ar->size; i++)
+    fn(result, ar->buffer[i], result);
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] ar the array to iterate over
+ */
+void array_iter_init(ArrayIter *iter, Array *ar) {
+  iter->ar = ar;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the Array has been reached.
+ */
+enum cc_stat array_iter_next(ArrayIter *iter, void **out) {
+  if (iter->index >= iter->ar->size)
+    return CC_ITER_END;
+
+  *out = iter->ar->buffer[iter->index];
+
+  iter->index++;
+  iter->last_removed = false;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>array_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat array_iter_remove(ArrayIter *iter, void **out) {
+  enum cc_stat status = CC_ERR_VALUE_NOT_FOUND;
+
+  if (!iter->last_removed) {
+    status = array_remove_at(iter->ar, iter->index - 1, out);
+    if (status == CC_OK)
+      iter->last_removed = true;
+  }
+  return status;
+}
+
+/**
+ * Adds a new element to the Array after the last returned element by
+ * <code>array_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_ALLOC if the
+ * memory allocation for the new element failed, or CC_ERR_MAX_CAPACITY if
+ * the array is already at maximum capacity.
+ */
+enum cc_stat array_iter_add(ArrayIter *iter, void *element) {
+  return array_add_at(iter->ar, element, iter->index++);
+}
+
+/**
+ * Replaces the last returned element by <code>array_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * array_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat array_iter_replace(ArrayIter *iter, void *element, void **out) {
+  return array_replace_at(iter->ar, element, iter->index - 1, out);
+}
+
+/**
+ * Returns the index of the last returned element by <code>array_iter_next()
+ * </code>.
+ *
+ * @note
+ * This function should not be called before a call to <code>array_iter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index.
+ */
+size_t array_iter_index(ArrayIter *iter) { return iter->index - 1; }
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] ar1  first array
+ * @param[in] ar2  second array
+ */
+void array_zip_iter_init(ArrayZipIter *iter, Array *ar1, Array *ar2) {
+  iter->ar1 = ar1;
+  iter->ar2 = ar2;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first array element
+ * @param[out] out2 output of the second array element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the arrays has been reached.
+ */
+enum cc_stat array_zip_iter_next(ArrayZipIter *iter, void **out1, void **out2) {
+  if (iter->index >= iter->ar1->size || iter->index >= iter->ar2->size)
+    return CC_ITER_END;
+
+  *out1 = iter->ar1->buffer[iter->index];
+  *out2 = iter->ar2->buffer[iter->index];
+
+  iter->index++;
+  iter->last_removed = false;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>array_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[out] out1 output of the removed element from the first array
+ * @param[out] out2 output of the removed element from the second array
+ *
+ * @return CC_OK if the element was successfully removed, CC_ERR_OUT_OF_RANGE if
+ * the state of the iterator is invalid, or CC_ERR_VALUE_NOT_FOUND if the
+ * element was already removed.
+ */
+enum cc_stat array_zip_iter_remove(ArrayZipIter *iter, void **out1,
+                                   void **out2) {
+  if ((iter->index - 1) >= iter->ar1->size ||
+      (iter->index - 1) >= iter->ar2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (!iter->last_removed) {
+    array_remove_at(iter->ar1, iter->index - 1, out1);
+    array_remove_at(iter->ar2, iter->index - 1, out2);
+    iter->last_removed = true;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Adds a new element pair to the arrays after the last returned element pair by
+ * <code>array_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>array_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ * @param[in] e1   element added to the first array
+ * @param[in] e2   element added to the second array
+ *
+ * @return CC_OK if the element pair was successfully added to the arrays, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat array_zip_iter_add(ArrayZipIter *iter, void *e1, void *e2) {
+  size_t index = iter->index++;
+  Array *ar1 = iter->ar1;
+  Array *ar2 = iter->ar2;
+
+  /* Make sure both array buffers have room */
+  if ((ar1->size == ar1->capacity && (expand_capacity(ar1) != CC_OK)) ||
+      (ar2->size == ar2->capacity && (expand_capacity(ar2) != CC_OK)))
+    return CC_ERR_ALLOC;
+
+  array_add_at(ar1, e1, index);
+  array_add_at(ar2, e2, index);
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>array_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @param[in] iter  iterator on which this operation is being performed
+ * @param[in]  e1   first array's replacement element
+ * @param[in]  e2   second array's replacement element
+ * @param[out] out1 output of the replaced element from the first array
+ * @param[out] out2 output of the replaced element from the second array
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat array_zip_iter_replace(ArrayZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  if ((iter->index - 1) >= iter->ar1->size ||
+      (iter->index - 1) >= iter->ar2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  array_replace_at(iter->ar1, e1, iter->index - 1, out1);
+  array_replace_at(iter->ar2, e2, iter->index - 1, out2);
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>array_zip_iter_next()</code>.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ *
+ * @return current iterator index.
+ */
+size_t array_zip_iter_index(ArrayZipIter *iter) { return iter->index - 1; }

--- a/test/c/collections-c/normal/src/common.c
+++ b/test/c/collections-c/normal/src/common.c
@@ -1,0 +1,140 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2016 Srđan Panić <i@srdja.me>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common.h"
+
+/**
+ * String comparator function.
+ *
+ * @param[in] str1 first string
+ * @param[in] str2 second string
+ *
+ * @return
+ */
+int cc_common_cmp_str(const void *str1, const void *str2) {
+  return strcmp((const char *)str1, (const char *)str2);
+}
+
+/* extern unsigned char __heap_base; */
+/* unsigned int bump_pointer = &__heap_base; */
+
+/* void *malloc(unsigned int size) { */
+/*   unsigned int r = bump_pointer; */
+/*   for (int i = 0; i < size; ++i) */
+/*     *((unsigned char *)bump_pointer + i) = 'i'; */
+/*   bump_pointer += size; */
+/*   return (void*)alloc(r, size); */
+/* } */
+
+/* void *calloc(unsigned int nmemb, unsigned int size) { */
+/*   unsigned int r = bump_pointer; */
+/*   for (int i = 0; i < nmemb * size; ++i) */
+/*     *((unsigned char *)bump_pointer + i) = 0; */
+/*   bump_pointer += (nmemb * size); */
+/*   return (void*)alloc(r, nmemb * size); */
+/* } */
+
+/* void free(void *ptr) { */
+/*   dealloc(ptr); */
+/* } */
+
+/* void *memset(void *s, int c, size_t n) { */
+/*   char *ptr; */
+
+/*   for (ptr = (char*)s; ptr < (ptr + n); ++ptr) */
+/*     *ptr = c & 0xff; */
+/* } */
+
+/* int strcmp(const char *s1, const char *s2) { */
+/*   int i, f; */
+/*   const char *s1_ptr; */
+/*   const char *s2_ptr; */
+
+/*   f = 0; */
+/*   s1_ptr = (const char*) s1, s2_ptr = (const char*) s2; */
+
+/*   if ((s1_ptr != NULL) && (s2_ptr != NULL)) */
+/*     for (i = 0; *s1_ptr != 0; ++s1_ptr, ++s2_ptr) */
+/*       if (*s1_ptr != *s2_ptr) f = 1; */
+
+/*   return f; */
+/* } */
+
+/* void *memcpy(void *dst, const void *src, unsigned int n) { */
+/*   int i; */
+/*   char *dst_ptr = (char*)dst; */
+/*   const char *src_ptr = (const char*)src; */
+
+/*   if ((dst_ptr != NULL) && (src_ptr != NULL)) */
+/*     for (i = 0; i < n; ++i, ++dst_ptr, ++src_ptr) */
+/*       *dst_ptr = *src_ptr; */
+
+/*   return dst; */
+/* } */
+
+/* void *memmove(void *dst, const void *src, unsigned int n) { */
+
+/*   char *dst_ptr = (char*)dst; */
+/*   const char *src_ptr = (const char*)src; */
+
+/*   char tmp[n]; */
+
+/*   for (int i = 0; i < n; ++i) */
+/*     tmp[i] = src_ptr[i]; */
+
+/*   for (int i = 0; i < n; ++i) */
+/*     dst_ptr[i] = tmp[i]; */
+
+/*   return dst; */
+/* } */
+
+/* void qsort(void *base, size_t nmemb, size_t size, */
+/*     int (*compar)(const void *, const void *)) { */
+/*   int i, j, min; */
+/*   char *base_ptr, *lo; */
+
+/*   base_ptr = (char *)base; lo = base_ptr; */
+
+/*   for (i = 0; i < nmemb - 1; ++i) { */
+/*     min = i; */
+/*     for (j = i + 1; j < nmemb; ++j) */
+/*       if ((*compar)((void *)(lo + j * size), (void *)(lo + min * size)) < 0)
+ */
+/*         min = j; */
+
+/*     // swap 8 bytes */
+/*     unsigned long *a = (unsigned long *)(lo + min * size); */
+/*     unsigned long *b = (unsigned long *)(lo + i * size); */
+/*     unsigned long tmp = *a; */
+/*     *a = *b; */
+/*     *b = tmp; */
+/* #if 0 */
+/*     // swap each byte one by one */
+/*     size_t _n = size; */
+/*     char *a = lo + min * size; */
+/*     char *b = lo + i * size; */
+/*     do { */
+/*       char tmp = *a; */
+/*       *a++ = *b; */
+/*       *b++ = tmp; */
+/*     } while(--_n > 0); */
+/* #endif */
+/*   } */
+/* } */

--- a/test/c/collections-c/normal/src/deque.c
+++ b/test/c/collections-c/normal/src/deque.c
@@ -1,0 +1,1230 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "deque.h"
+
+#define DEFAULT_CAPACITY 8
+#define DEFAULT_EXPANSION_FACTOR 2
+
+struct deque_s {
+  size_t size;
+  size_t capacity;
+  size_t first;
+  size_t last;
+  void **buffer;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static size_t upper_pow_two(size_t);
+static void copy_buffer(Deque const *const deque, void **buff,
+                        void *(*cp)(void *));
+
+static enum cc_stat expand_capacity(Deque *deque);
+
+/**
+ * Creates a new empty deque and returns a status code.
+ *
+ * @param[out] out Pointer to where the newly created Deque is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new Deque structure failed.
+ */
+enum cc_stat deque_new(Deque **deque) {
+  DequeConf conf;
+  deque_conf_init(&conf);
+  return deque_new_conf(&conf, deque);
+}
+
+/**
+ * Creates a new empty Deque based on the specified DequeConf object and
+ * returns a status code.
+ *
+ * The Deque is allocated using the allocators specified in the DequeConf
+ * struct. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf Deque configuration structure. All fields must be initialized
+ *                 with appropriate values.
+ * @param[out] out Pointer to where the newly created Deque is to be stored
+ *
+ * @return CC_OK if the creation was successful, CC_ERR_INVALID_CAPACITY if
+ * the above mentioned condition is not met, or CC_ERR_ALLOC if the memory
+ * allocation for the new Deque structure failed.
+ */
+enum cc_stat deque_new_conf(DequeConf const *const conf, Deque **d) {
+  Deque *deque = conf->mem_calloc(1, sizeof(Deque));
+
+  if (!deque)
+    return CC_ERR_ALLOC;
+
+  if (!(deque->buffer = conf->mem_alloc(conf->capacity * sizeof(void *)))) {
+    conf->mem_free(deque);
+    return CC_ERR_ALLOC;
+  }
+
+  deque->mem_alloc = conf->mem_alloc;
+  deque->mem_calloc = conf->mem_calloc;
+  deque->mem_free = conf->mem_free;
+  deque->capacity = upper_pow_two(conf->capacity);
+  deque->first = 0;
+  deque->last = 0;
+  deque->size = 0;
+
+  *d = deque;
+  return CC_OK;
+}
+
+/**
+ * Initializes the fields of the DequeConf struct to default values.
+ *
+ * @param[in, out] conf DequeConf structure that is being initialized
+ */
+void deque_conf_init(DequeConf *conf) {
+  conf->capacity = DEFAULT_CAPACITY;
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Destroys the Deque structure, but leaves the data it used to hold, intact.
+ *
+ * @param[in] deque Deque that is to be destroyed
+ */
+void deque_destroy(Deque *deque) {
+  deque->mem_free(deque->buffer);
+  deque->mem_free(deque);
+}
+
+/**
+ * Destroys the Deque structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a Deque that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] deque Deque that is to be destroyed
+ */
+void deque_destroy_cb(Deque *deque, void (*cb)(void *)) {
+  deque_remove_all_cb(deque, cb);
+  deque_destroy(deque);
+}
+
+/**
+ * Adds a new element to the deque. The element is appended to the deque making
+ * it the last element (the one with the highest index) of the Deque.
+ *
+ * @param[in] deque Deque to which the element is being added
+ * @param[in] element element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat deque_add(Deque *deque, void *element) {
+  return deque_add_last(deque, element);
+}
+
+/**
+ * Adds a new element to the front of the Deque.
+ *
+ * @param[in] deque Deque to which the element is being added
+ * @param[in] element element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat deque_add_first(Deque *deque, void *element) {
+  if (deque->size >= deque->capacity && expand_capacity(deque) != CC_OK)
+    return CC_ERR_ALLOC;
+
+  deque->first = (deque->first - 1) & (deque->capacity - 1);
+  deque->buffer[deque->first] = element;
+  deque->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the back of the Deque.
+ *
+ * @param[in] deque the Deque to which the element is being added
+ * @param[in] element the element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat deque_add_last(Deque *deque, void *element) {
+  if (deque->capacity == deque->size && expand_capacity(deque) != CC_OK)
+    return CC_ERR_ALLOC;
+
+  deque->buffer[deque->last] = element;
+  deque->last = (deque->last + 1) & (deque->capacity - 1);
+  deque->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Inserts a new element at the specified index within the deque. The index
+ * must be within the range of the Deque.
+ *
+ * @param[in] deque Deque to which this new element is being added
+ * @param[in] element element that is being added
+ * @param[in] index position within the Deque at which this new element is
+ *                  is being added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, or CC_ERR_ALLOC if the memory
+ * allocation for the new element failed.
+ */
+enum cc_stat deque_add_at(Deque *deque, void *element, size_t index) {
+  if (index >= deque->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (deque->capacity == deque->size && expand_capacity(deque) != CC_OK)
+    return CC_ERR_ALLOC;
+
+  const size_t c = deque->capacity - 1;
+  const size_t l = deque->last & c;
+  const size_t f = deque->first & c;
+  const size_t p = (deque->first + index) & c;
+
+  if (index == 0)
+    return deque_add_first(deque, element);
+
+  if (index == c)
+    return deque_add_last(deque, element);
+
+  if (index <= (deque->size / 2) - 1) {
+    if (p < f || f == 0) {
+      /* _________________________________
+       * | 1 | 2 | 3 | 4 | 5 | . | . | 6 |
+       * ---------------------------------
+       *  (p) <--          L           F
+       *
+       * Left circular shift from (p)
+       */
+      const size_t r_move = (f != 0) ? c - f + 1 : 0;
+      const size_t l_move = p;
+
+      void *e_first = deque->buffer[0];
+
+      if (f != 0) {
+        memmove(&(deque->buffer[f - 1]), &(deque->buffer[f]),
+                r_move * sizeof(void *));
+      }
+      if (p != 0) {
+        memmove(&(deque->buffer[0]), &(deque->buffer[1]),
+                l_move * sizeof(void *));
+      }
+      deque->buffer[c] = e_first;
+    } else {
+      memmove(&(deque->buffer[f - 1]), &(deque->buffer[f]),
+              index * sizeof(void *));
+    }
+    deque->first = (deque->first - 1) & c;
+  } else {
+    if (p > l || l == c) {
+      /* _________________________________
+       * | 1 | . | . | 6 | 5 | 4 | 3 | 2 |
+       * ---------------------------------
+       *   L           F          (p) -->
+       *
+       * Circular right shift from (p)
+       */
+      void *e_last = deque->buffer[c];
+
+      if (p != c) {
+        memmove(&(deque->buffer[p + 1]), &(deque->buffer[p]),
+                (c - p) * sizeof(void *));
+      }
+      if (l != c) {
+        memmove(&(deque->buffer[1]), &(deque->buffer[0]),
+                (l + 1) * sizeof(void *));
+      }
+      deque->buffer[0] = e_last;
+    } else {
+      memmove(&(deque->buffer[p + 1]), &(deque->buffer[p]),
+              (deque->size - index) * sizeof(void *));
+    }
+    deque->last = (deque->last + 1) & c;
+  }
+  deque->buffer[p] = element;
+  deque->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces a deque element at the specified index and optionally sets the out
+ * parameter to the value of the replaced element. The specified index must be
+ * within the bounds of the Deque.
+ *
+ * @param[in] deque the deque whose element is being replaced
+ * @param[in] element the replacement element
+ * @param[in] index the index at which the replacement element should be
+ * inserted
+ * @param[out] out     Pointer to where the replaced element is stored, or NULL
+ * if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat deque_replace_at(Deque *deque, void *element, size_t index,
+                              void **out) {
+  if (index >= deque->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i = (deque->first + index) & (deque->capacity - 1);
+
+  if (out)
+    *out = deque->buffer[i];
+
+  deque->buffer[i] = element;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the specified element from the deque if such element exists and
+ * optionally sets the out parameter to the value of the removed element.
+ *
+ * @param[in] deque the deque from which the element is being removed
+ * @param[in] element the element being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat deque_remove(Deque *deque, void *element, void **out) {
+  size_t index;
+  enum cc_stat status = deque_index_of(deque, element, &index);
+
+  if (status != CC_OK)
+    return status;
+
+  return deque_remove_at(deque, index, out);
+}
+
+/**
+ * Removes a Deque element from the specified index and optionally sets the
+ * out parameter to the value of the removed element. The index must  be within
+ * the bounds of the deque.
+ *
+ * @param[in] deque the deque from which the element is being removed
+ * @param[in] index the index of the element being removed
+ * @param[out] out  Pointer to where the removed value is stored,
+ *                  or NULL if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the index was out of range.
+ */
+enum cc_stat deque_remove_at(Deque *deque, size_t index, void **out) {
+  if (index >= deque->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  const size_t c = deque->capacity - 1;
+  const size_t l = deque->last & c;
+  const size_t f = deque->first & c;
+  const size_t p = (deque->first + index) & c;
+
+  void *removed = deque->buffer[index];
+
+  if (index == 0)
+    return deque_remove_first(deque, out);
+
+  if (index == c)
+    return deque_remove_last(deque, out);
+
+  if (index <= (deque->size / 2) - 1) {
+    if (p < f) {
+      void *e = deque->buffer[c];
+
+      if (f != c) {
+        memmove(&(deque->buffer[f + 1]), &(deque->buffer[f]),
+                (c - f) * sizeof(void *));
+      }
+      if (p != 0) {
+        memmove(&(deque->buffer[1]), &(deque->buffer[0]), p * sizeof(void *));
+      }
+      deque->buffer[0] = e;
+    } else {
+      memmove(&(deque->buffer[f + 1]), &(deque->buffer[f]),
+              index * sizeof(void *));
+    }
+    deque->first = (deque->first + 1) & c;
+  } else {
+    if (p > l) {
+      void *e = deque->buffer[0];
+
+      if (p != c) {
+        memmove(&(deque->buffer[p]), &(deque->buffer[p + 1]),
+                (c - p) * sizeof(void *));
+      }
+      if (p != 0) {
+        memmove(&(deque->buffer[1]), &(deque->buffer[0]), l * sizeof(void *));
+      }
+      deque->buffer[c] = e;
+    } else {
+      memmove(&(deque->buffer[p]), &(deque->buffer[p + 1]),
+              (l - p) * sizeof(void *));
+    }
+    deque->last = (deque->last - 1) & c;
+  }
+  deque->size--;
+
+  if (out)
+    *out = removed;
+  return CC_OK;
+}
+
+/**
+ * Removes the first element of the deque and optionally sets the out parameter
+ * to the value of the removed element.
+ *
+ * @param[in] deque the deque whose first element (or head) is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the Deque is already empty.
+ */
+enum cc_stat deque_remove_first(Deque *deque, void **out) {
+  if (deque->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  void *element = deque->buffer[deque->first];
+  deque->first = (deque->first + 1) & (deque->capacity - 1);
+  deque->size--;
+
+  if (out)
+    *out = element;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last element of the deque and optionally sets the out parameter
+ * to the value of the removed element.
+ *
+ * @param[in] deque the deque whose last element (or tail) is being removed
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the Deque is already empty.
+ */
+enum cc_stat deque_remove_last(Deque *deque, void **out) {
+  if (deque->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t last = (deque->last - 1) & (deque->capacity - 1);
+  void *element = deque->buffer[last];
+  deque->last = last;
+  deque->size--;
+
+  if (out)
+    *out = element;
+
+  return CC_OK;
+}
+
+/**
+ * Removes all elements from the Deque.
+ *
+ * @note This function does not shrink the Deque's capacity.
+
+ * @param[in] deque Deque from which all element are being removed
+ */
+void deque_remove_all(Deque *deque) {
+  deque->first = 0;
+  deque->last = 0;
+  deque->size = 0;
+}
+
+/**
+ * Removes and frees all element from the specified Deque.
+ *
+ * @note This function does not shrink the Deque's capacity.
+ * @note This function should not be called on Deques that have some
+ *       of their elements allocated on stack.
+ *
+ * @param[in] deque Deque from which all elements are being removed
+ */
+void deque_remove_all_cb(Deque *deque, void (*cb)(void *)) {
+  deque_foreach(deque, cb);
+  deque_remove_all(deque);
+}
+
+/**
+ * Gets a Deque element from the specified index and sets the out parameter to
+ * its value. The specified index must be withing the bounds of the deque.
+ *
+ * @param[in] deque Deque from which the element is being returned
+ * @param[in] index index of the Deque element
+ * @param[out] out Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat deque_get_at(Deque const *const deque, size_t index, void **out) {
+  if (index > deque->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i = (deque->first + index) & (deque->capacity - 1);
+  *out = deque->buffer[i];
+  return CC_OK;
+}
+
+/**
+ * Gets the first (head) element of the Deque.
+ *
+ * @param[in] deque Deque whose first element is being returned
+ * @param[out] out Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the
+ * Deque is empty.
+ */
+enum cc_stat deque_get_first(Deque const *const deque, void **out) {
+  if (deque->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  *out = deque->buffer[deque->first];
+  return CC_OK;
+}
+
+/**
+ * Returns the last (tail) element of the Deque.
+ *
+ * @param[in] deque the deque whose last element is being returned
+ * @param[out] out Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the
+ * Deque is empty.
+ */
+enum cc_stat deque_get_last(Deque const *const deque, void **out) {
+  if (deque->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t last = (deque->last - 1) & (deque->capacity - 1);
+  *out = deque->buffer[last];
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified Deque. A shallow copy is a copy of
+ * the deque structure, but not the elements it holds.
+ *
+ * @note The new Deque is allocated using the original Deques's allocators
+ *       and it also inherits the configuration of the original Deque.
+ *
+ * @param[in] deque Deque to be copied
+ * @param[out] out Pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat deque_copy_shallow(Deque const *const deque, Deque **out) {
+  Deque *copy = deque->mem_alloc(sizeof(Deque));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = deque->mem_alloc(deque->capacity * sizeof(void *)))) {
+    deque->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+  copy->size = deque->size;
+  copy->capacity = deque->capacity;
+  copy->mem_alloc = deque->mem_alloc;
+  copy->mem_calloc = deque->mem_calloc;
+  copy->mem_free = deque->mem_free;
+
+  copy_buffer(deque, copy->buffer, NULL);
+
+  copy->first = 0;
+  copy->last = copy->size;
+
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified Deque. A deep copy is a copy of
+ * both the Deque structure and the data it holds.
+ *
+ * @note The new Deque is allocated using the original Deque's allocators
+ *       and also inherits the configuration of the original Deque.
+ *
+ * @param[in] deque the deque to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data.
+ * @param[out] out Pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat deque_copy_deep(Deque const *const deque, void *(*cp)(void *),
+                             Deque **out) {
+  Deque *copy = deque->mem_alloc(sizeof(Deque));
+
+  if (!copy)
+    return CC_ERR_ALLOC;
+
+  if (!(copy->buffer = deque->mem_alloc(deque->capacity * sizeof(void *)))) {
+    deque->mem_free(copy);
+    return CC_ERR_ALLOC;
+  }
+
+  copy->size = deque->size;
+  copy->capacity = deque->capacity;
+  copy->mem_alloc = deque->mem_alloc;
+  copy->mem_calloc = deque->mem_calloc;
+  copy->mem_free = deque->mem_free;
+
+  copy_buffer(deque, copy->buffer, cp);
+
+  copy->first = 0;
+  copy->last = copy->size;
+
+  *out = copy;
+
+  return CC_OK;
+}
+
+/**
+ * Trims the capacity of the deque to a power of 2 that is the nearest
+ * upper power of 2 to the number of elements in the deque.
+ *
+ * @param[in] deque Deque whose capacity is being trimmed
+ *
+ * @return CC_OK if the capacity was trimmed successfully, or CC_ERR_ALLOC if
+ * the reallocation failed.
+ */
+enum cc_stat deque_trim_capacity(Deque *deque) {
+  if (deque->capacity == deque->size)
+    return CC_OK;
+
+  size_t new_size = upper_pow_two(deque->size);
+
+  if (new_size == deque->capacity)
+    return CC_OK;
+
+  void **new_buff = deque->mem_alloc(sizeof(void *) * new_size);
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  copy_buffer(deque, new_buff, NULL);
+  deque->mem_free(deque->buffer);
+
+  deque->buffer = new_buff;
+  deque->first = 0;
+  deque->last = deque->size;
+  deque->capacity = new_size;
+  return CC_OK;
+}
+
+/**
+ * Reverses the order of elements in the specified deque.
+ *
+ * @param[in] deque the deque that is being reversed
+ */
+void deque_reverse(Deque *deque) {
+  size_t i;
+  size_t j;
+  size_t s = deque->size;
+  size_t c = deque->capacity - 1;
+
+  size_t first = deque->first;
+
+  for (i = 0, j = s - 1; i < (s - 1) / 2; i++, j--) {
+    size_t f = (first + i) & c;
+    size_t l = (first + j) & c;
+
+    void *tmp = deque->buffer[f];
+    deque->buffer[f] = deque->buffer[l];
+    deque->buffer[l] = tmp;
+  }
+}
+
+/**
+ * Returns the number of occurrences of the element within the specified Deque.
+ *
+ * @param[in] deque Deque that is being searched
+ * @param[in] element the element that is being searched for
+ *
+ * @return the number of occurrences of the element
+ */
+size_t deque_contains(Deque const *const deque, const void *element) {
+  size_t i;
+  size_t o = 0;
+
+  for (i = 0; i < deque->size; i++) {
+    size_t p = (deque->first + i) & (deque->capacity - 1);
+    if (deque->buffer[p] == element)
+      o++;
+  }
+  return o;
+}
+
+/**
+ * Returns the number of occurrences of the value poined to by
+ * <code>element</code> within the deque.
+ *
+ * @param[in] deque Deque that is being searched
+ * @param[in] element the element that is being searched for
+ * @param[in] cmp Comparator function which returns 0 if the values passed to it
+ * are equal
+ *
+ * @return the number of occurrences of the element
+ */
+size_t deque_contains_value(Deque const *const deque, const void *element,
+                            int (*cmp)(const void *, const void *)) {
+  size_t i;
+  size_t o = 0;
+
+  for (i = 0; i < deque->size; i++) {
+    size_t p = (deque->first + i) & (deque->capacity - 1);
+    if (cmp(deque->buffer[p], element) == 0)
+      o++;
+  }
+  return o;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of the
+ * Deque.
+ *
+ * @param[in] deque deque being searched
+ * @param[in] element the element whose index is being looked up
+ * @param[out] index  Pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat deque_index_of(Deque const *const deque, const void *element,
+                            size_t *index) {
+  size_t i;
+
+  for (i = 0; i < deque->size; i++) {
+    size_t p = (deque->first + i) & (deque->capacity - 1);
+    if (deque->buffer[p] == element) {
+      *index = i;
+      return CC_OK;
+    }
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Returns the size of the specified Deque. The size of the Deque is the
+ * number of elements contained within the Deque.
+ *
+ * @param[in] deque Deque whose size is being returned
+ *
+ * @return the number of elements within the specified Deque
+ */
+size_t deque_size(Deque const *const deque) { return deque->size; }
+
+/**
+ * Retruns the capacity of the specified deque. The capacity of the deque is
+ * the maximum number of elements a Deque can hold before its underlying buffer
+ * needs to be resized.
+ *
+ * @param[in] deque Deque whose capacity is being returned
+ *
+ * @return the capacity of the specified Deque
+ */
+size_t deque_capacity(Deque const *const deque) { return deque->capacity; }
+
+/**
+ * Return the underlying deque buffer.
+ *
+ * @note Any direct modification of the buffer may invalidate the Deque.
+ *
+ * @param[in] deque the deque whose underlying buffer is being returned
+ *
+ * @return Deques internal buffer
+ */
+const void *const *deque_get_buffer(Deque const *const deque) {
+  return (const void *const *)deque->buffer;
+}
+
+/**
+ * Applies the function fn to each element of the Deque.
+ *
+ * @param[in] deque the deque on which this operation is performed
+ * @param[in] fn    the operation function that is to be invoked on each Deque
+ *                  element
+ */
+void deque_foreach(Deque *deque, void (*fn)(void *)) {
+  size_t i;
+
+  for (i = 0; i < deque->size; i++) {
+    size_t p = (deque->first + i) & (deque->capacity - 1);
+    fn(deque->buffer[p]);
+  }
+}
+
+/**
+ * Filters the Deque by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] deque deque that is to be filtered
+ * @param[in] pred  predicate function which returns true if the element should
+ *                  be kept in the Deque
+ *
+ * @return CC_OK if the deque was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the Deque is empty.
+ */
+enum cc_stat deque_filter_mut(Deque *deque, bool (*pred)(const void *)) {
+  if (deque_size(deque) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i = 0, c = deque->capacity - 1;
+
+  while (i < deque_size(deque)) {
+    size_t d_index = (deque->first + i) & c;
+
+    if (!pred(deque->buffer[d_index])) {
+      deque_remove_at(deque, i, NULL);
+    } else {
+      i++;
+    }
+  }
+
+  return CC_OK;
+}
+
+/**
+ * Filters the Deque by creating a new Deque that contains all elements from the
+ * original Deque that return true on pred(element) without modifying the
+ * original deque.
+ *
+ * @param[in] deque deque that is to be filtered
+ * @param[in] deque predicate function which returns true if the element should
+ *                  be kept in the filtered deque
+ * @param[out] out pointer to where the new filtered deque is to be stored
+ *
+ * @return CC_OK if the deque was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the deque is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new deque failed.
+ */
+enum cc_stat deque_filter(Deque *deque, bool (*pred)(const void *),
+                          Deque **out) {
+  if (deque_size(deque) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i;
+  Deque *filtered = NULL;
+  deque_new(&filtered);
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  for (i = 0; i < deque->size; i++) {
+    size_t d_index = (deque->first + i) & (deque->capacity - 1);
+
+    if (pred(deque->buffer[d_index])) {
+      deque_add(filtered, deque->buffer[d_index]);
+    }
+  }
+
+  *out = filtered;
+  return CC_OK;
+}
+
+/**
+ * Copies the elements from the Deque's buffer to the buffer buff. This function
+ * only copies the elements instead of the whole buffer and also realigns the
+ * buffer in the process.
+ *
+ * @param[in] deque The deque whose buffer is being copied to the new buffer
+ * @param[in] buff The destination buffer. This buffer is expected to be at
+ * least the capacity of the original deque's buffer or greater.
+ * @param[in] cp An optional copy function that returns a copy of the element
+ * passed to it. If NULL is passed, then only a shallow copy will be performed.
+ */
+static void copy_buffer(Deque const *const deque, void **buff,
+                        void *(*cp)(void *)) {
+  if (cp == NULL) {
+    if (deque->last > deque->first) {
+      memcpy(buff, &(deque->buffer[deque->first]),
+             deque->size * sizeof(void *));
+    } else {
+      size_t l = deque->last;
+      size_t e = deque->capacity - deque->first;
+
+      memcpy(buff, &(deque->buffer[deque->first]), e * sizeof(void *));
+
+      memcpy(&(buff[e]), deque->buffer, l * sizeof(void *));
+    }
+  } else {
+    size_t i;
+    for (i = 0; i < deque->size; i++) {
+      size_t p = (deque->first + i) & (deque->capacity - 1);
+      buff[i] = cp(deque->buffer[p]);
+    }
+  }
+}
+
+/**
+ * Expands the deque capacity. This operation might fail if the new buffer
+ * cannot be allocated. If the capacity is already the maximum capacity,
+ * no new buffer is allocated.
+ *
+ * @param[in] deque the deque whose capacity is being expanded
+ *
+ * @return CC_OK if the buffer was expanded successfully, CC_ERR_ALLOC if
+ * the memory allocation for the new buffer failed, or CC_ERR_MAX_CAPACITY
+ * if the Deque is already at maximum capacity.
+ */
+static enum cc_stat expand_capacity(Deque *deque) {
+  if (deque->capacity == MAX_POW_TWO)
+    return CC_ERR_MAX_CAPACITY;
+
+  size_t new_capacity = deque->capacity << 1;
+  void **new_buffer = deque->mem_calloc(new_capacity, sizeof(void *));
+
+  if (!new_buffer)
+    return CC_ERR_ALLOC;
+
+  copy_buffer(deque, new_buffer, NULL);
+  deque->mem_free(deque->buffer);
+
+  deque->first = 0;
+  deque->last = deque->size;
+  deque->capacity = new_capacity;
+  deque->buffer = new_buffer;
+
+  return CC_OK;
+}
+
+/**
+ * Rounds the integer to the nearest upper power of two.
+ *
+ * @param[in] the unsigned integer that is being rounded
+ *
+ * @return the nearest upper power of two
+ */
+static INLINE size_t upper_pow_two(size_t n) {
+  if (n >= MAX_POW_TWO)
+    return MAX_POW_TWO;
+
+  if (n == 0)
+    return 2;
+
+  /**
+   * taken from:
+   * http://graphics.stanford.edu/~seander/
+   * bithacks.html#RoundUpPowerOf2Float
+   */
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n++;
+
+  return n;
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] deque the vector to iterate over
+ */
+void deque_iter_init(DequeIter *iter, Deque *deque) {
+  iter->deque = deque;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out Pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the Deque has been reached.
+ */
+enum cc_stat deque_iter_next(DequeIter *iter, void **out) {
+  const size_t c = (iter->deque->capacity - 1);
+  const size_t last = (iter->deque->last) & c;
+  const size_t first = (iter->deque->first) & c;
+
+  if (last == first || iter->index >= iter->deque->size)
+    return CC_ITER_END;
+
+  const size_t i = (iter->deque->first + iter->index) & c;
+
+  iter->index++;
+  iter->last_removed = false;
+  *out = iter->deque->buffer[i];
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>deque_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * deque_iter_next()</code>
+
+ * @param[out] out Pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return CC_OK if the element was successfully removed, CC_ERR_OUT_OF_RANGE
+ * if the iterator state is invalid, or CC_ERR_VALUE_NOT_FOUND if the value
+ * was already removed.
+ */
+enum cc_stat deque_iter_remove(DequeIter *iter, void **out) {
+  if (iter->last_removed)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *rm;
+  enum cc_stat status = deque_remove_at(iter->deque, iter->index, &rm);
+  if (status == CC_OK) {
+    iter->index--;
+    iter->last_removed = true;
+    if (out)
+      *out = rm;
+  }
+  return status;
+}
+
+/**
+ * Adds a new element to the Deque after the last returned element by
+ * <code>deque_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * deque_iter_next()</code>
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat deque_iter_add(DequeIter *iter, void *element) {
+  enum cc_stat status = deque_add_at(iter->deque, element, iter->index);
+  if (status == CC_OK)
+    iter->index++;
+
+  return status;
+}
+
+/**
+ * Replaces the last returned element by <code>deque_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * deque_iter_next()</code>
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out Pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return  CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat deque_iter_replace(DequeIter *iter, void *replacement,
+                                void **out) {
+  return deque_replace_at(iter->deque, replacement, iter->index, out);
+}
+
+/**
+ * Returns the index of the last returned element by <code>deque_iter_next()
+ * </code>.
+ *
+ * @note
+ * This function should not be called before a call to <code>deque_iter_next()
+ * </code>
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index
+ */
+size_t deque_iter_index(DequeIter *iter) { return iter->index - 1; }
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter Iterator that is being initialized
+ * @param[in] ar1  First deque
+ * @param[in] ar2  Second deque
+ */
+void deque_zip_iter_init(DequeZipIter *iter, Deque *d1, Deque *d2) {
+  iter->d1 = d1;
+  iter->d2 = d2;
+  iter->index = 0;
+  iter->last_removed = false;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter Iterator that is being advanced
+ * @param[out] out1 Output of the first deque element
+ * @param[out] out2 Output of the second deque element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the deques has been reached.
+ */
+enum cc_stat deque_zip_iter_next(DequeZipIter *iter, void **out1, void **out2) {
+  const size_t d1_capacity = (iter->d1->capacity - 1);
+  const size_t d1_last = (iter->d1->last) & d1_capacity;
+  const size_t d1_first = (iter->d1->first) & d1_capacity;
+
+  if (d1_last == d1_first || iter->index >= iter->d1->size)
+    return CC_ITER_END;
+
+  const size_t d2_capacity = (iter->d2->capacity - 1);
+  const size_t d2_last = (iter->d2->last) & d2_capacity;
+  const size_t d2_first = (iter->d2->first) & d2_capacity;
+
+  if (d2_last == d2_first || iter->index >= iter->d2->size)
+    return CC_ITER_END;
+
+  const size_t d1_index = (iter->d1->first + iter->index) & d1_capacity;
+  const size_t d2_index = (iter->d2->first + iter->index) & d2_capacity;
+
+  *out1 = iter->d1->buffer[d1_index];
+  *out2 = iter->d2->buffer[d2_index];
+
+  iter->index++;
+  iter->last_removed = false;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element pair to the deques after the last returned element pair by
+ * <code>deque_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>deque_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ * @param[in] e1   element added to the first deque
+ * @param[in] e2   element added to the second deque
+ *
+ * @return CC_OK if the element pair was successfully added to the deques, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat deque_zip_iter_add(DequeZipIter *iter, void *e1, void *e2) {
+  if (iter->index >= iter->d1->size || iter->index >= iter->d2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  /* While this check is performed by a call to deque_add_at, it is necessary to
+     know in advance whether both deque buffers have enough room before
+     inserting new elements because this operation must insert either both
+     elements, or none.*/
+  if ((iter->d1->capacity == iter->d1->size &&
+       expand_capacity(iter->d1) != CC_OK) &&
+      (iter->d2->capacity == iter->d2->size &&
+       expand_capacity(iter->d2) != CC_OK)) {
+    return CC_ERR_ALLOC;
+  }
+
+  /* The retun status can be ignored since the checks have already been made. */
+  deque_add_at(iter->d1, e1, iter->index);
+  deque_add_at(iter->d2, e2, iter->index);
+
+  iter->index++;
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>deque_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @param[in]  iter Iterator on which this operation is being performed
+ * @param[out] out1 Output of the removed element from the first deque
+ * @param[out] out2 Output of the removed element from the second deque
+ *
+ * @return CC_OK if the element was successfully removed, CC_ERR_OUT_OF_RANGE if
+ * the iterator is in an invalid state, or CC_ERR_VALUE_NOT_FOUND if the value
+ * was already removed.
+ */
+enum cc_stat deque_zip_iter_remove(DequeZipIter *iter, void **out1,
+                                   void **out2) {
+  if (iter->last_removed)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  if ((iter->index - 1) >= iter->d1->size ||
+      (iter->index - 1) >= iter->d2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  deque_remove_at(iter->d1, iter->index - 1, out1);
+  deque_remove_at(iter->d2, iter->index - 1, out2);
+
+  iter->index--;
+  iter->last_removed = true;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>deque_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @param[in] iter  Iterator on which this operation is being performed
+ * @param[in]  e1   First deque's replacement element
+ * @param[in]  e2   Second deque's replacement element
+ * @param[out] out1 Output of the replaced element from the first deque
+ * @param[out] out2 Output of the replaced element from the second deque
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat deque_zip_iter_replace(DequeZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  if ((iter->index - 1) >= iter->d1->size ||
+      (iter->index - 1) >= iter->d2->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  deque_replace_at(iter->d1, e1, iter->index - 1, out1);
+  deque_replace_at(iter->d2, e2, iter->index - 1, out2);
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>deque_zip_iter_next()</code>.
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ *
+ * @return current iterator index
+ */
+size_t deque_zip_iter_index(DequeZipIter *iter) { return iter->index - 1; }

--- a/test/c/collections-c/normal/src/hashset.c
+++ b/test/c/collections-c/normal/src/hashset.c
@@ -1,0 +1,231 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hashset.h"
+
+struct hashset_s {
+  HashTable *table;
+  int *dummy;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+/**
+ * Initializes the fields of the HashSetConf struct to default values.
+ *
+ * @param[in, out] conf the configuration struct that is being initialized
+ */
+void hashset_conf_init(HashSetConf *conf) { hashtable_conf_init(conf); }
+
+/**
+ * Creates a new HashSet and returns a status code.
+ *
+ * @note The newly created HashSet will be a set of strings.
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new HashSet failed.
+ */
+enum cc_stat hashset_new(HashSet **hs) {
+  HashSetConf hsc;
+  hashset_conf_init(&hsc);
+  return hashset_new_conf(&hsc, hs);
+}
+
+/**
+ * Creates a new empty HashSet based on the specified HashSetConf struct and
+ * returns a status code.
+ *
+ * The HashSet is allocated using the allocators specified in the HashSetConf
+ * object. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf The hashset configuration object. All fields must be
+ * initialized.
+ * @param[out] out Pointer to where the newly created HashSet is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new HashSet structure failed.
+ */
+enum cc_stat hashset_new_conf(HashSetConf const *const conf, HashSet **hs) {
+  HashSet *set = conf->mem_calloc(1, sizeof(HashSet));
+
+  if (!set)
+    return CC_ERR_ALLOC;
+
+  HashTable *table;
+  enum cc_stat stat = hashtable_new_conf(conf, &table);
+
+  if (stat != CC_OK) {
+    conf->mem_free(set);
+    return stat;
+  }
+
+  set->table = table;
+  set->mem_alloc = conf->mem_alloc;
+  set->mem_calloc = conf->mem_calloc;
+  set->mem_free = conf->mem_free;
+
+  /* A dummy pointer that is never actually dereferenced
+   *  that must not be null.*/
+  set->dummy = (int *)1;
+  *hs = set;
+  return CC_OK;
+}
+
+/**
+ * Destroys the specified HashSet structure without destroying the data
+ * it holds.
+ *
+ * @param[in] table HashSet to be destroyed.
+ */
+void hashset_destroy(HashSet *set) {
+  hashtable_destroy(set->table);
+  set->mem_free(set);
+}
+
+/**
+ * Adds a new element to the HashSet.
+ *
+ * @param[in] set the set to which the element is being added
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation failed.
+ */
+enum cc_stat hashset_add(HashSet *set, void *element) {
+  return hashtable_add(set->table, element, set->dummy);
+}
+
+/**
+ * Removes the specified element from the HashSet and sets the out
+ * parameter to its value.
+ *
+ * @param[in] set the set from which the element is being removed
+ * @param[in] element the element being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the value was not found.
+ */
+enum cc_stat hashset_remove(HashSet *set, void *element, void **out) {
+  return hashtable_remove(set->table, element, out);
+}
+
+/**
+ * Removes all elements from the specified set.
+ *
+ * @param set the set from which all elements are being removed
+ */
+void hashset_remove_all(HashSet *set) { hashtable_remove_all(set->table); }
+
+/**
+ * Checks whether an element is a part of the specified set.
+ *
+ * @param[in] set the set being searched for the specified element
+ * @param[in] element the element being searched for
+ *
+ * @return true if the specified element is an element of the set
+ */
+bool hashset_contains(HashSet *set, void *element) {
+  return hashtable_contains_key(set->table, element);
+}
+
+/**
+ * Returns the size of the specified set.
+ *
+ * @param[in] set the set whose size is being returned
+ *
+ * @return the size of the set
+ */
+size_t hashset_size(HashSet *set) { return hashtable_size(set->table); }
+
+/**
+ * Returns the capacity of the specified set.
+ *
+ * @param[in] set the set whose capacity is being returned
+ *
+ * @return the capacity of the set
+ */
+size_t hashset_capacity(HashSet *set) { return hashtable_capacity(set->table); }
+
+/**
+ * Applies the function fn to each element of the HashSet.
+ *
+ * @param[in] set the set on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each element of the
+ *               set
+ */
+void hashset_foreach(HashSet *set, void (*fn)(const void *e)) {
+  hashtable_foreach_key(set->table, fn);
+}
+
+/**
+ * Initializes the set iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] set the set on which this iterator will operate
+ */
+void hashset_iter_init(HashSetIter *iter, HashSet *set) {
+  hashtable_iter_init(&(iter->iter), set->table);
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out Pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the HashSet has been reached.
+ */
+enum cc_stat hashset_iter_next(HashSetIter *iter, void **out) {
+  TableEntry *entry;
+  enum cc_stat status = hashtable_iter_next(&(iter->iter), &entry);
+
+  if (status != CC_OK)
+    return status;
+
+  if (out)
+    *out = entry->key;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned entry by <code>hashset_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the
+ * out parameter to the value of the removed element.
+ *
+ * @note This Function should only ever be called after a call to <code>
+ * hashset_iter_next()</code>.
+ *
+ * @param[in] iter The iterator on which this operation is performed
+ * @param[out] out Pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the entry was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat hashset_iter_remove(HashSetIter *iter, void **out) {
+  return hashtable_iter_remove(&(iter->iter), out);
+}

--- a/test/c/collections-c/normal/src/hashtable.c
+++ b/test/c/collections-c/normal/src/hashtable.c
@@ -1,0 +1,1051 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hashtable.h"
+
+#define DEFAULT_CAPACITY 16
+#define DEFAULT_LOAD_FACTOR 0.75f
+
+struct hashtable_s {
+  size_t capacity;
+  size_t size;
+  size_t threshold;
+  uint32_t hash_seed;
+  int key_len;
+  float load_factor;
+  TableEntry **buckets;
+
+  size_t (*hash)(const void *key, int l, uint32_t seed);
+  int (*key_cmp)(const void *k1, const void *k2);
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static enum cc_stat resize(HashTable *t, size_t new_capacity);
+static enum cc_stat get_null_key(HashTable *table, void **out);
+static enum cc_stat add_null_key(HashTable *table, void *val);
+static enum cc_stat remove_null_key(HashTable *table, void **out);
+
+static size_t get_table_index(HashTable *table, void *key);
+static size_t round_pow_two(size_t n);
+static void move_entries(TableEntry **src_bucket, TableEntry **dest_bucket,
+                         size_t src_size, size_t dest_size);
+
+/**
+ * Creates a new HashTable and returns a status code.
+ *
+ * @note The newly created HashTable will work with string keys.
+ *
+ * @param[out] out Pointer to where the newly created HashTable is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new HashTable failed.
+ */
+enum cc_stat hashtable_new(HashTable **out) {
+  HashTableConf htc;
+  hashtable_conf_init(&htc);
+  return hashtable_new_conf(&htc, out);
+}
+
+/**
+ * Creates a new HashTable based on the specified HashTableConf struct and
+ * returns a status code.
+ *
+ * The table is allocated using the memory allocators specified in the
+ * HashTableConf struct.
+ *
+ * @param[in] conf the HashTable conf structure
+ * @param[out] out Pointer to where the newly created HashTable is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new HashTable structure failed.
+ */
+enum cc_stat hashtable_new_conf(HashTableConf const *const conf,
+                                HashTable **out) {
+  HashTable *table = conf->mem_calloc(1, sizeof(HashTable));
+
+  if (!table)
+    return CC_ERR_ALLOC;
+
+  table->capacity = round_pow_two(conf->initial_capacity);
+  table->buckets = conf->mem_calloc(table->capacity, sizeof(TableEntry));
+
+  if (!table->buckets) {
+    conf->mem_free(table);
+    return CC_ERR_ALLOC;
+  }
+
+  table->hash = conf->hash;
+  table->key_cmp = conf->key_compare;
+  table->load_factor = conf->load_factor;
+  table->hash_seed = conf->hash_seed;
+  table->key_len = conf->key_length;
+  table->size = 0;
+  table->mem_alloc = conf->mem_alloc;
+  table->mem_calloc = conf->mem_calloc;
+  table->mem_free = conf->mem_free;
+  table->threshold = table->capacity * table->load_factor;
+
+  *out = table;
+  return CC_OK;
+}
+
+/**
+ * Initializes the HashTableConf structs fields to default values.
+ *
+ * @param[in] conf the struct that is being initialized
+ */
+void hashtable_conf_init(HashTableConf *conf) {
+  conf->hash = STRING_HASH;
+  conf->key_compare = cc_common_cmp_str;
+  conf->initial_capacity = DEFAULT_CAPACITY;
+  conf->load_factor = DEFAULT_LOAD_FACTOR;
+  conf->key_length = KEY_LENGTH_VARIABLE;
+  conf->hash_seed = 0;
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Destroys the specified HashTable structure without destroying the data
+ * contained within it. In other words, the keys and the values are not freed,
+ * but only the table structure.
+ *
+ * @param[in] table HashTable to be destroyed
+ */
+void hashtable_destroy(HashTable *table) {
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *next = table->buckets[i];
+
+    while (next) {
+      TableEntry *tmp = next->next;
+      table->mem_free(next);
+      next = tmp;
+    }
+  }
+  table->mem_free(table->buckets);
+  table->mem_free(table);
+}
+
+/**
+ * Creates a new key-value mapping in the specified HashTable. If the unique key
+ * is already mapped to a value in this table, that value is replaced with the
+ * new value. This operation may fail if the space allocation for the new entry
+ * fails.
+ *
+ * @param[in] table the table to which this new key-value mapping is being added
+ * @param[in] key a hash table key used to access the specified value
+ * @param[in] val a value that is being stored in the table
+ *
+ * @return CC_OK if the mapping was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation failed.
+ */
+enum cc_stat hashtable_add(HashTable *table, void *key, void *val) {
+  enum cc_stat stat;
+  if (table->size >= table->threshold) {
+    if ((stat = resize(table, table->capacity << 1)) != CC_OK)
+      return stat;
+  }
+
+  if (!key)
+    return add_null_key(table, val);
+
+  const size_t hash = table->hash(key, table->key_len, table->hash_seed);
+  const size_t i = hash & (table->capacity - 1);
+
+  TableEntry *replace = table->buckets[i];
+
+  while (replace) {
+    void *rk = replace->key;
+    if (rk && table->key_cmp(rk, key) == 0) {
+      replace->value = val;
+      return CC_OK;
+    }
+    replace = replace->next;
+  }
+
+  TableEntry *new_entry = table->mem_alloc(sizeof(TableEntry));
+
+  if (!new_entry)
+    return CC_ERR_ALLOC;
+
+  new_entry->key = key;
+  new_entry->value = val;
+  new_entry->hash = hash;
+  new_entry->next = table->buckets[i];
+
+  table->buckets[i] = new_entry;
+  table->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Creates a new key-value mapping for the NULL key. This operation may fail if
+ * the space allocation for the new entry fails.
+ *
+ * @param[in] table the table into which this key value-mapping is being added
+ * @param[in] val the value that is being mapped to the NULL key
+ *
+ * @return CC_OK if the mapping was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation failed.
+ */
+static enum cc_stat add_null_key(HashTable *table, void *val) {
+  TableEntry *replace = table->buckets[0];
+
+  while (replace) {
+    if (!replace->key) {
+      replace->value = val;
+      return CC_OK;
+    }
+    replace = replace->next;
+  }
+
+  TableEntry *new_entry = table->mem_alloc(sizeof(TableEntry));
+
+  if (!new_entry)
+    return CC_ERR_ALLOC;
+
+  new_entry->key = NULL;
+  new_entry->value = val;
+  new_entry->hash = 0;
+  new_entry->next = table->buckets[0];
+
+  table->buckets[0] = new_entry;
+  table->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Gets a value associated with the specified key and sets the out
+ * parameter to it.
+ *
+ * @param[in] table the table from which the mapping is being returned
+ * @param[in] key   the key that is being looked up
+ * @param[out] out  pointer to where the value is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat hashtable_get(HashTable *table, void *key, void **out) {
+  if (!key)
+    return get_null_key(table, out);
+
+  size_t index = get_table_index(table, key);
+  TableEntry *bucket = table->buckets[index];
+
+  while (bucket) {
+    if (bucket->key && table->key_cmp(bucket->key, key) == 0) {
+      *out = bucket->value;
+      return CC_OK;
+    }
+    bucket = bucket->next;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Returns a value associated with the NULL key and sets the out parameter
+ * to it.
+ *
+ * @param[in] table the table from which the value mapped to this key is being
+ *                  returned
+ * @param[out] pointer to where the value is stored
+ *
+ * @return CC_OK if a NULL key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+static enum cc_stat get_null_key(HashTable *table, void **out) {
+  TableEntry *bucket = table->buckets[0];
+
+  while (bucket) {
+    if (bucket->key == NULL) {
+      *out = bucket->value;
+      return CC_OK;
+    }
+    bucket = bucket->next;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Removes a key-value mapping from the specified hash table and sets the out
+ * parameter to value.
+ *
+ * @param[in] table the table from which the key-value pair is being removed
+ * @param[in] key the key of the value being returned
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the key was not found.
+ */
+enum cc_stat hashtable_remove(HashTable *table, void *key, void **out) {
+  if (!key)
+    return remove_null_key(table, out);
+
+  const size_t i = get_table_index(table, key);
+
+  TableEntry *e = table->buckets[i];
+  TableEntry *prev = NULL;
+  TableEntry *next = NULL;
+
+  while (e) {
+    next = e->next;
+
+    if (e->key && table->key_cmp(key, e->key) == 0) {
+      void *value = e->value;
+
+      if (!prev)
+        table->buckets[i] = next;
+      else
+        prev->next = next;
+
+      table->mem_free(e);
+      table->size--;
+      if (out)
+        *out = value;
+      return CC_OK;
+    }
+    prev = e;
+    e = next;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Removes a NULL key mapping from the specified hash table and sets the out
+ * parameter to value.
+ *
+ * @param[in] table the table from which the NULL key mapping is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the key was not found.
+ */
+enum cc_stat remove_null_key(HashTable *table, void **out) {
+  TableEntry *e = table->buckets[0];
+
+  TableEntry *prev = NULL;
+  TableEntry *next = NULL;
+
+  while (e) {
+    next = e->next;
+
+    if (e->key == NULL) {
+      void *value = e->value;
+
+      if (!prev)
+        table->buckets[0] = next;
+      else
+        prev->next = next;
+
+      table->mem_free(e);
+      table->size--;
+      if (out)
+        *out = value;
+      return CC_OK;
+    }
+    prev = e;
+    e = next;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Removes all key-value mappings from the specified table.
+ *
+ * @param[in] table the table from which all mappings are being removed
+ */
+void hashtable_remove_all(HashTable *table) {
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *entry = table->buckets[i];
+    while (entry) {
+      TableEntry *next = entry->next;
+      table->mem_free(entry);
+      table->size--;
+      entry = next;
+    }
+    table->buckets[i] = NULL;
+  }
+}
+
+/**
+ * Resizes the table to match the provided capacity. The new capacity must be a
+ * power of two.
+ *
+ * @param[in] table the table that is being resized
+ * @param[in] new_capacity the new capacity to which the table should be resized
+ *
+ * @return CC_OK if the resize was successful, or CC_ERR_MAX_CAPACITY if maximum
+ * capacity has been reached, or CC_ERR_ALLOC if the memory allocation for the
+ * new buffer failed.
+ */
+static enum cc_stat resize(HashTable *t, size_t new_capacity) {
+  if (t->capacity == MAX_POW_TWO)
+    return CC_ERR_MAX_CAPACITY;
+
+  TableEntry **new_buckets = t->mem_calloc(new_capacity, sizeof(TableEntry));
+
+  if (!new_buckets)
+    return CC_ERR_ALLOC;
+
+  TableEntry **old_buckets = t->buckets;
+
+  move_entries(old_buckets, new_buckets, t->capacity, new_capacity);
+
+  t->buckets = new_buckets;
+  t->capacity = new_capacity;
+  t->threshold = t->load_factor * new_capacity;
+
+  t->mem_free(old_buckets);
+
+  return CC_OK;
+}
+
+/**
+ * Rounds the integer to the nearest upper power of two.
+ *
+ * @param[in] the unsigned integer that is being rounded
+ *
+ * @return the nearest upper power of two.
+ */
+static INLINE size_t round_pow_two(size_t n) {
+  if (n >= MAX_POW_TWO)
+    return MAX_POW_TWO;
+
+  if (n == 0)
+    return 2;
+  /**
+   * taken from:
+   * http://graphics.stanford.edu/~seander/
+   * bithacks.html#RoundUpPowerOf2Float
+   */
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n++;
+
+  return n;
+}
+
+/**
+ * Moves all entries from one bucket array to another.
+ *
+ * @param[in] src_bucket  the source bucket from which the entries are moved
+ * @param[in] dest_bucket the destination bucket to which the entries are being
+ *                        moved
+ * @param[in] src_size    size of the source bucket
+ * @param[in] dest_size   size of the destination bucket
+ */
+static INLINE void move_entries(TableEntry **src_bucket,
+                                TableEntry **dest_bucket, size_t src_size,
+                                size_t dest_size) {
+  size_t i;
+  for (i = 0; i < src_size; i++) {
+    TableEntry *entry = src_bucket[i];
+
+    while (entry) {
+      TableEntry *next = entry->next;
+      size_t index = entry->hash & (dest_size - 1);
+
+      entry->next = dest_bucket[index];
+      dest_bucket[index] = entry;
+
+      entry = next;
+    }
+  }
+}
+
+/**
+ * Returns the size of the specified HashTable. Size of a HashTable represents
+ * the number of key-value mappings within the table.
+ *
+ * @param[in] table the table whose size is being returned
+ *
+ * @return the size of the table.
+ */
+size_t hashtable_size(HashTable *table) { return table->size; }
+
+/**
+ * Returns the current capacity of the table. The capacity is the number of
+ * buckets or the number of random access for table entries.
+ *
+ * @param[in] table the table whose current capacity is being returned
+ *
+ * @return the current capacity of the specified table.
+ */
+size_t hashtable_capacity(HashTable *table) { return table->capacity; }
+
+/**
+ * Checks whether or not the HashTable contains the specified key.
+ *
+ * @param[in] table the table on which the search is being performed
+ * @param[in] key the key that is being searched for
+ *
+ * @return true if the table contains the key.
+ */
+bool hashtable_contains_key(HashTable *table, void *key) {
+  TableEntry *entry = table->buckets[get_table_index(table, key)];
+
+  while (entry) {
+    if (table->key_cmp(key, entry->key) == 0)
+      return true;
+
+    entry = entry->next;
+  }
+  return false;
+}
+
+/**
+ * Returns an Array of hashtable values. The returned Array is allocated
+ * using the same memory allocators used by the HashTable.
+ *
+ * @param[in] table the table whose values are being returned
+ * @param[out] out pointer to where the array is stored
+ *
+ * @return CC_OK if the Array was successfully created, or CC_ERR_ALLOC
+ * if the memory allocation for the Array failed.
+ */
+enum cc_stat hashtable_get_values(HashTable *table, Array **out) {
+  ArrayConf ac;
+  array_conf_init(&ac);
+
+  ac.capacity = table->size;
+  ac.mem_alloc = table->mem_alloc;
+  ac.mem_calloc = table->mem_calloc;
+  ac.mem_free = table->mem_free;
+
+  Array *values;
+  enum cc_stat stat = array_new_conf(&ac, &values);
+  if (stat != CC_OK)
+    return stat;
+
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *entry = table->buckets[i];
+
+    while (entry) {
+      if ((stat = array_add(values, entry->value)) == CC_OK) {
+        entry = entry->next;
+      } else {
+        array_destroy(values);
+        return stat;
+      }
+    }
+  }
+  *out = values;
+  return CC_OK;
+}
+
+/**
+ * Returns an Array of hashtable keys. The returned Array is allocated
+ * using the same memory allocators used by the HashTable.
+ *
+ * @param[in] table the table whose keys are being returned
+ * @param[out] out pointer to where the array is stored
+ *
+ * @return CC_OK if the Array was successfully created, or CC_ERR_ALLOC
+ * if the memory allocation for the Array failed.
+ */
+enum cc_stat hashtable_get_keys(HashTable *table, Array **out) {
+  ArrayConf vc;
+  array_conf_init(&vc);
+
+  vc.capacity = table->size;
+  vc.mem_alloc = table->mem_alloc;
+  vc.mem_calloc = table->mem_calloc;
+  vc.mem_free = table->mem_free;
+
+  Array *keys;
+  enum cc_stat stat = array_new_conf(&vc, &keys);
+  if (stat != CC_OK)
+    return stat;
+
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *entry = table->buckets[i];
+
+    while (entry) {
+      if ((stat = array_add(keys, entry->key)) == CC_OK) {
+        entry = entry->next;
+      } else {
+        array_destroy(keys);
+        return stat;
+      }
+    }
+  }
+  *out = keys;
+  return CC_OK;
+}
+
+/**
+ * Returns the bucket index that maps to the specified key.
+ */
+static INLINE size_t get_table_index(HashTable *table, void *key) {
+  size_t hash = table->hash(key, table->key_len, table->hash_seed);
+  return hash & (table->capacity - 1);
+}
+
+/**
+ * Applies the function fn to each key of the HashTable.
+ *
+ * @note The operation function should not modify the key. Any modification
+ * of the key will invalidate the HashTable.
+ *
+ * @param[in] table the table on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each key of the table
+ */
+void hashtable_foreach_key(HashTable *table, void (*fn)(const void *key)) {
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *entry = table->buckets[i];
+
+    while (entry) {
+      fn(entry->key);
+      entry = entry->next;
+    }
+  }
+}
+
+/**
+ * Applies the function fn to each value of the HashTable.
+ *
+ * @param[in] table the table on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each value of the
+ *               table
+ */
+void hashtable_foreach_value(HashTable *table, void (*fn)(void *val)) {
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *entry = table->buckets[i];
+
+    while (entry) {
+      fn(entry->value);
+      entry = entry->next;
+    }
+  }
+}
+
+/**
+ * Initializes the HashTableIter structure.
+ *
+ * @note The order at which the entries are returned is unspecified.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] table the table over whose entries the iterator is going to
+ * iterate
+ */
+void hashtable_iter_init(HashTableIter *iter, HashTable *table) {
+  memset(iter, 0, sizeof(HashTableIter));
+  iter->table = table;
+
+  size_t i;
+  for (i = 0; i < table->capacity; i++) {
+    TableEntry *e = table->buckets[i];
+    if (e) {
+      iter->bucket_index = i;
+      iter->next_entry = e;
+      iter->prev_entry = NULL;
+      break;
+    }
+  }
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next TableEntry.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out pointer to where the next entry is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the HashTable has been reached.
+ */
+enum cc_stat hashtable_iter_next(HashTableIter *iter, TableEntry **te) {
+  if (!iter->next_entry)
+    return CC_ITER_END;
+
+  iter->prev_entry = iter->next_entry;
+  iter->next_entry = iter->next_entry->next;
+
+  /* Iterate through the list */
+  if (iter->next_entry) {
+    *te = iter->prev_entry;
+    return CC_OK;
+  }
+
+  /* Find the next list and return the first element*/
+  size_t i;
+  for (i = iter->bucket_index + 1; i < iter->table->capacity; i++) {
+    iter->next_entry = iter->table->buckets[i];
+
+    if (iter->next_entry) {
+      iter->bucket_index = i;
+      break;
+    }
+  }
+  *te = iter->prev_entry;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned entry by <code>hashtable_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the
+ * out parameter to the value of the removed entry.
+ *
+ * @note This Function should only ever be called after a call to <code>
+ * hashtable_iter_next()</code>.
+ *
+ * @param[in] iter The iterator on which this operation is performed
+ * @param[out] out Pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the entry was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND.
+ */
+enum cc_stat hashtable_iter_remove(HashTableIter *iter, void **out) {
+  return hashtable_remove(iter->table, iter->prev_entry->key, out);
+}
+
+/*******************************************************************************
+ *
+ *
+ *  djb2 string hash
+ *
+ *
+ ******************************************************************************/
+
+size_t hashtable_hash_string(const void *key, int len, uint32_t seed) {
+  const char *str = key;
+  register size_t hash =
+      seed + 5381 + len + 1; /* Suppress the unused param warning */
+
+  int c;
+  while ((c = *str++))
+    hash = ((hash << 5) + hash) ^ c;
+
+  return hash;
+}
+
+/*******************************************************************************
+ *
+ *
+ *  MurmurHash3 by Austin Appleby, adapted for hashtable use.
+ *
+ *
+ ******************************************************************************/
+
+#ifdef _MSC_VER
+
+#define ROTL32(x, y) _rotl(x, y)
+#define ROTL64(x, y) _rotl64(x, y)
+#define BIG_CONSTANT(x) (x)
+
+#else
+
+FORCE_INLINE uint32_t rotl32(uint32_t x, int8_t r) {
+  return (x << r) | (x >> (32 - r));
+}
+
+FORCE_INLINE uint64_t rotl64(uint64_t x, int8_t r) {
+  return (x << r) | (x >> (64 - r));
+}
+
+#define ROTL32(x, y) rotl32(x, y)
+#define ROTL64(x, y) rotl64(x, y)
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif
+
+/*****************************************************************************
+ *
+ *                            -- 64bit --
+ *
+ ****************************************************************************/
+#ifdef ARCH_64
+
+FORCE_INLINE uint64_t fmix64(uint64_t k) {
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+uint64_t hashtable_hash(const void *key, int len, uint32_t seed) {
+  const uint8_t *data = (const uint8_t *)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  const uint64_t *blocks = (const uint64_t *)(data);
+
+  int i;
+  for (i = 0; i < nblocks; i++) {
+    uint64_t k1 = blocks[i * 2 + 0];
+    uint64_t k2 = blocks[i * 2 + 1];
+
+    k1 *= c1;
+    k1 = ROTL64(k1, 31);
+    k1 *= c2;
+    h1 ^= k1;
+    h1 = ROTL64(h1, 27);
+    h1 += h2;
+    h1 = h1 * 5 + 0x52dce729;
+
+    k2 *= c2;
+    k2 = ROTL64(k2, 33);
+    k2 *= c1;
+    h2 ^= k2;
+    h2 = ROTL64(h2, 31);
+    h2 += h1;
+    h2 = h2 * 5 + 0x38495ab5;
+  }
+
+  const uint8_t *tail = (const uint8_t *)(data + nblocks * 16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch (len & 15) {
+  case 15:
+    k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14:
+    k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13:
+    k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12:
+    k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11:
+    k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10:
+    k2 ^= ((uint64_t)tail[9]) << 8;
+  case 9:
+    k2 ^= ((uint64_t)tail[8]) << 0;
+    k2 *= c2;
+    k2 = ROTL64(k2, 33);
+    k2 *= c1;
+    h2 ^= k2;
+
+  case 8:
+    k1 ^= ((uint64_t)tail[7]) << 56;
+  case 7:
+    k1 ^= ((uint64_t)tail[6]) << 48;
+  case 6:
+    k1 ^= ((uint64_t)tail[5]) << 40;
+  case 5:
+    k1 ^= ((uint64_t)tail[4]) << 32;
+  case 4:
+    k1 ^= ((uint64_t)tail[3]) << 24;
+  case 3:
+    k1 ^= ((uint64_t)tail[2]) << 16;
+  case 2:
+    k1 ^= ((uint64_t)tail[1]) << 8;
+  case 1:
+    k1 ^= ((uint64_t)tail[0]) << 0;
+    k1 *= c1;
+    k1 = ROTL64(k1, 31);
+    k1 *= c2;
+    h1 ^= k1;
+  };
+
+  h1 ^= len;
+  h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  return h1;
+}
+
+/*
+ * MurmurHash3 the 64bit variant that hashes the pointer itself
+ */
+uint64_t hashtable_hash_ptr(const void *key, int len, uint32_t seed) {
+  const int nblocks = len / 4;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  int i;
+  for (i = 0; i < nblocks; i++) {
+    uint64_t k1 = ((uintptr_t)key >> (2 * i)) & 0xff;
+    uint64_t k2 = ROTL64(k1, 13);
+
+    k1 *= c1;
+    k1 = ROTL64(k1, 31);
+    k1 *= c2;
+    h1 ^= k1;
+    h1 = ROTL64(h1, 27);
+    h1 += h2;
+    h1 = h1 * 5 + 0x52dce729;
+
+    k2 *= c2;
+    k2 = ROTL64(k2, 33);
+    k2 *= c1;
+    h2 ^= k2;
+    h2 = ROTL64(h2, 31);
+    h2 += h1;
+    h2 = h2 * 5 + 0x38495ab5;
+  }
+
+  /* Since the pointers are power of two length
+   * we don't need a tail mix */
+
+  h1 ^= len;
+  h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  return h1;
+}
+
+/*****************************************************************************
+ *
+ *                            -- 32bit --
+ *
+ ****************************************************************************/
+#else
+
+FORCE_INLINE uint32_t fmix32(uint32_t h) {
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+/**
+ * MurmurHash3 the 32bit variant.
+ */
+size_t hashtable_hash(const void *key, int len, uint32_t seed) {
+  const uint8_t *data = (const uint8_t *)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  const uint32_t *blocks = (const uint32_t *)(data + nblocks * 4);
+
+  int i;
+  for (i = -nblocks; i; i++) {
+    uint32_t k1 = blocks[i];
+
+    k1 *= c1;
+    k1 = ROTL32(k1, 15);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = ROTL32(h1, 13);
+    h1 = h1 * 5 + 0xe6546b64;
+  }
+
+  const uint8_t *tail = (const uint8_t *)(data + nblocks * 4);
+
+  uint32_t k1 = 0;
+
+  switch (len & 3) {
+  case 3:
+    k1 ^= tail[2] << 16;
+  case 2:
+    k1 ^= tail[1] << 8;
+  case 1:
+    k1 ^= tail[0];
+    k1 *= c1;
+    k1 = ROTL32(k1, 15);
+    k1 *= c2;
+    h1 ^= k1;
+  };
+
+  h1 ^= len;
+  h1 = fmix32(h1);
+
+  return (size_t)h1;
+}
+
+/*
+ * MurmurHash3 the 32bit variant that hashes the pointer itself
+ */
+size_t hashtable_hash_ptr(const void *key, int len, uint32_t seed) {
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  int i;
+  for (i = 0; i < nblocks; i++) {
+    uint32_t k1 = ((uintptr_t)key >> (2 * i)) & 0xff;
+
+    k1 *= c1;
+    k1 = ROTL32(k1, 15);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = ROTL32(h1, 13);
+    h1 = h1 * 5 + 0xe6546b64;
+  }
+
+  /* Since the pointers are power of two length
+   * we don't need a tail mix */
+
+  h1 ^= len;
+  h1 = fmix32(h1);
+
+  return (size_t)h1;
+}
+
+#endif /* ARCH_64 */

--- a/test/c/collections-c/normal/src/list.c
+++ b/test/c/collections-c/normal/src/list.c
@@ -1,0 +1,1946 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "list.h"
+
+struct list_s {
+  size_t size;
+  Node *head;
+  Node *tail;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static void *unlinkn(List *list, Node *node);
+static bool unlinkn_all(List *list, void (*cb)(void *));
+static void link_behind(Node *node, Node *inserted);
+static void link_after(Node *base, Node *inserted);
+static void swap(Node *n1, Node *n2);
+static void swap_adjacent(Node *n1, Node *n2);
+static void splice_between(List *list1, List *list2, Node *left, Node *right);
+static bool link_all_externally(List *l, Node **h, Node **t);
+static Node *get_node(List *list, void *element);
+static enum cc_stat get_node_at(List *list, size_t index, Node **out);
+static enum cc_stat add_all_to_empty(List *l1, List *l2);
+
+/**
+ * Initializes the fields of the ListConf struct to default values.
+ *
+ * @param[in] conf the configuration struct that is being initialized
+ */
+void list_conf_init(ListConf *conf) {
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Creates a new empty list and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created List is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if
+ * the memory allocation for the new List failed.
+ */
+enum cc_stat list_new(List **out) {
+  ListConf lc;
+  list_conf_init(&lc);
+  return list_new_conf(&lc, out);
+}
+
+/**
+ * Creates a new empty list based on the specified ListConf struct and
+ * returns a status code.
+ *
+ * The List is allocated using the allocators specified in the ListConf
+ * struct. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf List configuration struct. All fields must be
+ *                 initialized to appropriate values.
+ * @param[out] out Pointer to where the newly created List is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new List structure failed.
+ */
+enum cc_stat list_new_conf(ListConf const *const conf, List **out) {
+  List *list = conf->mem_calloc(1, sizeof(List));
+
+  if (!list)
+    return CC_ERR_ALLOC;
+
+  list->mem_alloc = conf->mem_alloc;
+  list->mem_calloc = conf->mem_calloc;
+  list->mem_free = conf->mem_free;
+
+  *out = list;
+  return CC_OK;
+}
+
+/**
+ * Destroys the list structure, but leaves the data that it holds intact.
+ *
+ * @param[in] list list that is to be destroyed
+ */
+void list_destroy(List *list) {
+  if (list->size > 0)
+    list_remove_all(list);
+
+  list->mem_free(list);
+}
+
+/**
+ * Destroys the list structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a list that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] list list that is to be destroyed
+ */
+void list_destroy_cb(List *list, void (*cb)(void *)) {
+  list_remove_all_cb(list, cb);
+  list->mem_free(list);
+}
+
+/**
+ * Adds a new element to the list. The element is appended to the list making it
+ * the last element in the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add(List *list, void *element) {
+  return list_add_last(list, element);
+}
+
+/**
+ * Prepends a new element to the list (adds a new "head") making it the first
+ * element of the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being prepended
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add_first(List *list, void *element) {
+  Node *node = list->mem_calloc(1, sizeof(Node));
+
+  if (node == NULL)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    node->next = list->head;
+    list->head->prev = node;
+    list->head = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Appends a new element to the list (adds an new "tail") making it the last
+ * element of the list.
+ *
+ * @param[in] list list to which the element is being added
+ * @param[in] element element being appended
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat list_add_last(List *list, void *element) {
+  Node *node = list->mem_calloc(1, sizeof(Node));
+
+  if (node == NULL)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    node->prev = list->tail;
+    list->tail->next = node;
+    list->tail = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Adds a new element at the specified location in the List and shifts all
+ * subsequent elements by one. This operation cannot be performed on an empty
+ * List. The index at which the new element is being added must be within the
+ * bounds of the List.
+ *
+ * @param[in] list list to which this element is being added
+ * @param[in] element element that is being added
+ * @param[in] index the position in the list at which the new element is being
+ *                  added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, or CC_ERR_ALLOC if the memory
+ * allocation for the new element failed.
+ */
+enum cc_stat list_add_at(List *list, void *element, size_t index) {
+  Node *base;
+  enum cc_stat stat = get_node_at(list, index, &base);
+
+  if (stat != CC_OK)
+    return stat;
+
+  Node *new = list->mem_calloc(1, sizeof(Node));
+
+  if (!new)
+    return CC_ERR_ALLOC;
+
+  new->data = element;
+  link_behind(base, new);
+
+  if (index == 0)
+    list->head = new;
+
+  list->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Adds all elements from the second list to the first. The elements from the
+ * second list are added after the last element of the first list.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ *
+ * @return CC_OK if the elements where successfully added, or CC_ERR_ALLOC if
+ * the memory allocation for the new elements failed.
+ */
+enum cc_stat list_add_all(List *list1, List *list2) {
+  if (list1->size == 0)
+    return add_all_to_empty(list1, list2);
+
+  return list_add_all_at(list1, list2, list1->size);
+}
+
+/**
+ * Adds all elements from the second list to the first list which is empty.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ *
+ * @return CC_OK if the element were successfully added, or CC_ERR_ALLOC if
+ * the memory allocation for the new elements failed.
+ */
+static enum cc_stat add_all_to_empty(List *list1, List *list2) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  Node *head = NULL;
+  Node *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  list1->head = head;
+  list1->tail = tail;
+  list1->size = list2->size;
+  return CC_OK;
+}
+
+/**
+ * Adds all elements from the second list to the first at the specified position
+ * by shifting all subsequent elements by the size of the second list. The index
+ * range at which the elements can be added ranges from 0 to max_index + 1.
+ *
+ * @param[in] list1 list to which the elements are being added
+ * @param[in] list2 list from which the elements are being taken
+ * @param[in] index position in the first list at which the element should be
+ *                  added
+ *
+ * @return CC_OK if the elements were successfully added,
+ * CC_ERR_INDEX_OUT_OF_BOUNDS if the index was out of range, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat list_add_all_at(List *list1, List *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (index > list1->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  /* Link the new nodes together outside of the list so
+     that if anything goes wrong we don't have to leave
+     garbage in the actual list. */
+  Node *head = NULL;
+  Node *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  /* Now we can safely attach the new nodes. */
+  Node *end = NULL;
+  get_node_at(list1, index, &end);
+
+  Node *base = NULL;
+  if (end)
+    base = end->prev;
+  else
+    get_node_at(list1, index - 1, &base);
+
+  if (!end) {
+    list1->tail->next = head;
+    head->prev = list1->tail;
+    list1->tail = tail;
+  } else if (!base) {
+    list1->head->prev = tail;
+    tail->next = list1->head;
+    list1->head = head;
+  } else {
+    head->prev = base;
+    base->next = head;
+    tail->next = end;
+    end->prev = tail;
+  }
+
+  list1->size += list2->size;
+
+  return CC_OK;
+}
+
+/**
+ * Duplicates the structure of the list without directly attaching it to a
+ * specific list. If the operation fails, the mess is cleaned up and false
+ * is returned to indicate failure.
+ *
+ * @param[in] list the list whose structure is being duplicated
+ * @param[in, out] h the pointer to which the new head will be attached
+ * @param[in, out] t the pointer to which the new tail will be attached
+ *
+ * @return true if the operation was successful, false otherwise.
+ */
+static bool link_all_externally(List *list, Node **h, Node **t) {
+  Node *insert = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    Node *new = list->mem_calloc(1, sizeof(Node));
+
+    if (!new) {
+      while (*h) {
+        Node *tmp = (*h)->next;
+        list->mem_free(*h);
+        *h = tmp;
+      }
+      return false;
+    }
+
+    new->data = insert->data;
+
+    if (!*h) {
+      *h = new;
+      *t = new;
+    } else {
+      (*t)->next = new;
+      new->prev = *t;
+      *t = new;
+    }
+
+    insert = insert->next;
+  }
+  return true;
+}
+
+/**
+ * Splices the two doubly linked lists together by appending the second list to
+ * the first. This function moves all elements from the second list into the
+ * first list, leaving the second list empty.
+ *
+ * @param[in] list1 the consumer list to which the elements are moved
+ * @param[in] list2 the producer list from which the elements are moved
+ *
+ * @return CC_OK if the elements were successfully moved, or CC_ERR_OUT_OF_RANGE
+ * if the index was not in range.
+ */
+enum cc_stat list_splice(List *list1, List *list2) {
+  return list_splice_at(list1, list2, list1->size);
+}
+
+/**
+ * Splices the two lists together at the specified index of the first list. This
+ * function moves all elements from the second list into the first list at the
+ * position specified by the <code>index</code> parameter. After this operation
+ * the second list will be left empty.
+ *
+ * @param[in] list1 the consumer list to which the elements are moved
+ * @param[in] list2 the producer list from which the elements are moved
+ * @param[in] index the index in the first list after which the elements from
+ * the second list should be inserted
+ *
+ * @return CC_OK if the elements were successfully moved, or CC_ERR_OUT_OF_RANGE
+ * if the index was not in range.
+ */
+enum cc_stat list_splice_at(List *list1, List *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (index > list1->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  if (list1->size == 0) {
+    // TODO move to splice_between
+    list1->head = list2->head;
+    list1->tail = list2->tail;
+    list1->size = list2->size;
+
+    list2->head = NULL;
+    list2->tail = NULL;
+    list2->size = 0;
+    return CC_OK;
+  }
+
+  Node *end = NULL;
+  get_node_at(list1, index, &end);
+
+  Node *base = NULL;
+  if (end)
+    base = end->prev;
+  else
+    get_node_at(list1, index - 1, &base);
+
+  splice_between(list1, list2, base, end);
+
+  return CC_OK;
+}
+
+/**
+ * Inserts the second list between the two nodes of the first list. If the left
+ * node is NULL, the head of the second list will become the head of the first
+ * list. Similarly, if the right node is null, the tail of the first list will
+ * become the tail of the second list.
+ *
+ * @param[in, out] l1 the list to which the elements are being transferred
+ * @param[in, out] l2 the list from which the elements are being transferred
+ * @param[in] left the node after which the element are being added
+ * @param[in] right the node behind which the elements are being added
+ */
+static void splice_between(List *l1, List *l2, Node *left, Node *right) {
+  if (!left) {
+    l1->head->prev = l2->tail;
+    l2->tail->next = l1->head;
+    l1->head = l2->head;
+  } else if (!right) {
+    l1->tail->next = l2->head;
+    l2->head->prev = l1->tail;
+    l1->tail = l2->tail;
+  } else {
+    left->next = l2->head;
+    l2->head->prev = left;
+    right->prev = l2->tail;
+    l2->tail->next = right;
+  }
+  l1->size += l2->size;
+
+  l2->head = NULL;
+  l2->tail = NULL;
+  l2->size = 0;
+}
+
+/**
+ * Removes the first occurrence of the element from the specified List
+ * and optionally sets the out parameter to the value of the removed
+ * element.
+ *
+ * @param[in] list list from which the element is being removed
+ * @param[in] element element that is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat list_remove(List *list, void *element, void **out) {
+  Node *node = get_node(list, element);
+
+  if (!node)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  if (out)
+    *out = node->data;
+
+  unlinkn(list, node);
+  return CC_OK;
+}
+
+/**
+ * Removes the element at the specified index and optionally sets the out
+ * parameter to the value of the removed element. The index must be
+ * within the bounds of the list.
+ *
+ * @param[in] list List from which the element is being removed.
+ * @param[in] index Index of the element is being removed. Must be be within the
+ *            index range of the list.
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored.
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat list_remove_at(List *list, size_t index, void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status != CC_OK)
+    return status;
+
+  if (out)
+    *out = node->data;
+
+  unlinkn(list, node);
+  return CC_OK;
+}
+
+/**
+ * Removes and returns the first (head) element of the list and optionally sets
+ * the out parameter to the value of the removed element.
+ *
+ * @param[in] list list from which the first element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the List is already empty.
+ */
+enum cc_stat list_remove_first(List *list, void **out) {
+  if (!list->size)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(list, list->head);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and returns the last (tail) element of the list and optionally sets
+ * the out parameter to the value of the removed element.
+ *
+ * @param[in] list list from which the last element is being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the List is already empty.
+ */
+enum cc_stat list_remove_last(List *list, void **out) {
+  if (!list->size)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(list, list->tail);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes all elements from the specified list.
+ *
+ * @param[in] list list from which all elements are being removed
+ *
+ * @return CC_OK if the elements were successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat list_remove_all(List *list) {
+  bool unlinked = unlinkn_all(list, NULL);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Removes and frees all elements from the specified list.
+ *
+ * @note
+ * This function should not be called on a list that has some of its elements
+ * allocated on the stack.
+ *
+ * @param[in] list list from which all the elements are being removed and
+ *            freed
+ *
+ * @return CC_OK if the elements were successfully removed and freed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat list_remove_all_cb(List *list, void (*cb)(void *)) {
+  bool unlinked = unlinkn_all(list, cb);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Replaces an element at the specified location and optionally sets the
+ * out parameter to the value of the replaced element. The specified index
+ * must be within the bounds of the list.
+ *
+ * @param[in] list list on which this operation is performed
+ * @param[in] element the replacement element
+ * @param[in] index index of the element that is being replaced
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat list_replace_at(List *list, void *element, size_t index,
+                             void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status == CC_OK) {
+    void *old = node->data;
+    node->data = element;
+    if (out)
+      *out = old;
+  }
+
+  return status;
+}
+
+/**
+ * Gets the first element from the specified list and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list list whose first element is being returned
+ * @param[in] out  pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat list_get_first(List *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->head->data;
+  return CC_OK;
+}
+
+/**
+ * Gets the last element from the specified list and sets the parameter to
+ * its value.
+ *
+ * @param[in] list list whose last element is being returned
+ * @param[in] out  pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat list_get_last(List *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->tail->data;
+  return CC_OK;
+}
+
+/**
+ * Gets the list element from the specified index and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list  List from which the element is being returned.
+ * @param[in] index The index of a list element being returned. The index must
+ *                  be within the bound of the list.
+ * @param[out] out  Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat list_get_at(List *list, size_t index, void **out) {
+  Node *node;
+  enum cc_stat status = get_node_at(list, index, &node);
+
+  if (status == CC_OK)
+    *out = node->data;
+
+  return status;
+}
+
+/**
+ * Reverses the order of elements in the specified list.
+ *
+ * @param[in] list list that is being reversed
+ */
+void list_reverse(List *list) {
+  if (list->size == 0 || list->size == 1)
+    return;
+
+  Node *head_old = list->head;
+  Node *tail_old = list->tail;
+
+  Node *left = list->head;
+  Node *right = list->tail;
+
+  size_t i;
+  for (i = 0; i < list->size / 2; i++) {
+    Node *tmpl = left->next;
+    Node *tmpr = right->prev;
+
+    swap(left, right);
+
+    left = tmpl;
+    right = tmpr;
+  }
+
+  list->head = tail_old;
+  list->tail = head_old;
+}
+
+/**
+ * Creates a sublist of the specified List. The created sublist contains all
+ * the elements from the List that are contained between the two indices
+ * including the elements at the indices. For example, if a list contains 5
+ * elements [5, 6, 7, 8, 9], a sublist from index 1 to 3 will will be a new
+ * List of length 3, containing [6, 7, 8]. The returned sublist is only a copy
+ * of the original lists structure, meaning the data it points to is not copied.
+ *
+ * @param[in] list List from which the sublist is taken.
+ * @param[in] b    The beginning index, i.e., the first element to be included.
+ *                 Must be a positive integer and may not exceed the list size
+ *                 or the end index.
+ * @param[in] e    The ending index, i.e., the last element to be included. Must
+ *                 be a positive integer no greater than the list size and no
+ *                 smaller that the beginning index.
+ * @param[out] out Pointer to where the new sublist is stored.
+ *
+ * @return CC_OK if the sublist was successfully created, CC_ERR_INVALID_RANGE
+ * if the specified index range is invalid, or CC_ERR_ALLOC if the memory
+ * allocation for the new sublist failed.
+ */
+enum cc_stat list_sublist(List *list, size_t b, size_t e, List **out) {
+  if (b > e || e >= list->size)
+    return CC_ERR_INVALID_RANGE;
+
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *sub;
+  enum cc_stat status = list_new_conf(&conf, &sub);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node;
+  status = get_node_at(list, b, &node);
+
+  if (status != CC_OK) {
+    list->mem_free(sub);
+    return status;
+  }
+
+  size_t i;
+  for (i = b; i <= e; i++) {
+    status = list_add(sub, node->data);
+    if (status != CC_OK) {
+      list_destroy(sub);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = sub;
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified list. A shallow copy is a copy of the
+ * list structure. This operation does not copy the actual data that this list
+ * holds.
+ *
+ * @note The new list is allocated using the original lists allocators and also
+ *       inherits the configuration of the original list.
+ *
+ * @param[in] list list to be copied
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat list_copy_shallow(List *list, List **out) {
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *copy;
+  enum cc_stat status = list_new_conf(&conf, &copy);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  if (!node) {
+    *out = copy;
+    return CC_OK;
+  }
+  while (node) {
+    status = list_add(copy, node->data);
+    if (status != CC_OK) {
+      list_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified list. This functions copies the
+ * structure of the list along with all the data it holds. The element copying
+ * is done through the specified copy function that should return a pointer to
+ * the copy of the element passed to it.
+ *
+ * @param[in] list list to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data
+ * @param[out] out pointer to where the newly created copy is stored
+ *
+ * @return  CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat list_copy_deep(List *list, void *(*cp)(void *e1), List **out) {
+  ListConf conf;
+
+  conf.mem_alloc = list->mem_alloc;
+  conf.mem_calloc = list->mem_calloc;
+  conf.mem_free = list->mem_free;
+
+  List *copy;
+  enum cc_stat status = list_new_conf(&conf, &copy);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  if (!node) {
+    *out = copy;
+    return CC_OK;
+  }
+
+  while (node) {
+    status = list_add(copy, cp(node->data));
+    if (status != CC_OK) {
+      list_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates an array representation of the specified list. None of the elements
+ * are copied into the array and thus any modification of the elements within
+ * the array will affect the list elements as well. The size of the created
+ * array is the same as the size of the list from which this array was
+ * constructed.
+ *
+ * @param[in] list list on which this operation is being performed
+ * @param[out] out pointer to where the newly created array is stored
+ *
+ * @return CC_OK if the array was successfully created, CC_ERR_INVALID_RANGE if
+ * the list is emtpy, or CC_ERR_ALLOC if the memory allocation for the new array
+ * failed.
+ */
+enum cc_stat list_to_array(List *list, void ***out) {
+  if (list->size == 0)
+    return CC_ERR_INVALID_RANGE;
+
+  void **array = list->mem_calloc(list->size, sizeof(void *));
+
+  if (!array)
+    return CC_ERR_ALLOC;
+
+  Node *node = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    array[i] = node->data;
+    node = node->next;
+  }
+  *out = array;
+  return CC_OK;
+}
+
+/**
+ * Returns an integer representing the number of occurrences of the specified
+ * element within the list.
+ *
+ * @param[in] list list on which the search is performed
+ * @param[in] element element being searched for
+ *
+ * @return number of matches found.
+ */
+size_t list_contains(List *list, void *element) {
+  Node *node = list->head;
+  size_t e_count = 0;
+
+  while (node) {
+    if (node->data == element)
+      e_count++;
+    node = node->next;
+  }
+  return e_count;
+}
+
+/**
+ * Returns the number occurrences of the value pointed to by
+ * <code>element</code> within the List.
+ *
+ * @param[in] list list on which the search is performed
+ * @param[in] element element being searched for
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ *                are equal
+ *
+ * @return number of matches found.
+ */
+size_t list_contains_value(List *list, void *element,
+                           int (*cmp)(const void *, const void *)) {
+  Node *node = list->head;
+  size_t e_count = 0;
+
+  while (node) {
+    if (cmp(node->data, element) == 0)
+      e_count++;
+    node = node->next;
+  }
+  return e_count;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of
+ * the list.
+ *
+ * @param[in] list list on which this operation is performed
+ * @param[in] element the element whose index is being looked up
+ * @param[in] cmp comparator function which returns 0 if the values passed to it
+ *                are equal
+ * @param[out] index pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat list_index_of(List *list, void *element,
+                           int (*cmp)(const void *, const void *),
+                           size_t *index) {
+  Node *node = list->head;
+  size_t i = 0;
+
+  while (node) {
+    if (cmp(node->data, element) == 0) {
+      *index = i;
+      return CC_OK;
+    }
+    i++;
+    node = node->next;
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Returns the number of elements in the specified list.
+ *
+ * @param[in] list list whose size is being returned
+ *
+ * @return the number of the elements contained in the specified list.
+ */
+size_t list_size(List *list) { return list->size; }
+
+/**
+ * Sorts the specified list. This function makes no guaranties that the
+ * sort will be performed in place or in a stable way.
+ *
+ * @note Pointers passed to the comparator function will be pointers to
+ *       the list elements that are of type (void*), i.e. void**. So an
+ *       extra step of dereferencing will be required before the data can
+ *       be used for comparison:
+ *       e.g. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @param[in] list list to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                int cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ *
+ * @return CC_OK if the sort was performed successfully, or CC_ERR_ALLOC
+ * if it could not allocate enough memory to perform the sort.
+ */
+enum cc_stat list_sort(List *list, int (*cmp)(void const *e1, void const *e2)) {
+  void **elements;
+  enum cc_stat status = list_to_array(list, &elements);
+
+  if (status != CC_OK)
+    return status;
+
+  Node *node = list->head;
+
+  qsort(elements, list->size, sizeof(void *), cmp);
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    node->data = elements[i];
+    node = node->next;
+  }
+  list->mem_free(elements);
+  return CC_OK;
+}
+
+static Node *split(List *, Node *b, size_t l,
+                   int (*cmp)(void const *e1, void const *e2));
+static void merge(Node **, Node **, size_t, size_t,
+                  int (*cmp)(void const *e1, void const *e2));
+
+/**
+ * Sorts the specified list in place in a stable way.
+ *
+ * @note Pointers passed to the comparator function will be pointers to the list
+ *       elements that are of type (void*), i.e. void**. So an extra step of
+ *       dereferencing will be required before the data can be used for
+ * comparison: e.g. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @param[in] list list to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                int cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first
+ */
+void list_sort_in_place(List *list,
+                        int (*cmp)(void const *e1, void const *e2)) {
+  split(list, list->head, list->size, cmp);
+}
+
+/**
+ * Splits the list section into two partitions.
+ *
+ * @param[in] list the sublist
+ * @param[in] b    the head node of the sublist
+ * @param[in] size number of nodes in the sublist
+ * @param[in] cmp  comparator function
+ *
+ * @return
+ */
+static Node *split(List *list, Node *b, size_t size,
+                   int (*cmp)(void const *, void const *)) {
+  if (size < 2)
+    return b;
+
+  size_t l_size = size / 2;
+  size_t r_size = size / 2 + (size % 2);
+
+  Node *center = b;
+
+  size_t i;
+  for (i = 0; i < l_size; i++)
+    center = center->next;
+
+  Node *l_head = split(list, b, l_size, cmp);
+  Node *r_head = split(list, center, r_size, cmp);
+
+  merge(&l_head, &r_head, l_size, r_size, cmp);
+
+  list->head = l_head;
+  list->tail = r_head;
+
+  return l_head;
+}
+
+/**
+ * Merges the two partitions together in place in a stable way. The left
+ * partition starts at the "left" node and ends "l_size" nodes to the right of
+ *it. Similarly the right partition starts at the "right" and ends "r_size"
+ *nodes to the right. Both "left" and "right" parameters are used for input and
+ * output. As an output parameter the "left" parameter will be assigned as the
+ * head node of the newly merged section, while the "right" parameter will be
+ * assigned the tail after the merge. The result of this function is a sorted
+ * section of the list in an ascending order.
+ *
+ *@param[in, out] left   the beginning of the left partition as input and the
+ *                       the head node of the merged section as the output
+ *@param[in, out] right  the beginning of the right partition as input and the
+ *                       the tail node of the merged section as the output
+ *@param[in]      l_size size of the the left partition
+ *@param[in]      r_size size of the right partition
+ *@param[in]      cmp    the comparator function
+ */
+static INLINE void merge(Node **left, Node **right, size_t l_size,
+                         size_t r_size,
+                         int (*cmp)(void const *, void const *)) {
+  size_t size = r_size + l_size;
+  size_t l = 0; /* Number of processed elements from the left partition */
+  size_t r = 0; /* NUmber of processed elements from the right partition. */
+
+  Node *l_part = *left;
+  Node *r_part = *right;
+
+  size_t i;
+  for (i = 0; i < size; i++) {
+    int c = cmp(&(l_part->data), &(r_part->data));
+
+    if ((c < 0 || c == 0)) {
+      /* The two partitions are already sorted. */
+      if (i == 0 && size == 2) {
+        break;
+      }
+      /* If all the elements on the left side are in place,
+         all the elements on the right must be as well. */
+      if (l == l_size) {
+        /* Quickly advance the right pointer to the end for
+         * the remainder of r and exit.*/
+        for (; r < r_size - 1; r++)
+          r_part = r_part->next;
+        *right = r_part;
+        break;
+      }
+      l_part = l_part->next;
+      l++;
+    } else {
+      Node *tmp = (r_part)->next;
+      link_behind(l_part, r_part);
+      /* The elements are swapped. Now set head and tail and
+       * exit the loop. */
+      if (i == 0 && size == 2) {
+        *right = l_part;
+        *left = r_part;
+        break;
+      }
+      r++;
+      /* All right partition elements are now behind the left
+       * partition elements.*/
+      if (r == r_size) {
+        /* Quickly advance the left partition pointer and set
+         * the rightmost element as the new head. */
+        for (; l < l_size - 1; l++)
+          l_part = l_part->next;
+        *right = l_part;
+        break;
+      }
+      if (i == 0) {
+        *left = r_part;
+      }
+      r_part = tmp;
+    }
+  }
+}
+
+/**
+ * A 'foreach loop' function that invokes the specified function on each element
+ * in the list.
+ *
+ * @param[in] list list on which this operation is being performed
+ * @param[in] op the operation function that is to be invoked on each list
+ *               element
+ */
+void list_foreach(List *list, void (*op)(void *e)) {
+  Node *n = list->head;
+
+  while (n) {
+    op(n->data);
+    n = n->next;
+  }
+}
+
+/**
+ * Filters the List by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] list list that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the List
+ *
+ * @return CC_OK if the list was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the List is empty.
+ */
+enum cc_stat list_filter_mut(List *list, bool (*pred)(const void *)) {
+  if (list_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  Node *curr = list->head;
+  Node *next = NULL;
+
+  while (curr) {
+    next = curr->next;
+
+    if (!pred(curr->data)) {
+      unlinkn(list, curr);
+    }
+    curr = next;
+  }
+
+  return CC_OK;
+}
+
+/**
+ * Filters the List by creating a new List that contains all elements from the
+ * original List that return true on pred(element) without modifying the
+ * original list.
+ *
+ * @param[in] list list that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the filtered list
+ * @param[out] out pointer to where the new filtered list is to be stored
+ *
+ * @return CC_OK if the list was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the list is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new list failed.
+ */
+enum cc_stat list_filter(List *list, bool (*pred)(const void *), List **out) {
+  if (list_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  List *filtered = NULL;
+  list_new(&filtered);
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  Node *curr = list->head;
+
+  while (curr) {
+    if (pred(curr->data)) {
+      list_add(filtered, curr->data);
+    }
+    curr = curr->next;
+  }
+
+  *out = filtered;
+
+  return CC_OK;
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] list list to iterate over
+ */
+void list_iter_init(ListIter *iter, List *list) {
+  iter->index = 0;
+  iter->list = list;
+  iter->last = NULL;
+  iter->next = list->head;
+}
+
+/**
+ * Removes the last returned element by <code>list_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_iter_remove(ListIter *iter, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(iter->list, iter->last);
+  iter->last = NULL;
+
+  if (out)
+    *out = e;
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the list after the last returned element by
+ * <code>list_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added to the list
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat list_iter_add(ListIter *iter, void *element) {
+  Node *new_node = iter->list->mem_calloc(1, sizeof(Node));
+
+  if (!new_node)
+    return CC_ERR_ALLOC;
+
+  new_node->data = element;
+
+  link_after(iter->last, new_node);
+
+  if (iter->index == iter->list->size)
+    iter->list->tail = new_node;
+
+  iter->list->size++;
+  iter->index++;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element by <code>list_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_iter_replace(ListIter *iter, void *element, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old = iter->last->data;
+  iter->last->data = element;
+
+  if (out)
+    *out = old;
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element by <code>list_iter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is performed
+ *
+ * @return the index.
+ */
+size_t list_iter_index(ListIter *iter) { return iter->index - 1; }
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the list has been reached.
+ */
+enum cc_stat list_iter_next(ListIter *iter, void **out) {
+  if (!iter->next)
+    return CC_ITER_END;
+
+  void *data = iter->next->data;
+  iter->last = iter->next;
+  iter->next = iter->next->next;
+  iter->index++;
+
+  *out = data;
+
+  return CC_OK;
+}
+
+/**
+ * Returns a new descending iterator. A descending iterator or a reverse
+ * iterator, is an iterator that traverses the list from tail to head.
+ *
+ * @param[in] iter the iterator
+ * @param[in] list list on which this iterator will operate
+ */
+void list_diter_init(ListIter *iter, List *list) {
+  iter->index = list->size;
+  iter->list = list;
+  iter->last = NULL;
+  iter->next = list->tail;
+}
+
+/**
+ * Adds a new element to the list after the last returned element by
+ * <code>list_diter_next()</code> function (or before the element in
+ * the list) without invalidating the  iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added to the list
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat list_diter_add(ListIter *iter, void *element) {
+  Node *new_node = iter->list->mem_calloc(1, sizeof(Node));
+
+  if (!new_node)
+    return CC_ERR_ALLOC;
+
+  new_node->data = element;
+
+  if (iter->index == 0)
+    iter->list->head = new_node;
+
+  link_behind(iter->last, new_node);
+
+  iter->list->size++;
+  iter->last = new_node;
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>list_diter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_diter_remove(ListIter *iter, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(iter->list, iter->last);
+  iter->last = NULL;
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element by <code>list_diter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_diter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_diter_replace(ListIter *iter, void *element, void **out) {
+  if (!iter->last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old = iter->last->data;
+  iter->last->data = element;
+
+  if (out)
+    *out = old;
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element by <code>list_diter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index.
+ */
+size_t list_diter_index(ListIter *iter) { return iter->index - 1; }
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the list has been reached.
+ */
+enum cc_stat list_diter_next(ListIter *iter, void **out) {
+  if (!iter->next)
+    return CC_ITER_END;
+
+  void *data = iter->next->data;
+  iter->last = iter->next;
+  iter->next = iter->next->prev;
+  iter->index--;
+
+  *out = data;
+
+  return CC_OK;
+}
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] l1   first list
+ * @param[in] l2   second list
+ */
+void list_zip_iter_init(ListZipIter *iter, List *l1, List *l2) {
+  iter->index = 0;
+  iter->l1 = l1;
+  iter->l2 = l2;
+  iter->l1_last = NULL;
+  iter->l2_last = NULL;
+  iter->l1_next = l1->head;
+  iter->l2_next = l2->head;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first list element
+ * @param[out] out2 output of the second list element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the lists has been reached.
+ */
+enum cc_stat list_zip_iter_next(ListZipIter *iter, void **out1, void **out2) {
+  if (!iter->l1_next || !iter->l2_next)
+    return CC_ITER_END;
+
+  void *data1 = iter->l1_next->data;
+  void *data2 = iter->l2_next->data;
+
+  iter->l1_last = iter->l1_next;
+  iter->l2_last = iter->l2_next;
+  iter->l1_next = iter->l1_next->next;
+  iter->l2_next = iter->l2_next->next;
+  iter->index++;
+
+  *out1 = data1;
+  *out2 = data2;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element pair to the lists after the last returned element pair by
+ * <code>list_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>list_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ * @param[in] e1   element added to the first list
+ * @param[in] e2   element added to the second list
+ *
+ * @return CC_OK if the element pair was successfully added to the lists, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat list_zip_iter_add(ListZipIter *iter, void *e1, void *e2) {
+  Node *new_node1 = iter->l1->mem_calloc(1, sizeof(Node));
+
+  if (!new_node1)
+    return CC_ERR_ALLOC;
+
+  Node *new_node2 = iter->l2->mem_calloc(1, sizeof(Node));
+
+  if (!new_node2) {
+    iter->l1->mem_free(new_node1);
+    return CC_ERR_ALLOC;
+  }
+
+  new_node1->data = e1;
+  new_node2->data = e2;
+
+  link_after(iter->l1_last, new_node1);
+  link_after(iter->l2_last, new_node2);
+
+  if (iter->index == iter->l1->size)
+    iter->l1->tail = new_node1;
+
+  if (iter->index == iter->l2->size)
+    iter->l2->tail = new_node2;
+
+  iter->l1->size++;
+  iter->l2->size++;
+  iter->index++;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>list_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[out] out1 output of the removed element from the first List
+ * @param[out] out2 output of the removed element from the second List
+ *
+ * @return CC_OK if the element was removed successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_zip_iter_remove(ListZipIter *iter, void **out1, void **out2) {
+  if (!iter->l1_last || !iter->l2_last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e1 = unlinkn(iter->l1, iter->l1_last);
+  void *e2 = unlinkn(iter->l2, iter->l2_last);
+
+  iter->l1_last = NULL;
+  iter->l2_last = NULL;
+
+  if (out1)
+    *out1 = e1;
+
+  if (out2)
+    *out2 = e2;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>list_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @note This function should only ever be called after a call to
+ *       <code>list_zip_iter_next()</code>.
+ *
+ * @param[in]  iter iterator on which this operation is being performed
+ * @param[in]  e1   first list's replacement element
+ * @param[in]  e2   second list's replacement element
+ * @param[out] out1 output of the replaced element from the first list
+ * @param[out] out2 output of the replaced element from the second list
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat list_zip_iter_replace(ListZipIter *iter, void *e1, void *e2,
+                                   void **out1, void **out2) {
+  if (!iter->l1_last || !iter->l2_last)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old1 = iter->l1_last->data;
+  void *old2 = iter->l2_last->data;
+
+  iter->l1_last->data = e1;
+  iter->l2_last->data = e2;
+
+  if (out1)
+    *out1 = old1;
+
+  if (out2)
+    *out2 = old2;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>list_zip_iter_next()</code>.
+ *
+ * @param[in] iter iterator on which this operation is being performed
+ *
+ * @return current iterator index.
+ */
+size_t list_zip_iter_index(ListZipIter *iter) { return iter->index - 1; }
+
+/**
+ * Links the <code>ins</code> node behind the <code>base</code> node.
+ *
+ * @param[in] base the node behind which the <code>ins</code> is going to be
+ *                 linked
+ * @param[in] ins  the node that is being linked behind the <code>base</code>
+ *                 node
+ */
+static void link_behind(Node *const base, Node *ins) {
+  /* link the gap */
+  if (ins->next != NULL)
+    ins->next->prev = ins->prev;
+
+  if (ins->prev != NULL)
+    ins->prev->next = ins->next;
+
+  /* link behind */
+  if (base->prev == NULL) {
+    ins->prev = NULL;
+    ins->next = base;
+    base->prev = ins;
+  } else {
+    ins->prev = base->prev;
+    ins->prev->next = ins;
+    ins->next = base;
+    base->prev = ins;
+  }
+}
+
+/**
+ * Links the <code>ins</code> in front of the <code>base</code> node.
+ *
+ * @param[in] base the node in front of which the <code>ins</code> not is going
+ *                 to be linked
+ * @param[in] ins  the node that is being linked in front the <code>base</code>
+ *                 node
+ */
+static void link_after(Node *base, Node *ins) {
+  if (ins->next)
+    ins->next->prev = ins->prev;
+
+  if (ins->prev)
+    ins->prev->next = ins->next;
+
+  if (!base->next) {
+    ins->prev = base;
+    base->next = ins;
+    ins->next = NULL;
+  } else {
+    ins->next = base->next;
+    ins->next->prev = ins;
+    ins->prev = base;
+    base->next = ins;
+  }
+}
+
+/**
+ * Swaps the list positions of the specified nodes.
+ *
+ * @param[in] n1 the first node
+ * @param[in] n2 the second node
+ */
+static void swap(Node *n1, Node *n2) {
+  /* A special case is when the nodes are next to each other */
+  if (n1->next == n2 || n2->next == n1) {
+    swap_adjacent(n1, n2);
+    return;
+  }
+
+  Node *n1_left = n1->prev;
+  Node *n1_right = n1->next;
+  Node *n2_left = n2->prev;
+  Node *n2_right = n2->next;
+
+  if (n1_left)
+    n1_left->next = n2;
+
+  n2->prev = n1_left;
+
+  if (n1_right)
+    n1_right->prev = n2;
+
+  n2->next = n1_right;
+
+  if (n2_left)
+    n2_left->next = n1;
+
+  n1->prev = n2_left;
+
+  if (n2_right)
+    n2_right->prev = n1;
+
+  n1->next = n2_right;
+}
+
+/**
+ * Swaps two adjacent nodes. This handles the special case when the nodes
+ * are adjacent to each other.
+ *
+ * @param[in] n1 the first node
+ * @param[in] n2 the second node
+ */
+static void swap_adjacent(Node *n1, Node *n2) {
+  if (n1->next == n2) {
+    if (n2->next)
+      n2->next->prev = n1;
+
+    n1->next = n2->next;
+
+    if (n1->prev)
+      n1->prev->next = n2;
+
+    n2->prev = n1->prev;
+
+    n1->prev = n2;
+    n2->next = n1;
+    return;
+  }
+
+  if (n2->next == n1) {
+    if (n1->next)
+      n1->next->prev = n2;
+
+    n2->next = n1->next;
+
+    if (n2->prev)
+      n2->prev->next = n1;
+
+    n1->prev = n2->prev;
+
+    n2->prev = n1;
+    n1->next = n2;
+    return;
+  }
+}
+
+/**
+ * Unlinks a node from the list and returns the data that was associated with
+ * it.
+ *
+ * @param[in] list the list from which the node is being unlinked
+ * @param[in] node the node being unlinked
+ *
+ * @return the data that was at this node.
+ */
+static void *unlinkn(List *list, Node *node) {
+  void *data = node->data;
+
+  if (node->prev != NULL)
+    node->prev->next = node->next;
+
+  if (node->prev == NULL)
+    list->head = node->next;
+
+  if (node->next == NULL)
+    list->tail = node->prev;
+
+  if (node->next != NULL)
+    node->next->prev = node->prev;
+
+  list->mem_free(node);
+  list->size--;
+
+  return data;
+}
+
+/**
+ * Unlinks all nodes from the list and optionally frees the data at the nodes.
+ *
+ * @param[in] list the list from which all the nodes are being unlinked
+ * @param[in] freed a bool that determines whether or not the data at the nodes
+ *                  should also be freed
+ *
+ * @return false if the list is already empty, otherwise returns true.
+ */
+static bool unlinkn_all(List *list, void (*cb)(void *)) {
+  if (list->size == 0)
+    return false;
+
+  Node *node = list->head;
+
+  while (node) {
+    Node *tmp = node->next;
+
+    if (cb)
+      cb(node->data);
+
+    unlinkn(list, node);
+    node = tmp;
+  }
+  return true;
+}
+
+/**
+ * Returns the node at the specified index.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] index the index of the node being returned
+ *
+ * @return CC_OK if the node was found, or CC_ERR_OUT_OF_RANGE if not.
+ */
+static enum cc_stat get_node_at(List *list, size_t index, Node **out) {
+  if (!list || index >= list->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  size_t i;
+  Node *node = NULL;
+
+  if (index < list->size / 2) {
+    node = list->head;
+    for (i = 0; i < index; i++)
+      node = node->next;
+  } else {
+    node = list->tail;
+    for (i = list->size - 1; i > index; i--)
+      node = node->prev;
+  }
+  *out = node;
+  return CC_OK;
+}
+
+/**
+ * Returns the first node from the beginning of the list that is associated
+ * with the specified element. If no node is associated with the element, NULL
+ * is returned instead.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] element the element whose list node is being returned
+ *
+ * @return the node associated with the specified element.
+ */
+static Node *get_node(List *list, void *element) {
+  Node *node = list->head;
+  while (node) {
+    if (node->data == element)
+      return node;
+    node = node->next;
+  }
+  return NULL;
+}

--- a/test/c/collections-c/normal/src/pqueue.c
+++ b/test/c/collections-c/normal/src/pqueue.c
@@ -1,0 +1,319 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pqueue.h"
+
+#define CC_PARENT(x) (x - 1) / 2
+#define CC_LEFT(x) 2 * x + 1
+#define CC_RIGHT(x) 2 * x + 2
+
+#define DEFAULT_CAPACITY 8
+#define DEFAULT_EXPANSION_FACTOR 2
+
+struct pqueue_s {
+  size_t size;
+  size_t capacity;
+  float exp_factor;
+  void **buffer;
+
+  /* Memory management function pointers */
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+
+  /*  Comparator function pointer, for compairing the elements of PQueue */
+  int (*cmp)(const void *a, const void *b);
+};
+
+static void pqueue_heapify(PQueue *pqueue, size_t index);
+
+/**
+ * Initializes the fields of PQueueConf to default values
+ *
+ * @param[in, out] conf PQueueConf structure that is being initialized
+ * @param[in] comp The comparator function required for PQueue
+ */
+void pqueue_conf_init(PQueueConf *conf,
+                      int (*cmp)(const void *, const void *)) {
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+  conf->cmp = cmp;
+  conf->exp_factor = DEFAULT_EXPANSION_FACTOR;
+  conf->capacity = DEFAULT_CAPACITY;
+}
+
+/**
+ * Creates a new empty pqueue and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created PQueue is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new PQueue structure failed.
+ */
+enum cc_stat pqueue_new(PQueue **out, int (*cmp)(const void *, const void *)) {
+  PQueueConf conf;
+  pqueue_conf_init(&conf, cmp);
+  return pqueue_new_conf(&conf, out);
+}
+
+/**
+ * Creates a new empty PQueue based on the PQueueConf struct and returns a
+ * status code.
+ *
+ * The priority queue is allocated using the allocators specified in the
+ * PQueueConf struct. The allocation may fail if the underlying allocator fails.
+ * It may also fail if the values of exp_factor and capacity in the ArrayConf
+ * structure of the PQueueConf do not meet the following condition:
+ * <code>exp_factor < (CC_MAX_ELEMENTS / capacity)</code>.
+ *
+ * @param[in] conf priority queue configuration structure
+ * @param[out] out pointer to where the newly created PQueue is to be stored
+ *
+ * @return CC_OK if the creation was successful, CC_ERR_INVALID_CAPACITY if
+ * the above mentioned condition is not met, or CC_ERR_ALLOC if the memory
+ * allocation for the new PQueue structure failed.
+ */
+enum cc_stat pqueue_new_conf(PQueueConf const *const conf, PQueue **out) {
+  float ex;
+
+  /* The expansion factor must be greater than one for the
+   * array to grow */
+  if (conf->exp_factor <= 1)
+    ex = DEFAULT_EXPANSION_FACTOR;
+  else
+    ex = conf->exp_factor;
+
+  /* Needed to avoid an integer overflow on the first resize and
+   * to easily check for any future overflows. */
+  if (!conf->capacity || ex >= CC_MAX_ELEMENTS / conf->capacity)
+    return CC_ERR_INVALID_CAPACITY;
+
+  PQueue *pq = conf->mem_calloc(1, sizeof(PQueue));
+
+  if (!pq)
+    return CC_ERR_ALLOC;
+
+  void **buff = conf->mem_alloc(conf->capacity * sizeof(void *));
+
+  if (!buff) {
+    conf->mem_free(pq);
+    return CC_ERR_ALLOC;
+  }
+
+  pq->mem_alloc = conf->mem_alloc;
+  pq->mem_calloc = conf->mem_calloc;
+  pq->mem_free = conf->mem_free;
+  pq->cmp = conf->cmp;
+  pq->buffer = buff;
+  pq->exp_factor = ex;
+  pq->capacity = conf->capacity;
+
+  *out = pq;
+  return CC_OK;
+}
+
+/**
+ * Destroys the specified PQueue structure, while leaving the data it holds
+ * intact.
+ *
+ * @param[in] pq the PQueue to be destroyed
+ */
+void pqueue_destroy(PQueue *pq) {
+  pq->mem_free(pq->buffer);
+  pq->mem_free(pq);
+}
+
+/**
+ * Destroys the specified priority queue structure along with all the data it
+ * holds.
+ *
+ * @note This function should not be called on a PQueue that has some of its
+ * elements allocated on the Stack (stack memory of function calls).
+ *
+ * @param[in] pq the Priority Queue to be destroyed
+ */
+void pqueue_destroy_cb(PQueue *pq, void (*cb)(void *)) {
+  size_t i;
+  for (i = 0; i < pq->size; i++)
+    cb(pq->buffer[i]);
+
+  pqueue_destroy(pq);
+}
+
+/**
+ * Expands the Pqueue capacity. This might fail if the the new buffer
+ * cannot be allocated. In case the expansion would overflow the index
+ * range, a maximum capacity buffer is allocated instead. If the capacity
+ * is already at the maximum capacity, no new buffer is allocated.
+ *
+ * @param[in] pq pqueue whose capacity is being expanded
+ *
+ * @return CC_OK if the buffer was expanded successfully, CC_ERR_ALLOC if
+ * the memory allocation for the new buffer failed, or CC_ERR_MAX_CAPACITY
+ * if the pqueue is already at maximum capacity.
+ */
+static enum cc_stat expand_capacity(PQueue *pq) {
+  if (pq->capacity == CC_MAX_ELEMENTS)
+    return CC_ERR_MAX_CAPACITY;
+
+  size_t new_capacity = pq->capacity * pq->exp_factor;
+
+  /* As long as the capacity is greater that the expansion factor
+   * at the point of overflow, this is check is valid. */
+  if (new_capacity <= pq->capacity)
+    pq->capacity = CC_MAX_ELEMENTS;
+  else
+    pq->capacity = new_capacity;
+
+  void **new_buff = pq->mem_alloc(new_capacity * sizeof(void *));
+
+  if (!new_buff)
+    return CC_ERR_ALLOC;
+
+  memcpy(new_buff, pq->buffer, pq->size * sizeof(void *));
+
+  pq->mem_free(pq->buffer);
+  pq->buffer = new_buff;
+
+  return CC_OK;
+}
+
+/**
+ * Pushes the element in the pqueue
+ *
+ * @param[in] pq the priority queue in which the element is to be pushed
+ * @param[in] element the element which is needed to be pushed
+ *
+ * @return CC_OK if the element was successfully pushed, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat pqueue_push(PQueue *pq, void *element) {
+  size_t i = pq->size;
+
+  if (i >= pq->capacity) {
+    enum cc_stat status = expand_capacity(pq);
+    if (status != CC_OK)
+      return status;
+  }
+
+  pq->buffer[i] = element;
+  pq->size++;
+
+  if (i == 0)
+    return CC_OK;
+
+  void *child = pq->buffer[i];
+  void *parent = pq->buffer[CC_PARENT(i)];
+
+  while (i != 0 && pq->cmp(child, parent) > 0) {
+    void *tmp = pq->buffer[i];
+    pq->buffer[i] = pq->buffer[CC_PARENT(i)];
+    pq->buffer[CC_PARENT(i)] = tmp;
+
+    i = CC_PARENT(i);
+    child = pq->buffer[i];
+    parent = pq->buffer[CC_PARENT(i)];
+  }
+  return CC_OK;
+}
+
+/**
+ * Gets the most prioritized element from the queue without popping it
+ * @param[in] pqueue the PQueue structure of which the top element is needed
+ * @param[out] out pointer where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if the
+ * PQueue is empty.
+ */
+enum cc_stat pqueue_top(PQueue *pq, void **out) {
+  if (pq->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  *out = pq->buffer[0];
+  return CC_OK;
+}
+
+/**
+ * Removes the most prioritized element from the PQueue
+ * @param[in] pq the PQueue structure whose element is needed to be popped
+ * @param[out] out the pointer where the removed element will be stored
+ *
+ * return CC_OK if the element was popped successfully, or CC_ERR_OUT_OF_RANGE
+ * if pqueue was empty
+ */
+enum cc_stat pqueue_pop(PQueue *pq, void **out) {
+  if (pq->size == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  void *tmp = pq->buffer[0];
+  pq->buffer[0] = pq->buffer[pq->size - 1];
+  pq->buffer[pq->size - 1] = tmp;
+
+  tmp = pq->buffer[pq->size - 1];
+  pq->size--;
+
+  pqueue_heapify(pq, 0);
+
+  if (out)
+    *out = tmp;
+
+  return CC_OK;
+}
+
+/**
+ * Maintains the heap property of the PQueue
+ *
+ * @param[in] pq the PQueue structure whose heap property is to be maintained
+ * @param[in] index the index from where we need to apply this operation
+ */
+static void pqueue_heapify(PQueue *pq, size_t index) {
+  if (pq->size <= 1)
+    return;
+
+  size_t L = CC_LEFT(index);
+  size_t R = CC_RIGHT(index);
+  size_t tmp = index;
+
+  void *left = pq->buffer[L];
+  void *right = pq->buffer[R];
+  void *indexPtr = pq->buffer[index];
+
+  if (L >= pq->size || R >= pq->size)
+    return;
+
+  if (pq->cmp(indexPtr, left) < 0) {
+    indexPtr = left;
+    index = L;
+  }
+
+  if (pq->cmp(indexPtr, right) < 0) {
+    indexPtr = right;
+    index = R;
+  }
+
+  if (index != tmp) {
+    void *swap_tmp = pq->buffer[tmp];
+    pq->buffer[tmp] = pq->buffer[index];
+    pq->buffer[index] = swap_tmp;
+
+    pqueue_heapify(pq, index);
+  }
+}

--- a/test/c/collections-c/normal/src/queue.c
+++ b/test/c/collections-c/normal/src/queue.c
@@ -1,0 +1,262 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "queue.h"
+
+struct queue_s {
+  Deque *d;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+/**
+ * Initializes the fields of the QueueConf struct to default values.
+ *
+ * @param[in, out] conf the configuration struct that is being initialized
+ */
+void queue_conf_init(QueueConf *conf) { deque_conf_init(conf); }
+
+/**
+ * Creates a new empty queue and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created Queue is to be stored
+ *
+ * @return  CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new Queue structure failed.
+ */
+enum cc_stat queue_new(Queue **queue) {
+  QueueConf conf;
+  queue_conf_init(&conf);
+  return queue_new_conf(&conf, queue);
+}
+
+/**
+ * Creates a new empty Queue based on the specified QueueConf object and
+ * returns a status code.
+ *
+ * The Queue is allocated using the allocators specified in the QueueConf
+ * struct. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf Queue configuration structure. All fields must be initialized
+ *                 with appropriate values.
+ * @param[out] out Pointer to where the newly created Queue is to be stored.
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new Queue structure failed.
+ */
+enum cc_stat queue_new_conf(QueueConf const *const conf, Queue **q) {
+  Queue *queue = conf->mem_calloc(1, sizeof(Queue));
+
+  if (!queue)
+    return CC_ERR_ALLOC;
+
+  Deque *deque;
+  deque_new_conf(conf, &deque);
+
+  if (!deque) {
+    conf->mem_free(queue);
+    return CC_ERR_ALLOC;
+  }
+
+  queue->d = deque;
+  queue->mem_alloc = conf->mem_alloc;
+  queue->mem_calloc = conf->mem_calloc;
+  queue->mem_free = conf->mem_free;
+
+  *q = queue;
+
+  return CC_OK;
+}
+
+/**
+ * Destroys the queue structure, but leaves the data it used to hold intact.
+ *
+ * @param[in] queue the queue that is to be destroyed
+ */
+void queue_destroy(Queue *queue) {
+  deque_destroy(queue->d);
+  queue->mem_free(queue);
+}
+
+/**
+ * Destroys the queue structure along with all the data it holds.
+ *
+ * @note This function should not be called on a queue that has some of its
+ *       elements allocated on the stack.
+ *
+ * @param[in] queue the queue that is to be destroyed
+ */
+void queue_destroy_cb(Queue *queue, void (*cb)(void *)) {
+  deque_destroy_cb(queue->d, cb);
+  free(queue);
+}
+
+/**
+ * Gets the element at the front of the queue and sets the out
+ * parameter to its value.
+ *
+ * @param[in] queue the Queue whose element is being returned
+ * @param[out] out pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the
+ * Queue is empty.
+ */
+enum cc_stat queue_peek(Queue const *const queue, void **out) {
+  return deque_get_last(queue->d, out);
+}
+
+/**
+ * Gets and removes the element at the front of the queue and optionally
+ * sets the out parameter to the value of the removed element.
+ *
+ * @param[in] queue the queue on which this operation is performed
+ * @param[out] out pointer to where the removed element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the
+ * Queue is empty.
+ */
+enum cc_stat queue_poll(Queue *queue, void **out) {
+  return deque_remove_last(queue->d, out);
+}
+
+/**
+ * Appends an element to the back of the queue. This operation may
+ * fail if the memory allocation for the new element fails.
+ *
+ * @param[in] queue the queue on which this operation is performed
+ * @param[in] element the element being enqueued
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat queue_enqueue(Queue *queue, void *element) {
+  return deque_add_first(queue->d, element);
+}
+
+/**
+ * Returns the size of the specified queue. The size of the queue is
+ * the number of elements contained within the queue.
+ *
+ * @param[in] queue the queue whose size is being returned
+ *
+ * @return the number of elements within the queue.
+ */
+size_t queue_size(Queue const *const queue) { return deque_size(queue->d); }
+
+/**
+ * Applies the function fn to each element of the Queue.
+ *
+ * @param[in] queue the queue on which this operation is performed
+ * @param[in] fn the operation function that is to be invoked on each queue
+ * element
+ */
+void queue_foreach(Queue *queue, void (*fn)(void *)) {
+  deque_foreach(queue->d, fn);
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] queue the queue to iterate over
+ */
+void queue_iter_init(QueueIter *iter, Queue *queue) {
+  deque_iter_init(&(iter->i), queue->d);
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the Queue has been reached.
+ */
+enum cc_stat queue_iter_next(QueueIter *iter, void **out) {
+  return deque_iter_next(&(iter->i), out);
+}
+
+/**
+ * Replaces the last returned element by <code>queue_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ *       queue_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return  CC_OK if the element was replaced successfully, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat queue_iter_replace(QueueIter *iter, void *replacement,
+                                void **out) {
+  return deque_iter_replace(&(iter->i), replacement, out);
+}
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] q1   first queue
+ * @param[in] q2   second queue
+ */
+void queue_zip_iter_init(QueueZipIter *iter, Queue *q1, Queue *q2) {
+  deque_zip_iter_init(&(iter->i), q1->d, q2->d);
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first queue element
+ * @param[out] out2 output of the second queue element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the queues has been reached.
+ */
+enum cc_stat queue_zip_iter_next(QueueZipIter *iter, void **out1, void **out2) {
+  return deque_zip_iter_next(&(iter->i), out1, out2);
+}
+
+/**
+ * Replaces the last returned element pair by <code>queue_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @param[in] iter  iterator on which this operation is being performed
+ * @param[in]  e1   first queue's replacement element
+ * @param[in]  e2   second queue's replacement element
+ * @param[out] out1 output of the replaced element from the first queue
+ * @param[out] out2 output of the replaced element from the second queue
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat queue_zip_iter_replace(QueueZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  return deque_zip_iter_replace(&(iter->i), e1, e2, out1, out2);
+}

--- a/test/c/collections-c/normal/src/ring_buffer.c
+++ b/test/c/collections-c/normal/src/ring_buffer.c
@@ -1,0 +1,89 @@
+/**
+ * @Author: S. Sharma <silentcat>
+ * @Date:   2019-03-07T10:32:56-06:00
+ * @Email:  silentcat@protonmail.com
+ * @Last modified by:   silentcat
+ * @Last modified time: 2019-03-09T15:23:25-06:00
+ */
+
+#include "ring_buffer.h"
+
+struct ring_buffer_conf {
+
+  size_t capacity;
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+struct ring_buffer {
+
+  size_t size, capacity;
+  size_t head, tail;
+  uint64_t *buf;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+enum cc_stat rbuf_new(Rbuf **rbuf) {
+  RbufConf conf;
+  rbuf_conf_init(&conf);
+  return rbuf_conf_new(&conf, rbuf);
+}
+
+enum cc_stat rbuf_conf_new(RbufConf *rconf, Rbuf **rbuf) {
+  Rbuf *ringbuf = rconf->mem_calloc(1, sizeof(Rbuf));
+  if (!ringbuf)
+    return CC_ERR_ALLOC;
+  if (!(ringbuf->buf = rconf->mem_calloc(rconf->capacity, sizeof(uint64_t)))) {
+    rconf->mem_free(ringbuf);
+    return CC_ERR_ALLOC;
+  }
+
+  ringbuf->mem_alloc = rconf->mem_alloc;
+  ringbuf->mem_calloc = rconf->mem_calloc;
+  ringbuf->mem_free = rconf->mem_free;
+  ringbuf->capacity = rconf->capacity;
+  ringbuf->size = 0;
+  ringbuf->head = 0, ringbuf->tail = 0;
+  *rbuf = ringbuf;
+  return CC_OK;
+}
+
+void rbuf_conf_init(RbufConf *rconf) {
+  rconf->capacity = DEFAULT_RBUF_CAPACITY;
+  rconf->mem_alloc = malloc;
+  rconf->mem_calloc = calloc;
+  rconf->mem_free = free;
+}
+
+void rbuf_destroy(Rbuf *rbuf) {
+  rbuf->mem_free(rbuf->buf);
+  rbuf->mem_free(rbuf);
+}
+
+bool rbuf_is_empty(Rbuf *rbuf) { return (rbuf->size == 0); }
+
+size_t rbuf_size(Rbuf *rbuf) { return rbuf->size; }
+
+void rbuf_enqueue(Rbuf *rbuf, uint64_t item) {
+  if (rbuf->head == rbuf->tail)
+    rbuf->tail = (rbuf->tail + 1) % rbuf->capacity;
+  rbuf->buf[rbuf->head] = item;
+  rbuf->head = (rbuf->head + 1) % rbuf->capacity;
+  if (rbuf->size < rbuf->capacity)
+    ++rbuf->size;
+}
+
+enum cc_stat rbuf_dequeue(Rbuf *rbuf, uint64_t *out) {
+  if (rbuf_is_empty(rbuf))
+    return CC_ERR_OUT_OF_RANGE;
+  *out = rbuf->buf[rbuf->tail];
+  rbuf->tail = (rbuf->tail + 1) % rbuf->capacity;
+  --rbuf->size;
+  return CC_OK;
+}
+
+uint64_t rbuf_peek(Rbuf *rbuf, int index) { return rbuf->buf[index]; }

--- a/test/c/collections-c/normal/src/slist.c
+++ b/test/c/collections-c/normal/src/slist.c
@@ -1,0 +1,1539 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "slist.h"
+
+struct slist_s {
+  size_t size;
+  SNode *head;
+  SNode *tail;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static void *unlinkn(SList *list, SNode *node, SNode *prev);
+static bool unlinkn_all(SList *list, void (*cb)(void *));
+static void splice_between(SList *list1, SList *list2, SNode *base, SNode *end);
+static bool link_all_externally(SList *list, SNode **h, SNode **t);
+static enum cc_stat get_node_at(SList *list, size_t index, SNode **node,
+                                SNode **prev);
+static enum cc_stat get_node(SList *list, void *element, SNode **node,
+                             SNode **prev);
+
+/**
+ * Initializes the fields SListConf struct to default values.
+ *
+ * @param[in] conf the SListConf struct that is being initialized.
+ */
+void slist_conf_init(SListConf *conf) {
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+}
+
+/**
+ * Creates a new empty list and returns a status code.
+ *
+ * @param[out] out Pointer to a SList that is being created.
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new SList structure failed.
+ */
+enum cc_stat slist_new(SList **out) {
+  SListConf conf;
+  slist_conf_init(&conf);
+  return slist_new_conf(&conf, out);
+}
+
+/**
+ * Creates a new empty SList based on the specified SListConf struct and
+ * returns a status code.
+ *
+ * The SList is allocated using the allocators specified in the SListConf
+ * struct. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf SList configuration struct. All fields must be initialized
+ *            to appropriate values.
+ *
+ * @param[out] out Pointer to a SList that is being createdo
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new SList structure failed.
+ */
+enum cc_stat slist_new_conf(SListConf const *const conf, SList **out) {
+  SList *list = conf->mem_calloc(1, sizeof(SList));
+
+  if (!list)
+    return CC_ERR_ALLOC;
+
+  list->mem_alloc = conf->mem_alloc;
+  list->mem_calloc = conf->mem_calloc;
+  list->mem_free = conf->mem_free;
+
+  *out = list;
+  return CC_OK;
+}
+
+/**
+ * Destroys the list structure, but leaves the data that is holds intact.
+ *
+ * @param[in] list SList that is to be destroyed
+ */
+void slist_destroy(SList *list) {
+  slist_remove_all(list);
+  list->mem_free(list);
+}
+
+/**
+ * Destroys the list structure along with all the data it holds.
+ *
+ * @note
+ * This function should not be called on a list that has some of it's elements
+ * allocated on the stack.
+ *
+ * @param[in] list SList that is to be destroyed
+ */
+void slist_destroy_cb(SList *list, void (*cb)(void *)) {
+  slist_remove_all_cb(list, cb);
+  list->mem_free(list);
+}
+
+/**
+ * Adds a new element to the list. The element is appended to the list making it
+ * the last element of the list.
+ *
+ * @param[in] list SList to which the element is being added
+ * @param[in] element element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat slist_add(SList *list, void *element) {
+  return slist_add_last(list, element);
+}
+
+/**
+ * Prepends a new element to the list (adds a new "head") making it the first
+ * element of the list.
+ *
+ * @param[in] list SList to which the element is being added
+ * @param[in] element element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat slist_add_first(SList *list, void *element) {
+  SNode *node = list->mem_calloc(1, sizeof(SNode));
+
+  if (!node)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    node->next = list->head;
+    list->head = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Appends a new element to the list (adds a new "tail") making it the last
+ * element of the list.
+ *
+ * @param[in] list SList to which the element is being added
+ * @param[in] element element that is being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC if the
+ * memory allocation for the new element has failed.
+ */
+enum cc_stat slist_add_last(SList *list, void *element) {
+  SNode *node = list->mem_calloc(1, sizeof(SNode));
+
+  if (!node)
+    return CC_ERR_ALLOC;
+
+  node->data = element;
+
+  if (list->size == 0) {
+    list->head = node;
+    list->tail = node;
+  } else {
+    list->tail->next = node;
+    list->tail = node;
+  }
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Adds a new element at the specified location in the SList and shifts all
+ * subsequent elements by one. The index at which the new element is being
+ * added must be within the bounds of the list.
+ *
+ * @note This operation cannot be performed on an empty list.
+ *
+ * @param[in] list SList to which this element is being added
+ * @param[in] element element that is being added
+ * @param[in] index the position in the list at which the new element is being
+ *                  added
+ *
+ * @return CC_OK if the element was successfully added, CC_ERR_OUT_OF_RANGE if
+ * the specified index was not in range, or CC_ERR_ALLOC if the memory
+ * allocation for the new element failed.
+ */
+enum cc_stat slist_add_at(SList *list, void *element, size_t index) {
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  SNode *new = list->mem_calloc(1, sizeof(SNode));
+
+  if (!new)
+    return CC_ERR_ALLOC;
+
+  new->data = element;
+
+  if (!prev) {
+    new->next = list->head;
+    list->head = new;
+  } else {
+    SNode *tmp = prev->next;
+    prev->next = new;
+    new->next = tmp;
+  }
+
+  list->size++;
+  return CC_OK;
+}
+
+/**
+ * Adds all elements from the second list to the first. The elements from the
+ * second list are added after the last element of the first list.
+ *
+ * @param[in] list1 SList to which the elements are being added
+ * @param[in] list2 SList from which the elements are being taken
+ *
+ * @return CC_OK if the elements where successfully added, or CC_ERR_ALLOC if
+ * the memory allocation for the new elements failed.
+ */
+enum cc_stat slist_add_all(SList *list1, SList *list2) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  SNode *head = NULL;
+  SNode *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  if (list1->size == 0) {
+    list1->head = head;
+    list1->tail = tail;
+  } else {
+    list1->tail->next = head;
+    list1->tail = tail;
+  }
+  list1->size += list2->size;
+
+  return CC_OK;
+}
+
+/**
+ * Adds all element from the second list to the first at the specified position
+ * by shifting all subsequent elements by the size of the second list. The index
+ * must be within the range of the first list.
+ *
+ * @param[in] list1 SList to which the elements are being added
+ * @param[in] list2 SList from which the elements are being taken
+ * @param[in] index position in the first list at which the elements should be
+ *                  added
+ *
+ * @return CC_OK if the elements were successfully added,
+ * CC_ERR_INDEX_OUT_OF_BOUNDS if the index was out of range, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat slist_add_all_at(SList *list1, SList *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list1, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  SNode *head = NULL;
+  SNode *tail = NULL;
+
+  if (!link_all_externally(list2, &head, &tail))
+    return CC_ERR_ALLOC;
+
+  if (!prev) {
+    tail->next = node;
+    list1->head = head;
+  } else {
+    prev->next = head;
+    tail->next = node;
+  }
+
+  list1->size += list2->size;
+
+  return CC_OK;
+}
+
+/**
+ * Duplicates the structure of the list without directly attaching it to a
+ * specific list. If the operation fails, everything is cleaned up and false
+ * is returned to indicate the failure.
+ *
+ * @param[in] list the list whose structure is being duplicated
+ * @param[in, out] h the pointer to which the new head will be attached
+ * @param[in, out] t the pointer to which the new tail will be attached
+ *
+ * @return true if the operation was successful
+ */
+static bool link_all_externally(SList *list, SNode **h, SNode **t) {
+  SNode *ins = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    SNode *new = list->mem_calloc(1, sizeof(SNode));
+
+    if (!new) {
+      while (*h) {
+        SNode *tmp = (*h)->next;
+        list->mem_free(*h);
+        *h = tmp;
+      }
+      return false;
+    }
+
+    new->data = ins->data;
+
+    if (!*h) {
+      *h = new;
+      *t = new;
+    } else {
+      (*t)->next = new;
+      *t = new;
+    }
+
+    ins = ins->next;
+  }
+  return true;
+}
+
+/**
+ * Splices the two SLists together by appending the second list to the
+ * first. This function moves all the elements from the second list into
+ * the first list, leaving the second list empty.
+ *
+ * @param[in] list1 The consumer list to which the elements are moved.
+ * @param[in] list2 The producer list from which the elements are moved.
+ *
+ * @return CC_OK if the elements were successfully moved
+ */
+enum cc_stat slist_splice(SList *list1, SList *list2) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (list1->size == 0) {
+    list1->head = list2->head;
+    list1->tail = list2->tail;
+  } else {
+    list1->tail->next = list2->head;
+    list1->tail = list2->tail;
+  }
+  list1->size += list2->size;
+
+  list2->head = NULL;
+  list2->tail = NULL;
+  list2->size = 0;
+
+  return CC_OK;
+}
+
+/**
+ * Splices the two SLists together at the specified index of the first list.
+ * this function moves all the elements from the second list into the first
+ * list at the position specified by the <code>index</code> parameter. After
+ * this operation the second list will be left empty.
+ *
+ * @param[in] list1 the consumer list to which the elements are moved
+ * @param[in] list2 the producer list from which the elements are moved
+ * @param[in] index the index in the first list after which the elements
+ *                   from the second list should be inserted
+ *
+ * @return CC_OK if the elements were successfully moved, CC_ERR_OUT_OF_RANGE if
+ * the index was not in range,
+ */
+enum cc_stat slist_splice_at(SList *list1, SList *list2, size_t index) {
+  if (list2->size == 0)
+    return CC_OK;
+
+  if (index >= list1->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list1, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  splice_between(list1, list2, prev, node);
+
+  return CC_OK;
+}
+
+/**
+ * Inserts the second list between the two nodes of the first list. If the left
+ * node is NULL the head of the second list will be become the head of the first
+ * list. Similarly if the right node is null the tail of the first list will
+ * become the tail of the second list.
+ *
+ * @param[in, out] l1 the consumer list
+ * @param[in, out] l2 the producer list
+ * @param[in] left the node after which the elements are being added
+ * @param[in] right the node behind which the elements are being added
+ */
+static INLINE void splice_between(SList *l1, SList *l2, SNode *base,
+                                  SNode *end) {
+  if (!base) {
+    l2->tail->next = l1->head;
+    l1->head = l2->head;
+  } else if (!end) {
+    l1->tail->next = l2->head;
+    l1->tail = l2->tail;
+  } else {
+    base->next = l2->head;
+    l2->tail->next = end;
+  }
+  l1->size += l2->size;
+
+  l2->head = NULL;
+  l2->tail = NULL;
+  l2->size = 0;
+}
+
+/**
+ * Removes the first occurrence of the element from the specified SList
+ * and optionally sets the out parameter to the value of the removed element.
+ *
+ * @param[in] list SList from which the element is being removed
+ * @param[in] element element that is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the element was not found.
+ */
+enum cc_stat slist_remove(SList *list, void *element, void **out) {
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node(list, element, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  void *val = unlinkn(list, node, prev);
+
+  if (out)
+    *out = val;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the element at the specified index and optionally sets
+ * the out parameter to the value of the removed element. The index
+ * must be within the bounds of the list.
+ *
+ * @param[in] list  SList from which the element is being removed
+ * @param[in] index Index of the element that is being removed. Must be be
+ *                  within the index range of the list.
+ * @param[out] out  Pointer to where the removed value is stored,
+ *                  or NULL if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or CC_ERR_OUT_OF_RANGE
+ * if the index was out of range.
+ */
+enum cc_stat slist_remove_at(SList *list, size_t index, void **out) {
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  void *e = unlinkn(list, node, prev);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the first (head) element of the list and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @param[in] list SList from which the first element is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list is empty.
+ */
+enum cc_stat slist_remove_first(SList *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(list, list->head, NULL);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last (tail) element of the list and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @param[in] list SList from which the last element is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL if it
+ * is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list is empty.
+ */
+enum cc_stat slist_remove_last(SList *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list, list->size - 1, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  void *e = unlinkn(list, node, prev);
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Removes all elements from the specified list.
+ *
+ * @param[in] list SList from which all elements are being removed
+ *
+ * @return CC_OK if the elements were successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat slist_remove_all(SList *list) {
+  bool unlinked = unlinkn_all(list, NULL);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Removes and frees all the elements from the specified list.
+ *
+ * @note
+ * This function should not be called on a list that has some of it's elements
+ * allocated on the stack.
+ *
+ * @param[in] list SList from which all the elements are being removed and freed
+ *
+ * @return CC_OK if the element were successfully removed and freed, or
+ * CC_ERR_VALUE_NOT_FOUND if the list was already empty.
+ */
+enum cc_stat slist_remove_all_cb(SList *list, void (*cb)(void *)) {
+  bool unlinked = unlinkn_all(list, cb);
+
+  if (unlinked) {
+    list->head = NULL;
+    list->tail = NULL;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Replaces an element at the specified location and optionally sets the out
+ * parameter to the value of the replaced element. The specified index must be
+ * within the bounds of the list.
+ *
+ * @param[in] list    SList on which this operation is performed
+ * @param[in] element the replacement element
+ * @param[in] index   index of the element being replaced
+ * @param[out] out    Pointer to where the replaced element is stored, or NULL
+ * if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE if the index was out of range.
+ */
+enum cc_stat slist_replace_at(SList *list, void *element, size_t index,
+                              void **out) {
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  void *old = node->data;
+  node->data = element;
+
+  if (out)
+    *out = old;
+
+  return CC_OK;
+}
+
+/**
+ * Gets the first element from the specified list and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list SList whose first element is being returned
+ * @param[in] out  Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat slist_get_first(SList *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->head->data;
+
+  return CC_OK;
+}
+
+/**
+ * Gets the last element from the specified list and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list SList whose last element is being returned
+ * @param[out] out Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat slist_get_last(SList *list, void **out) {
+  if (list->size == 0)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  *out = list->tail->data;
+
+  return CC_OK;
+}
+
+/**
+ * Gets the list element from the specified index and sets the out parameter to
+ * its value.
+ *
+ * @param[in] list  SList from which the element is being returned.
+ * @param[in] index The index of a list element being returned. The index must
+ *                  be within the bound of the list.
+ * @param[out] out  Pointer to where the element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+enum cc_stat slist_get_at(SList *list, size_t index, void **out) {
+  SNode *prev = NULL;
+  SNode *node = NULL;
+
+  enum cc_stat status = get_node_at(list, index, &node, &prev);
+
+  if (status != CC_OK)
+    return status;
+
+  *out = node->data;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the number of elements in the specified SList.
+ *
+ * @param[in] list SList whose size is being returned
+ *
+ * @return The number of elements contained in the specified SList.
+ */
+size_t slist_size(SList *list) { return list->size; }
+
+/**
+ * Reverses the order of elements in the specified list.
+ *
+ * @param[in] list SList that is being reversed
+ */
+void slist_reverse(SList *list) {
+  if (list->size == 0 || list->size == 1)
+    return;
+
+  SNode *prev = NULL;
+  SNode *next = NULL;
+  SNode *flip = list->head;
+
+  list->tail = list->head;
+
+  while (flip) {
+    next = flip->next;
+    flip->next = prev;
+    prev = flip;
+    flip = next;
+  }
+  list->head = prev;
+}
+
+/**
+ * Creates a sublist of the specified list. The created sublist contains all
+ * the elements from the list that are contained between the two indices
+ * including the elements at the indices. For example if a list contains 5
+ * elements [5, 6, 7, 8, 9], a sublist from index 1 to 3 will will be a new
+ * list of length 3, containing [6, 7, 8]. The created sublist is only a copy of
+ * the original lists structure, meaning the data it points to is not copied.
+ *
+ * @note The sublist is allocated using the original lists allocators and also
+ *       inherits the configuration of the original list.
+ *
+ * @param[in] list SList from which the sublist is taken
+ * @param[in] from The beginning index, ie., the first element to be included.
+ *                 Must be a positive integer and may not exceed the list size
+ *                 or the end index.
+ * @param[in] to   The ending index, ie., the last element to be included. Must
+ *                 be a positive integer no greater that the list size and no
+ *                 smaller that the beginning index.
+ * @param[out] out Pointer to where the new sublist is stored.
+ *
+ * @return CC_OK if the sublist was successfully created, CC_ERR_INVALID_RANGE
+ * if the specified index range is invalid, or CC_ERR_ALLOC if the memory
+ * allocation for the new sublist failed.
+ */
+enum cc_stat slist_sublist(SList *list, size_t from, size_t to, SList **out) {
+  if (from > to || to >= list->size)
+    return CC_ERR_INVALID_RANGE;
+
+  SNode *base = NULL;
+  SNode *node = NULL;
+
+  SList *sub;
+  enum cc_stat status = slist_new(&sub);
+
+  if (status != CC_OK)
+    return status;
+
+  status = get_node_at(list, from, &node, &base);
+
+  if (status != CC_OK) {
+    slist_destroy(sub);
+    return status;
+  }
+
+  size_t i;
+  for (i = from; i <= to; i++) {
+    status = slist_add(sub, node->data);
+    if (status != CC_OK) {
+      slist_destroy(sub);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = sub;
+  return CC_OK;
+}
+
+/**
+ * Creates a shallow copy of the specified list. A shallow copy is a copy of the
+ * list structure. This operation does not copy the actual data that this list
+ * holds.
+ *
+ * @note The new list is allocated using the original lists allocators and also
+ *       inherits the configuration of the original list.
+ *
+ * @param[in] list SList to be copied
+ * @param[out] out Pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat slist_copy_shallow(SList *list, SList **out) {
+  SList *copy;
+  enum cc_stat status = slist_new(&copy);
+
+  if (status != CC_OK)
+    return status;
+
+  SNode *node = list->head;
+
+  while (node) {
+    status = slist_add(copy, node->data);
+    if (status != CC_OK) {
+      slist_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Creates a deep copy of the specified list. This function copies the structure
+ * of the list along with all the data it holds. The element copying is done
+ * through the specified copy function that should return a pointer to the copy
+ * of the element passed to it.
+ *
+ * @note The new list is allocated using the original lists allocators and also
+ *       inherits the configuration of the original list.
+ *
+ * @param[in] list SList to be copied
+ * @param[in] cp   the copy function that should return a pointer to the copy of
+ *                 the data.
+ * @param[out] out Pointer to where the newly created copy is stored
+ *
+ * @return CC_OK if the copy was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the copy failed.
+ */
+enum cc_stat slist_copy_deep(SList *list, void *(*cp)(void *), SList **out) {
+  SList *copy;
+  enum cc_stat status = slist_new(&copy);
+
+  if (status != CC_OK)
+    return status;
+
+  SNode *node = list->head;
+
+  while (node) {
+    status = slist_add(copy, cp(node->data));
+    if (status != CC_OK) {
+      slist_destroy(copy);
+      return status;
+    }
+    node = node->next;
+  }
+  *out = copy;
+  return CC_OK;
+}
+
+/**
+ * Returns an integer representing the number of occurrences of the specified
+ * element within the SList.
+ *
+ * @param[in] list SList on which the search is performed
+ * @param[in] element element being searched for
+ *
+ * @return number of found matches
+ */
+size_t slist_contains(SList *list, void *element) {
+  SNode *node = list->head;
+  size_t e_count = 0;
+
+  while (node) {
+    if (node->data == element)
+      e_count++;
+    node = node->next;
+  }
+  return e_count;
+}
+
+/**
+ * Returns the number of occurrences of the value pointed to by
+ * <code>element</code> within the specified SList.
+ *
+ * @param[in] list SList on which the search is performed
+ * @param[in] element element being searched for
+ * @param[in] cmp Comparator function which returns 0 if the values passed to it
+ * are equal
+ *
+ * @return number of occurrences of the value
+ */
+size_t slist_contains_value(SList *list, void *element,
+                            int (*cmp)(const void *, const void *)) {
+  SNode *node = list->head;
+  size_t e_count = 0;
+
+  while (node) {
+    if (cmp(node->data, element) == 0)
+      e_count++;
+    node = node->next;
+  }
+  return e_count;
+}
+
+/**
+ * Gets the index of the specified element. The returned index is the index
+ * of the first occurrence of the element starting from the beginning of the
+ * list.
+ *
+ * @param[in] list    the SList on which this operation is performed
+ * @param[in] element the element whose index is being looked up
+ * @param[out] index  Pointer to where the index is stored
+ *
+ * @return CC_OK if the index was found, or CC_OUT_OF_RANGE if not.
+ */
+enum cc_stat slist_index_of(SList *list, void *element, size_t *index) {
+  SNode *node = list->head;
+
+  size_t i = 0;
+  while (node) {
+    if (node->data == element) {
+      *index = i;
+      return CC_OK;
+    }
+    i++;
+    node = node->next;
+  }
+  return CC_ERR_OUT_OF_RANGE;
+}
+
+/**
+ * Creates an array representation of the specified list. None of the elements
+ * are copied into the array and thus any modification of the elements within
+ * the array will affect the list elements as well. The size of the created
+ * array is the same as the size of the list from which the array was
+ * constructed.
+ *
+ * @param[in] list SList on which this operation is being performed
+ * @param[out] out Pointer to where the newly created array is stored
+ *
+ * @return CC_OK if the array was successfully created, or CC_ERR_ALLOC if the
+ * memory allocation for the new array failed.
+ */
+enum cc_stat slist_to_array(SList *list, void ***out) {
+  void **array = list->mem_alloc(list->size * sizeof(void *));
+
+  if (!array)
+    return CC_ERR_ALLOC;
+
+  SNode *node = list->head;
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    array[i] = node->data;
+    node = node->next;
+  }
+  *out = array;
+  return CC_OK;
+}
+
+/**
+ * Sorts the specified list. This function makes no guaranties that the
+ * sort will be performed in place or in a stable way.
+ *
+ * @note
+ * Pointers passed to the comparator function will be pointers to the list
+ * elements that are of type (void*) ie. void**. So an extra step of
+ * dereferencing will be required before the data can be used for comparison:
+ * eg. <code>my_type e = *(*((my_type**) ptr));</code>.
+ *
+ * @param[in] list SList to be sorted
+ * @param[in] cmp the comparator function that must be of type <code>
+ *                int cmp(const void e1*, const void e2*)</code> that
+ *                returns < 0 if the first element goes before the second,
+ *                0 if the elements are equal and > 0 if the second goes
+ *                before the first.
+ *
+ * @return CC_OK if the sort was performed successfully, or CC_ERR_ALLOC
+ * if the sort could not allocate enough memory to performed the sort.
+ */
+enum cc_stat slist_sort(SList *list,
+                        int (*cmp)(void const *e1, void const *e2)) {
+  if (list->size == 1)
+    return CC_OK;
+
+  void **elements;
+  enum cc_stat status = slist_to_array(list, &elements);
+
+  if (status != CC_OK)
+    return status;
+
+  SNode *node = list->head;
+
+  qsort(elements, list->size, sizeof(void *), cmp);
+
+  size_t i;
+  for (i = 0; i < list->size; i++) {
+    node->data = elements[i];
+    node = node->next;
+  }
+  list->mem_free(elements);
+  return CC_OK;
+}
+
+/**
+ * A 'foreach loop' function that invokes the specified function on each element
+ * in the list.
+ *
+ * @param[in] list the list on which this operation is being performed
+ * @param[in] op the operation function that is to be invoked on each list
+ *               element
+ */
+void slist_foreach(SList *list, void (*op)(void *)) {
+  SNode *n = list->head;
+
+  while (n) {
+    op(n->data);
+    n = n->next;
+  }
+}
+
+/**
+ * Filters the SList by creating a new SList that contains all elements from the
+ * original SList that return true on pred(element) without modifying the
+ * original SList.
+ *
+ * @param[in] list Slist that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the filtered SList
+ * @param[out] out pointer to where the new filtered SList is to be stored
+ *
+ * @return CC_OK if the SList was filtered successfully, CC_ERR_OUT_OF_RANGE
+ * if the SList is empty, or CC_ERR_ALLOC if the memory allocation for the
+ * new SList failed.
+ */
+enum cc_stat slist_filter(SList *list, bool (*pred)(const void *),
+                          SList **out) {
+  if (slist_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  SList *filtered = NULL;
+  slist_new(&filtered);
+
+  if (!filtered)
+    return CC_ERR_ALLOC;
+
+  SNode *curr = list->head;
+  while (curr) {
+    if (pred(curr->data)) {
+      slist_add(filtered, curr->data);
+    }
+
+    curr = curr->next;
+  }
+
+  *out = filtered;
+  return CC_OK;
+}
+
+/**
+ * Filters the SList by modifying it. It removes all elements that don't
+ * return true on pred(element).
+ *
+ * @param[in] list Slist that is to be filtered
+ * @param[in] pred predicate function which returns true if the element should
+ *                 be kept in the Slist
+ *
+ * @return CC_OK if the Slist was filtered successfully, or CC_ERR_OUT_OF_RANGE
+ * if the Slist is empty.
+ */
+enum cc_stat slist_filter_mut(SList *list, bool (*pred)(const void *)) {
+  if (slist_size(list) == 0)
+    return CC_ERR_OUT_OF_RANGE;
+
+  SNode *curr = list->head;
+  SNode *next = NULL, *prev = NULL;
+
+  while (curr) {
+    next = curr->next;
+
+    if (!pred(curr->data)) {
+      unlinkn(list, curr, prev);
+    } else {
+      prev = curr;
+    }
+    curr = next;
+  }
+
+  return CC_OK;
+}
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] list SList to iterate over
+ */
+void slist_iter_init(SListIter *iter, SList *list) {
+  iter->index = 0;
+  iter->list = list;
+  iter->current = NULL;
+  iter->prev = NULL;
+  iter->next = list->head;
+}
+
+/**
+ * Removes the last returned element by <code>slist_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the out
+ * parameter to the value of the removed element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_iter_next()</code>
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[out] out Pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND
+ */
+enum cc_stat slist_iter_remove(SListIter *iter, void **out) {
+  if (!iter->current)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e = unlinkn(iter->list, iter->current, iter->prev);
+  iter->current = NULL;
+  iter->index--;
+
+  if (out)
+    *out = e;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element to the list after the last returned element by
+ * <code>slist_iter_next()</code> function without invalidating the
+ * iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_iter_next()</code>
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the element was successfully added, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat slist_iter_add(SListIter *iter, void *element) {
+  SNode *new_node = iter->list->mem_calloc(1, sizeof(SNode));
+
+  if (!new_node)
+    return CC_ERR_ALLOC;
+
+  new_node->data = element;
+  new_node->next = iter->next;
+
+  iter->current->next = new_node;
+
+  if (iter->index == iter->list->size)
+    iter->list->tail = new_node;
+
+  iter->index++;
+  iter->list->size++;
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element by <code>slist_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_iter_next()</code>
+
+ * @param[in] iter the iterator on which this operation is being preformed
+ * @param[in] element the replacement element
+ * @param[out] out Pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return CC_OK if the element was replaced successfully, or
+ * CC_ERR_VALUE_NOT_FOUND
+ */
+enum cc_stat slist_iter_replace(SListIter *iter, void *element, void **out) {
+  if (!iter->current)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old = iter->current->data;
+  iter->current->data = element;
+
+  if (out)
+    *out = old;
+
+  return CC_OK;
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out Pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the list has been reached.
+ */
+enum cc_stat slist_iter_next(SListIter *iter, void **out) {
+  if (!iter->next)
+    return CC_ITER_END;
+
+  void *data = iter->next->data;
+
+  if (iter->current)
+    iter->prev = iter->current;
+
+  iter->current = iter->next;
+  iter->next = iter->next->next;
+  iter->index++;
+
+  *out = data;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element by <code>slist_iter_next()
+ * </code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ *
+ * @return the index
+ */
+size_t slist_iter_index(SListIter *iter) { return iter->index - 1; }
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter Iterator that is being initialized
+ * @param[in] l1   First SList
+ * @param[in] l2   Second SList
+ */
+void slist_zip_iter_init(SListZipIter *iter, SList *l1, SList *l2) {
+  iter->index = 0;
+  iter->l1 = l1;
+  iter->l2 = l2;
+  iter->l1_current = NULL;
+  iter->l2_current = NULL;
+  iter->l1_prev = NULL;
+  iter->l2_prev = NULL;
+  iter->l1_next = l1->head;
+  iter->l2_next = l2->head;
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter Iterator that is being advanced
+ * @param[out] out1 Output of the first SList element
+ * @param[out] out2 Output of the second SList element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the lists has been reached.
+ */
+enum cc_stat slist_zip_iter_next(SListZipIter *iter, void **out1, void **out2) {
+  if (!iter->l1_next || !iter->l2_next)
+    return CC_ITER_END;
+
+  void *data1 = iter->l1_next->data;
+  void *data2 = iter->l2_next->data;
+
+  if (iter->l1_current)
+    iter->l1_prev = iter->l1_current;
+
+  if (iter->l2_current)
+    iter->l2_prev = iter->l2_current;
+
+  iter->l1_current = iter->l1_next;
+  iter->l2_current = iter->l2_next;
+  iter->l1_next = iter->l1_next->next;
+  iter->l2_next = iter->l2_next->next;
+
+  iter->index++;
+
+  *out1 = data1;
+  *out2 = data2;
+
+  return CC_OK;
+}
+
+/**
+ * Adds a new element pair to the slists after the last returned element pair by
+ * <code>slist_zip_iter_next()</code> and immediately before an element pair
+ * that would be returned by a subsequent call to
+ * <code>slist_zip_iter_next()</code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_zip_iter_next()</code>
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ * @param[in] e1   element added to the first slist
+ * @param[in] e2   element added to the second slist
+ *
+ * @return CC_OK if the element pair was successfully added to the slists, or
+ * CC_ERR_ALLOC if the memory allocation for the new elements failed.
+ */
+enum cc_stat slist_zip_iter_add(SListZipIter *iter, void *e1, void *e2) {
+  SNode *new_node1 = iter->l1->mem_calloc(1, sizeof(SNode));
+
+  if (!new_node1)
+    return CC_ERR_ALLOC;
+
+  SNode *new_node2 = iter->l2->mem_calloc(1, sizeof(SNode));
+
+  if (!new_node2) {
+    iter->l1->mem_free(new_node1);
+    return CC_ERR_ALLOC;
+  }
+
+  new_node1->data = e1;
+  new_node2->data = e2;
+
+  new_node1->next = iter->l1_next;
+  new_node2->next = iter->l2_next;
+
+  iter->l1_current->next = new_node1;
+  iter->l2_current->next = new_node2;
+
+  if (iter->index == iter->l1->size)
+    iter->l1->tail = new_node1;
+
+  if (iter->index == iter->l2->size)
+    iter->l2->tail = new_node2;
+
+  iter->index++;
+  iter->l1->size++;
+  iter->l2->size++;
+
+  return CC_OK;
+}
+
+/**
+ * Removes and outputs the last returned element pair by
+ * <code>slist_zip_iter_next()
+ * </code> without invalidating the iterator.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_zip_iter_next()</code>
+ *
+ * @param[in]  iter Iterator on which this operation is being performed
+ * @param[out] out1 Output of the removed element from the first Slist
+ * @param[out] out2 Output of the removed element from the second Slist
+ *
+ * @return CC_OK of the element was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat slist_zip_iter_remove(SListZipIter *iter, void **out1,
+                                   void **out2) {
+  if (!iter->l1_current || !iter->l2_current)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *e1 = unlinkn(iter->l1, iter->l1_current, iter->l1_prev);
+  void *e2 = unlinkn(iter->l2, iter->l2_current, iter->l2_prev);
+
+  iter->l1_current = NULL;
+  iter->l2_current = NULL;
+
+  iter->index--;
+
+  if (out1)
+    *out1 = e1;
+
+  if (out2)
+    *out2 = e2;
+
+  return CC_OK;
+}
+
+/**
+ * Replaces the last returned element pair by <code>slist_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * slist_zip_iter_next()</code>
+ *
+ * @param[in]  iter Iterator on which this operation is being performed
+ * @param[in]  e1   First slist's replacement element
+ * @param[in]  e2   Second slist's replacement element
+ * @param[out] out1 Output of the replaced element from the first slist
+ * @param[out] out2 Output of the replaced element from the second slist
+ *
+ * @return CC_OK of the element was successfully replaced, or
+ * CC_ERR_VALUE_NOT_FOUND.
+ */
+enum cc_stat slist_zip_iter_replace(SListZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  if (!iter->l1_current || !iter->l2_current)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  void *old1 = iter->l1_current->data;
+  void *old2 = iter->l2_current->data;
+
+  iter->l1_current->data = e1;
+  iter->l2_current->data = e2;
+
+  if (out1)
+    *out1 = old1;
+
+  if (out2)
+    *out2 = old2;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the index of the last returned element pair by
+ * <code>slist_zip_iter_next()</code>.
+ *
+ * @param[in] iter Iterator on which this operation is being performed
+ *
+ * @return current iterator index
+ */
+size_t slist_zip_iter_index(SListZipIter *iter) { return iter->index - 1; }
+
+/**
+ * Unlinks the node from the list and returns the data that was associated with
+ * it and also adjusts the head / tail of the list if necessary.
+ *
+ * @param[in] list the list from which the node is being unlinked
+ * @parma[in] node the node being unlinked
+ * @param[in] prev the node that immediately precedes the node that is being
+ * unlinked
+ *
+ * @return the data that was at this node
+ */
+static void *unlinkn(SList *list, SNode *node, SNode *prev) {
+  void *data = node->data;
+
+  if (prev)
+    prev->next = node->next;
+  else
+    list->head = node->next;
+
+  if (!node->next)
+    list->tail = prev;
+
+  list->mem_free(node);
+  list->size--;
+
+  return data;
+}
+
+/**
+ * Unlinks all nodes from the list and optionally frees the data at the nodes.
+ *
+ * @param[in] list the list from which all nodes are being unlinked
+ * @param[in] freed specified whether or not the data at the nodes should also
+ *                  be deallocated.
+ *
+ * @return false if the list is already y empty, otherwise returns true
+ */
+static bool unlinkn_all(SList *list, void (*cb)(void *)) {
+  if (list->size == 0)
+    return false;
+
+  SNode *n = list->head;
+
+  while (n) {
+    SNode *tmp = n->next;
+
+    if (cb)
+      cb(n->data);
+
+    list->mem_free(n);
+    n = tmp;
+    list->size--;
+  }
+  return true;
+}
+
+/**
+ * Finds the node at the specified index. If the index is not in the bounds
+ * of the list, NULL is returned instead.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] index the index of the node
+ * @param[out] node the node at the specified index
+ * @param[out] prev the node that immediately precedes the node at the
+ *                  specified index
+ *
+ * @return CC_OK if the node was found, or CC_ERR_OUT_OF_RANGE if the index
+ * was out of range.
+ */
+static enum cc_stat get_node_at(SList *list, size_t index, SNode **node,
+                                SNode **prev) {
+  if (index >= list->size)
+    return CC_ERR_OUT_OF_RANGE;
+
+  *node = list->head;
+  *prev = NULL;
+
+  size_t i;
+  for (i = 0; i < index; i++) {
+    *prev = *node;
+    *node = (*node)->next;
+  }
+  return CC_OK;
+}
+
+/**
+ * Finds the first node from the beginning of the list that is associated
+ * with the specified element. If no node is associated with the element,
+ * NULL is returned instead.
+ *
+ * @param[in] list the list from which the node is being returned
+ * @param[in] element the element whose list node is being returned
+ * @param[out] node the node associated with the data
+ * @param[out] prev the node that immediately precedes the node at the
+ *                  specified index
+ *
+ * @return CC_OK if the node was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+static enum cc_stat get_node(SList *list, void *element, SNode **node,
+                             SNode **prev) {
+  *node = list->head;
+  *prev = NULL;
+
+  while (*node) {
+    if ((*node)->data == element)
+      return CC_OK;
+
+    *prev = *node;
+    *node = (*node)->next;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}

--- a/test/c/collections-c/normal/src/stack.c
+++ b/test/c/collections-c/normal/src/stack.c
@@ -1,0 +1,261 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stack.h"
+#include "array.h"
+
+struct stack_s {
+  Array *v;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+/**
+ * Initializes the fields of the StackConf struct to default values.
+ *
+ * @param[in, out] conf StackConf structure that is being initialized
+ */
+void stack_conf_init(StackConf *conf) { array_conf_init(conf); }
+
+/**
+ * Creates a new empty stack and returns a status code.
+ *
+ * @param[out] out pointer to where the newly created Stack is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new Stack structure failed.
+ */
+enum cc_stat stack_new(Stack **out) {
+  StackConf conf;
+  stack_conf_init(&conf);
+  return stack_new_conf(&conf, out);
+}
+
+/**
+ * Creates a new empty Stack based on the StackConf struct and returns a
+ * status code.
+ *
+ * The stack is allocated using the allocators specified in the StackConf
+ * struct. The allocation may fail if the underlying allocator fails. It may
+ * also fail if the values of exp_factor and capacity in the StackConf do not
+ * meet the following condition: <code>exp_factor < (CC_MAX_ELEMENTS /
+ * capacity)</code>.
+ *
+ * @param[in] conf stack configuration structure
+ * @param[out] out pointer to where the newly created Stack is to be stored
+ *
+ * @return CC_OK if the creation was successful, CC_ERR_INVALID_CAPACITY if
+ * the above mentioned condition is not met, or CC_ERR_ALLOC if the memory
+ * allocation for the new Stack structure failed.
+ */
+enum cc_stat stack_new_conf(StackConf const *const conf, Stack **out) {
+  Stack *stack = conf->mem_calloc(1, sizeof(Stack));
+
+  if (!stack)
+    return CC_ERR_ALLOC;
+
+  stack->mem_alloc = conf->mem_alloc;
+  stack->mem_calloc = conf->mem_calloc;
+  stack->mem_free = conf->mem_free;
+
+  Array *array;
+  enum cc_stat status;
+  if ((status = array_new_conf(conf, &array)) == CC_OK) {
+    stack->v = array;
+  } else {
+    conf->mem_free(stack);
+    return status;
+  }
+  *out = stack;
+  return CC_OK;
+}
+
+/**
+ * Destroys the specified stack structure, while leaving the data it holds
+ * intact.
+ *
+ * @param[in] stack the Stack to be destroyed
+ */
+void stack_destroy(Stack *stack) {
+  array_destroy(stack->v);
+  stack->mem_free(stack);
+}
+
+/**
+ * Destroys the specified stack structure along with all the data it holds.
+ *
+ * @note This function should not be called on a Stack that has some of its
+ * elements allocated on the stack (stack memory).
+ *
+ * @param[in] stack the stack to be destroyed
+ */
+void stack_destroy_cb(Stack *stack, void (*cb)(void *)) {
+  array_destroy_cb(stack->v, cb);
+  free(stack);
+}
+
+/**
+ * Pushes a new element onto the stack.
+ *
+ * @param[in] stack the stack on which the element is being pushed onto
+ * @param[in] element the element being pushed onto the stack
+ *
+ * @return CC_OK if the element was successfully pushed, or CC_ERR_ALLOC
+ * if the memory allocation for the new element failed.
+ */
+enum cc_stat stack_push(Stack *stack, void *element) {
+  return array_add(stack->v, element);
+}
+
+/**
+ * Gets the top element of the Stack without removing it and sets the out
+ * parameter to its value.
+ *
+ * @param[in] stack the stack whose top element is being returned
+ * @param[out] out pointer to where the returned value is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if the
+ * Stack is empty.
+ */
+enum cc_stat stack_peek(Stack *stack, void **out) {
+  return array_get_last(stack->v, out);
+}
+
+/**
+ * Pops (removes) the top element of the stack and optionally sets the out
+ * parameter to the value of the popped element.
+ *
+ * @param[in] stack the stack whose top element is being popped
+ * @param[out] out pointer to where the popped value is stored, or NULL if it is
+ *                 to be ignored
+ *
+ * @return CC_OK if the element was successfully popped, or CC_ERR_OUT_OF_RANGE
+ * if the Stack is already empty.
+ */
+enum cc_stat stack_pop(Stack *stack, void **out) {
+  return array_remove_last(stack->v, out);
+}
+
+/**
+ * Returns the number of Stack elements.
+ *
+ * @param[in] stack the Stack whose number of elements is being returned
+ *
+ * @return the number of Stack elements.
+ */
+size_t stack_size(Stack *stack) { return array_size(stack->v); }
+
+/**
+ * Applies the function fn to each element of the Stack.
+ *
+ * @param[in] stack the Stack on which this operation being performed
+ * @param[in] fn the operation function that is to be invoked on each
+ *               element of the Stack
+ */
+void stack_map(Stack *stack, void (*fn)(void *)) { array_map(stack->v, fn); }
+
+/**
+ * Initializes the iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] s the stack to iterate over
+ */
+void stack_iter_init(StackIter *iter, Stack *s) {
+  array_iter_init(&(iter->i), s->v);
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element in the sequence.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the Stack has been reached.
+ */
+enum cc_stat stack_iter_next(StackIter *iter, void **out) {
+  return array_iter_next(&(iter->i), out);
+}
+
+/**
+ * Replaces the last returned element by <code>stack_iter_next()</code>
+ * with the specified element and optionally sets the out parameter to
+ * the value of the replaced element.
+ *
+ * @note This function should only ever be called after a call to <code>
+ * stack_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is being performed
+ * @param[in] element the replacement element
+ * @param[out] out pointer to where the replaced element is stored, or NULL
+ *                if it is to be ignored
+ *
+ * @return  CC_OK if the element was replaced successfully, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat stack_iter_replace(StackIter *iter, void *element, void **out) {
+  return array_iter_replace(&(iter->i), element, out);
+}
+
+/**
+ * Initializes the zip iterator.
+ *
+ * @param[in] iter iterator that is being initialized
+ * @param[in] s1   first Stack
+ * @param[in] s2   second Stack
+ */
+void stack_zip_iter_init(StackZipIter *iter, Stack *s1, Stack *s2) {
+  array_zip_iter_init(&(iter->i), s1->v, s2->v);
+}
+
+/**
+ * Outputs the next element pair in the sequence and advances the iterator.
+ *
+ * @param[in]  iter iterator that is being advanced
+ * @param[out] out1 output of the first stack element
+ * @param[out] out2 output of the second stack element
+ *
+ * @return CC_OK if a next element pair is returned, or CC_ITER_END if the end
+ * of one of the stacks has been reached.
+ */
+enum cc_stat stack_zip_iter_next(StackZipIter *iter, void **out1, void **out2) {
+  return array_zip_iter_next(&(iter->i), out1, out2);
+}
+
+/**
+ * Replaces the last returned element pair by <code>stack_zip_iter_next()</code>
+ * with the specified replacement element pair.
+ *
+ * @param[in] iter  iterator on which this operation is being performed
+ * @param[in]  e1   first stack's replacement element
+ * @param[in]  e2   second stack's replacement element
+ * @param[out] out1 output of the replaced element from the first stack
+ * @param[out] out2 output of the replaced element from the second stack
+ *
+ * @return CC_OK if the element was successfully replaced, or
+ * CC_ERR_OUT_OF_RANGE.
+ */
+enum cc_stat stack_zip_iter_replace(StackZipIter *iter, void *e1, void *e2,
+                                    void **out1, void **out2) {
+  return array_zip_iter_replace(&(iter->i), e1, e2, out1, out2);
+}

--- a/test/c/collections-c/normal/src/treeset.c
+++ b/test/c/collections-c/normal/src/treeset.c
@@ -1,0 +1,283 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2014 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "treeset.h"
+
+struct treeset_s {
+  TreeTable *t;
+  int *dummy;
+
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+/**
+ * Initializes the fields of the TreeSetConf struct to default values.
+ *
+ * @param[in, out] conf the configuration struct that is being initialized
+ */
+void treeset_conf_init(TreeSetConf *conf) { treetable_conf_init(conf); }
+
+/**
+ * Creates a new TreeSet and returns a status code.
+ *
+ * @param[in] cmp the comparator function used to order elements
+ * @param[out] out pointer to where the newly created TreeSet is to be stored
+ *
+ * @return  CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new TreeSet failed.
+ */
+enum cc_stat treeset_new(int (*cmp)(const void *, const void *),
+                         TreeSet **set) {
+  TreeSetConf conf;
+  treeset_conf_init(&conf);
+  conf.cmp = cmp;
+  return treeset_new_conf(&conf, set);
+}
+
+/**
+ * Creates a new TreeSet based on the specified TreeSetConf struct and returns
+ * a status code.
+ *
+ * The TreeSet is allocated using the allocators specified in the TreeSetConf
+ * object. The allocation may fail if the underlying allocator fails.
+ *
+ * @param[in] conf  TreeSet configuration struct. All fields must be
+ * initialized.
+ * @param[out] out Pointer to where the newly created TreeSet is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new TreeSet structure failed.
+ */
+enum cc_stat treeset_new_conf(TreeSetConf const *const conf, TreeSet **tset) {
+  TreeSet *set = conf->mem_calloc(1, sizeof(TreeSet));
+
+  if (!set)
+    return CC_ERR_ALLOC;
+
+  TreeTable *table;
+  enum cc_stat s = treetable_new_conf(conf, &table);
+
+  if (s != CC_OK) {
+    conf->mem_free(set);
+    return s;
+  }
+  set->t = table;
+  set->dummy = (int *)1;
+  set->mem_alloc = conf->mem_alloc;
+  set->mem_calloc = conf->mem_calloc;
+  set->mem_free = conf->mem_free;
+
+  *tset = set;
+  return CC_OK;
+}
+
+/**
+ * Destroys the specified TreeSet.
+ *
+ * @param[in] set the TreeSet to be destroyed
+ */
+void treeset_destroy(TreeSet *set) {
+  treetable_destroy(set->t);
+  set->mem_free(set);
+}
+
+/**
+ * Adds a new element to the set.
+ *
+ * @param[in] set the set to which the element is being added
+ * @param[in] element the element being added
+ *
+ * @return CC_OK if the operation was successful, or CC_ERR_ALLOC if the
+ * memory allocation for the new element failed.
+ */
+enum cc_stat treeset_add(TreeSet *set, void *element) {
+  return treetable_add(set->t, element, set->dummy);
+}
+
+/**
+ * Removes the specified element from the TreeSet and sets the out
+ * parameter to its value.
+ *
+ * @param[in] set the set from which the element is being removed
+ * @param[in] element the element being removed
+ * @param[out] out pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_VALUE_NOT_FOUND if the value was not found.
+ */
+enum cc_stat treeset_remove(TreeSet *set, void *element, void **out) {
+  if (treetable_remove(set->t, element, out) == CC_ERR_KEY_NOT_FOUND)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return CC_OK;
+}
+
+/**
+ * Removes all elements from the specified set.
+ *
+ * @param set the set from which all elements are being removed
+ */
+void treeset_remove_all(TreeSet *set) { treetable_remove_all(set->t); }
+
+/**
+ * Returns the first element of the set.
+ *
+ * @param[in] set the set from which the first element is being returned
+ * @param[out] out pointer to where the returned element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treeset_get_first(TreeSet *set, void **out) {
+  if (treetable_get_first_key(set->t, out) == CC_ERR_KEY_NOT_FOUND)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the last (highest) element of the set.
+ *
+ * @param[in] set the set from which the last element is being returned
+ * @param[out] out pointer to where the returned element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treeset_get_last(TreeSet *set, void **out) {
+  if (treetable_get_last_key(set->t, out) == CC_ERR_KEY_NOT_FOUND)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the immediate successor of the specified element.
+ *
+ * @param[in] set the set on which this operation is performed
+ * @param[in] element the element whose successor is being returned
+ * @param[out] out pointer to where the returned element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treeset_get_greater_than(TreeSet *set, void *element, void **out) {
+  if (treetable_get_greater_than(set->t, element, out) == CC_ERR_KEY_NOT_FOUND)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return CC_OK;
+}
+
+/**
+ * Returns the immediate predecessor of the specified element.
+ *
+ * @param[in] set the set on which this operation is performed
+ * @param[in] element the element whose predecessor is being returned
+ * @param[out] out pointer to where the returned element is stored
+ *
+ * @return CC_OK if the element was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treeset_get_lesser_than(TreeSet *set, void *element, void **out) {
+  if (treetable_get_lesser_than(set->t, element, out) == CC_ERR_KEY_NOT_FOUND)
+    return CC_ERR_VALUE_NOT_FOUND;
+
+  return CC_OK;
+}
+
+/**
+ * Checks whether an element is a part of the specified set.
+ *
+ * @param[in] set the set being searched for the specified element
+ * @param[in] element the element being searched for
+ *
+ * @return true if the specified element is an element of the set.
+ */
+bool treeset_contains(TreeSet *set, void *element) {
+  return treetable_contains_key(set->t, element);
+}
+
+/**
+ * Returns the size of the specified set.
+ *
+ * @param[in] set the set whose size is being returned
+ *
+ * @return the size of the set.
+ */
+size_t treeset_size(TreeSet *set) { return treetable_size(set->t); }
+
+/**
+ * Applies the function fn to each element of the TreeSet.
+ *
+ * @param[in] set the set on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each element
+ *               of the set
+ */
+void treeset_foreach(TreeSet *set, void (*fn)(const void *)) {
+  treetable_foreach_key(set->t, fn);
+}
+
+/**
+ * Initializes the set iterator.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] set the set on which this iterator will operate
+ */
+void treeset_iter_init(TreeSetIter *iter, TreeSet *set) {
+  treetable_iter_init(&(iter->i), set->t);
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next element.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] element pointer to where the next element is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the TreeSet has been reached.
+ */
+enum cc_stat treeset_iter_next(TreeSetIter *iter, void **element) {
+  TreeTableEntry entry;
+
+  if (treetable_iter_next(&(iter->i), &entry) != CC_OK)
+    return CC_ITER_END;
+
+  *element = entry.key;
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned element by <code>treeset_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the
+ * out parameter to the value of the removed element.
+ *
+ * @note This Function should only ever be called after a call to <code>
+ * treeset_iter_next()</code>.
+ *
+ * @param[in] iter the iterator on which this operation is performed
+ * @param[out] out pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the element was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND.
+ */
+enum cc_stat treeset_iter_remove(TreeSetIter *iter, void **out) {
+  return treetable_iter_remove(&(iter->i), out);
+}

--- a/test/c/collections-c/normal/src/treetable.c
+++ b/test/c/collections-c/normal/src/treetable.c
@@ -1,0 +1,954 @@
+/*
+ * Collections-C
+ * Copyright (C) 2013-2015 Srđan Panić <srdja.panic@gmail.com>
+ *
+ * This file is part of Collections-C.
+ *
+ * Collections-C is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Collections-C is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Collections-C. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Tree operations are based on CLRS RB Tree. */
+
+#include "treetable.h"
+
+#define RB_BLACK 1
+#define RB_RED 0
+
+struct treetable_s {
+  RBNode *root;
+  RBNode *sentinel;
+  size_t size;
+
+  int (*cmp)(const void *k1, const void *k2);
+  void *(*mem_alloc)(size_t size);
+  void *(*mem_calloc)(size_t blocks, size_t size);
+  void (*mem_free)(void *block);
+};
+
+static void rotate_left(TreeTable *table, RBNode *n);
+static void rotate_right(TreeTable *table, RBNode *n);
+static void rebalance_after_insert(TreeTable *table, RBNode *n);
+static void rebalance_after_delete(TreeTable *table, RBNode *n);
+static void remove_node(TreeTable *table, RBNode *z);
+static void tree_destroy(TreeTable *table, RBNode *s);
+
+static INLINE void transplant(TreeTable *table, RBNode *u, RBNode *v);
+static INLINE RBNode *tree_min(TreeTable const *const table, RBNode *n);
+static INLINE RBNode *tree_max(TreeTable const *const table, RBNode *n);
+
+static RBNode *get_tree_node_by_key(TreeTable const *const table,
+                                    const void *key);
+static RBNode *get_successor_node(TreeTable const *const table, RBNode *x);
+static RBNode *get_predecessor_node(TreeTable const *const table, RBNode *x);
+
+/**
+ * Initializes the TreehTableConf structs fields to default values.
+ *
+ * @param[in] conf the struct that is being initialized
+ */
+void treetable_conf_init(TreeTableConf *conf) {
+  conf->mem_alloc = malloc;
+  conf->mem_calloc = calloc;
+  conf->mem_free = free;
+  conf->cmp = NULL;
+}
+
+/**
+ * Creates a new TreeTable and returns a status code.
+ *
+ * @param[in] cmp the comparator used to order keys within the table
+ * @param[out] out Pointer to where the newly created TreeTable is to be stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new TreeTable failed.
+ */
+enum cc_stat treetable_new(int (*cmp)(const void *, const void *),
+                           TreeTable **tt) {
+  TreeTableConf conf;
+  treetable_conf_init(&conf);
+  conf.cmp = cmp;
+  return treetable_new_conf(&conf, tt);
+}
+
+/**
+ * Creates a new TreeTable based on the specified TreeTableConf struct and
+ * returns a status code.
+ *
+ * The table is allocated using the memory allocators specified in the
+ * TreeTableConf struct.
+ *
+ * @param[in] conf the TreeTableConf struct used to configure this new TreeTable
+ * @param[out] out Pointer to where the newly created TreeTable is stored
+ *
+ * @return CC_OK if the creation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new TreeTable structure failed.
+ */
+enum cc_stat treetable_new_conf(TreeTableConf const *const conf,
+                                TreeTable **tt) {
+  TreeTable *table = conf->mem_calloc(1, sizeof(TreeTable));
+
+  if (!table)
+    return CC_ERR_ALLOC;
+
+  RBNode *sentinel = conf->mem_calloc(1, sizeof(RBNode));
+
+  if (!sentinel) {
+    conf->mem_free(table);
+    return CC_ERR_ALLOC;
+  }
+
+  sentinel->color = RB_BLACK;
+
+  table->size = 0;
+  table->cmp = conf->cmp;
+  table->mem_alloc = conf->mem_alloc;
+  table->mem_calloc = conf->mem_calloc;
+  table->mem_free = conf->mem_free;
+  table->root = sentinel;
+  table->sentinel = sentinel;
+
+  *tt = table;
+  return CC_OK;
+}
+
+/**
+ * Destroys the sub-tree specified by the root node n.
+ *
+ * @param[in] table TreeTable to be destroyed.
+ * @param[in] n root node of the sub tree that is being destroyed
+ */
+static void tree_destroy(TreeTable *table, RBNode *n) {
+  if (n == table->sentinel)
+    return;
+
+  tree_destroy(table, n->left);
+  tree_destroy(table, n->right);
+
+  table->mem_free(n);
+}
+
+/**
+ * Destroys the specified TreeTable structure without destroying the the data
+ * it holds. In other words the keys and the values are not freed, only the
+ * table structure is.
+ *
+ * @param[in] table TreeTable to be destroyed.
+ */
+void treetable_destroy(TreeTable *table) {
+  tree_destroy(table, table->root);
+
+  table->mem_free(table->sentinel);
+  table->mem_free(table);
+}
+
+/**
+ * Gets a value associated with the specified key and sets the out
+ * parameter to it.
+ *
+ * @param[in] table the table from which the mapping is being returned
+ * @param[in] key   the key that is being looked up
+ * @param[out] out  Pointer to where the returned value is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get(TreeTable const *const table, const void *key,
+                           void **out) {
+  RBNode *node = get_tree_node_by_key(table, key);
+
+  if (!node)
+    return CC_ERR_KEY_NOT_FOUND;
+
+  *out = node->value;
+  return CC_OK;
+}
+
+/**
+ * Gets the value associated with the first (lowest) key in the table
+ * and sets the out parameter to it.
+ *
+ * @param[in] table the table in which the lookup is performed
+ * @param[out] out  Pointer to where the returned value is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_first_value(TreeTable const *const table,
+                                       void **out) {
+  RBNode *node = tree_min(table, table->root);
+
+  if (node != table->sentinel) {
+    *out = node->value;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Gets the value associated with the highest (last) key in the table
+ * and sets the out parameter to it.
+ *
+ * @param[in] table the table in which the lookup is performed
+ * @param[out] out  Pointer to where the returned value is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_VALUE_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_last_value(TreeTable const *const table,
+                                      void **out) {
+  RBNode *node = tree_max(table, table->root);
+
+  if (node != table->sentinel) {
+    *out = node->value;
+    return CC_OK;
+  }
+  return CC_ERR_VALUE_NOT_FOUND;
+}
+
+/**
+ * Returns the first (lowest) key in the table and sets the out parameter
+ * to it.
+ *
+ * @param[in] table the table in which the lookup is performed
+ * @param[out] out  Pointer to where the returned key is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_first_key(TreeTable const *const table, void **out) {
+  RBNode *node = tree_min(table, table->root);
+
+  if (node != table->sentinel) {
+    *out = node->key;
+    return CC_OK;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Returns the last (highest) key in the table and sets the out parameter
+ * to it.
+ *
+ * @param[in] table the table in which the lookup is performed
+ * @param[out] out  Pointer to where the returned key is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_last_key(TreeTable const *const table, void **out) {
+  RBNode *node = tree_max(table, table->root);
+
+  if (node != table->sentinel) {
+    *out = node->key;
+    return CC_OK;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Gets the immediate successor of the specified key and sets the out
+ * parameter to its value.
+ *
+ * @param[in] table the table into which the lookup is performed
+ * @param[in] key   the key whose successor is being returned
+ * @param[out] out  Pointer to where the returned key is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_greater_than(TreeTable const *const table,
+                                        const void *key, void **out) {
+  RBNode *n = get_tree_node_by_key(table, key);
+  RBNode *s = get_successor_node(table, n);
+
+  if (n && s) {
+    *out = s->key;
+    return CC_OK;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Returns the immediate predecessor of the specified key and sets the
+ * out parameter to its value.
+ *
+ * @param[in] table the table into which the lookup is performed
+ * @param[in] key   the key whose predecessor is being returned
+ * @param[out] out  Pointer to where the returned key is stored
+ *
+ * @return CC_OK if the key was found, or CC_ERR_KEY_NOT_FOUND if not.
+ */
+enum cc_stat treetable_get_lesser_than(TreeTable const *const table,
+                                       const void *key, void **out) {
+  RBNode *n = get_tree_node_by_key(table, key);
+  RBNode *s = get_predecessor_node(table, n);
+
+  if (n && s) {
+    *out = s->key;
+    return CC_OK;
+  }
+  return CC_ERR_KEY_NOT_FOUND;
+}
+
+/**
+ * Returns the size of the specified TreeTable. Size of a TreeTable represents
+ * the number of key-value mappings within the table.
+ *
+ * @param[in] table the table whose size is being returned
+ *
+ * @return the size of the table
+ */
+size_t treetable_size(TreeTable const *const table) { return table->size; }
+
+/**
+ * Checks whether or not the TreeTable contains the specified key.
+ *
+ * @param[in] table the table into which the lookup is performed
+ * @param[in] key the key that is being looked up
+ *
+ * @return true if the table contains the key.
+ */
+bool treetable_contains_key(TreeTable const *const table, const void *key) {
+  RBNode *node = get_tree_node_by_key(table, key);
+
+  if (node)
+    return true;
+
+  return false;
+}
+
+/**
+ * Checks whether or not the TreeTable contains the specified value.
+ *
+ * @param[in] table the table into which the lookup is performed
+ * @param[in] value the value that is being looked up
+ *
+ * @return number of occurrences of the specified value.
+ */
+size_t treetable_contains_value(TreeTable const *const table,
+                                const void *value) {
+  RBNode *node = tree_min(table, table->root);
+
+  size_t o = 0;
+  while (node != table->sentinel) {
+    if (node->value == value)
+      o++;
+    node = get_successor_node(table, node);
+  }
+  return o;
+}
+
+/**
+ * Creates a new key-value mapping in the specified TreeTable. If the unique key
+ * is already mapped to a value in this table, that value is replaced with the
+ * new value. This operation may fail if the space allocation for the new entry
+ * fails.
+ *
+ * @param[in] table the table to which this new key-value mapping is being added
+ * @param[in] key a tree table key used to access the specified value
+ * @param[in] val a value that is being stored in the table
+ *
+ * @return CC_OK if the operation was successful, or CC_ERR_ALLOC if the memory
+ * allocation for the new element failed.
+ */
+enum cc_stat treetable_add(TreeTable *table, void *key, void *val) {
+  RBNode *y = table->sentinel;
+  RBNode *x = table->root;
+
+  int cmp;
+  while (x != table->sentinel) {
+    cmp = table->cmp(key, x->key);
+    y = x;
+
+    if (cmp < 0) {
+      x = x->left;
+    } else if (cmp > 0) {
+      x = x->right;
+    } else {
+      x->value = val;
+      return CC_OK;
+    }
+  }
+  RBNode *n = table->mem_alloc(sizeof(RBNode));
+
+  if (!n)
+    return CC_ERR_ALLOC;
+
+  n->value = val;
+  n->key = key;
+  n->parent = y;
+  n->left = table->sentinel;
+  n->right = table->sentinel;
+
+  table->size++;
+
+  if (y == table->sentinel) {
+    table->root = n;
+    n->color = RB_BLACK;
+  } else {
+    n->color = RB_RED;
+    if (table->cmp(key, y->key) < 0) {
+      y->left = n;
+    } else {
+      y->right = n;
+    }
+    rebalance_after_insert(table, n);
+  }
+  return CC_OK;
+}
+
+/**
+ * Rebalances the tale after an insert.
+ *
+ * @param[in] table TreeTable that is being rebalanced
+ * @param[in] z Node that was inserted
+ */
+static void rebalance_after_insert(TreeTable *table, RBNode *z) {
+  RBNode *y;
+
+  while (z->parent->color == RB_RED) {
+    if (z->parent == z->parent->parent->left) {
+      y = z->parent->parent->right;
+      if (y->color == RB_RED) {
+        z->parent->color = RB_BLACK;
+        y->color = RB_BLACK;
+        z->parent->parent->color = RB_RED;
+        z = z->parent->parent;
+      } else {
+        if (z == z->parent->right) {
+          z = z->parent;
+          rotate_left(table, z);
+        }
+        z->parent->color = RB_BLACK;
+        z->parent->parent->color = RB_RED;
+        rotate_right(table, z->parent->parent);
+      }
+    } else {
+      y = z->parent->parent->left;
+      if (y->color == RB_RED) {
+        z->parent->color = RB_BLACK;
+        y->color = RB_BLACK;
+        z->parent->parent->color = RB_RED;
+        z = z->parent->parent;
+      } else {
+        if (z == z->parent->left) {
+          z = z->parent;
+          rotate_right(table, z);
+        }
+        z->parent->color = RB_BLACK;
+        z->parent->parent->color = RB_RED;
+        rotate_left(table, z->parent->parent);
+      }
+    }
+  }
+  table->root->color = RB_BLACK;
+}
+
+/**
+ * Rebalances the tale after a delete.
+ *
+ * @param[in] table TreeTable that is being rebalanced
+ * @param[in] z Node that comes after the deleted node
+ */
+static void rebalance_after_delete(TreeTable *table, RBNode *x) {
+  RBNode *w;
+
+  while (x != table->root && x->color == RB_BLACK) {
+    if (x == x->parent->left) {
+      w = x->parent->right;
+      if (w->color == RB_RED) {
+        w->color = RB_BLACK;
+        x->parent->color = RB_RED;
+        rotate_left(table, x->parent);
+        w = x->parent->right;
+      }
+      if (w->left->color == RB_BLACK && w->right->color == RB_BLACK) {
+        w->color = RB_RED;
+        x = x->parent;
+      } else {
+        if (w->right->color == RB_BLACK) {
+          w->left->color = RB_BLACK;
+          w->color = RB_RED;
+          rotate_right(table, w);
+          w = x->parent->right;
+        }
+        w->color = x->parent->color;
+        x->parent->color = RB_BLACK;
+        w->right->color = RB_BLACK;
+        rotate_left(table, x->parent);
+        x = table->root;
+      }
+    } else {
+      w = x->parent->left;
+      if (w->color == RB_RED) {
+        w->color = RB_BLACK;
+        x->parent->color = RB_RED;
+        rotate_right(table, x->parent);
+        w = x->parent->left;
+      }
+      if (w->right->color == RB_BLACK && w->left->color == RB_BLACK) {
+        w->color = RB_RED;
+        x = x->parent;
+      } else {
+        if (w->left->color == RB_BLACK) {
+          w->right->color = RB_BLACK;
+          w->color = RB_RED;
+          rotate_left(table, w);
+          w = x->parent->left;
+        }
+        w->color = x->parent->color;
+        x->parent->color = RB_BLACK;
+        w->left->color = RB_BLACK;
+        rotate_right(table, x->parent);
+        x = table->root;
+      }
+    }
+  }
+  x->color = RB_BLACK;
+}
+
+static INLINE void transplant(TreeTable *table, RBNode *u, RBNode *v) {
+  if (u->parent == table->sentinel)
+    table->root = v;
+  else if (u == u->parent->left)
+    u->parent->left = v;
+  else
+    u->parent->right = v;
+
+  v->parent = u->parent;
+}
+
+static INLINE RBNode *tree_min(TreeTable const *const table, RBNode *n) {
+  RBNode *s = table->sentinel;
+
+  while (n->left != s)
+    n = n->left;
+  return n;
+}
+
+static INLINE RBNode *tree_max(TreeTable const *const table, RBNode *n) {
+  RBNode *s = table->sentinel;
+
+  while (n->right != s)
+    n = n->right;
+  return n;
+}
+
+/**
+ * Removes a node from the RB tree.
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] z the node that is being removed
+ */
+static void remove_node(TreeTable *table, RBNode *z) {
+  RBNode *x;
+  RBNode *y = z;
+
+  int y_color = y->color;
+
+  if (z->left == table->sentinel) {
+    x = z->right;
+    transplant(table, z, z->right);
+  } else if (z->right == table->sentinel) {
+    x = z->left;
+    transplant(table, z, z->left);
+  } else {
+    y = tree_min(table, z->right);
+    y_color = y->color;
+    x = y->right;
+    if (y->parent == z) {
+      x->parent = y;
+    } else {
+      transplant(table, y, y->right);
+      y->right = z->right;
+      y->right->parent = y;
+    }
+    transplant(table, z, y);
+    y->left = z->left;
+    y->left->parent = y;
+    y->color = z->color;
+  }
+  if (y_color == RB_BLACK)
+    rebalance_after_delete(table, x);
+
+  table->mem_free(z);
+  table->size--;
+}
+
+/**
+ * Removes a key-value mapping from the specified TreeTable and sets the out
+ * parameter to value.
+ *
+ * @param[in] table the table from which the key-value pair is being removed
+ * @param[in] key the key of the value being returned
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the key was not found.
+ */
+enum cc_stat treetable_remove(TreeTable *table, void *key, void **out) {
+  RBNode *node = get_tree_node_by_key(table, key);
+
+  if (!node)
+    return CC_ERR_KEY_NOT_FOUND;
+
+  if (out)
+    *out = node->value;
+
+  remove_node(table, node);
+  return CC_OK;
+}
+
+/**
+ * Removes the first (lowest) key from the specified table and sets the out
+ * parameter to value.
+ *
+ * @param[in] table the table from which the first entry is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the key was not found.
+ */
+enum cc_stat treetable_remove_first(TreeTable *table, void **out) {
+  if (table->size == 0)
+    return CC_ERR_KEY_NOT_FOUND;
+
+  RBNode *node = tree_min(table, table->root);
+
+  if (out)
+    *out = node->value;
+
+  remove_node(table, node);
+  return CC_OK;
+}
+
+/**
+ * Removes the last (highest) key from the specified table and sets the out
+ * parameter to value.
+ *
+ * @param[in] table the table from which the last entry is being removed
+ * @param[out] out Pointer to where the removed value is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the mapping was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the key was not found.
+ */
+enum cc_stat treetable_remove_last(TreeTable *table, void **out) {
+  RBNode *node = tree_max(table, table->root);
+
+  if (!node)
+    return CC_ERR_KEY_NOT_FOUND;
+
+  if (out)
+    *out = node->value;
+
+  remove_node(table, node);
+  return CC_OK;
+}
+
+/**
+ * Removes all entries from the table.
+ *
+ * @param[in] table the table from which all entries are to be removed
+ */
+void treetable_remove_all(TreeTable *table) {
+  tree_destroy(table, table->root);
+  table->size = 0;
+  table->root = table->sentinel;
+}
+
+/**
+ * Performs a right rotation on the specified table's RB tree at root <code>
+ * x</code>
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] x the node around which this operation is performed
+ */
+static void rotate_right(TreeTable *table, RBNode *x) {
+  RBNode *y = x->left;
+
+  x->left = y->right;
+
+  if (y->right != table->sentinel)
+    y->right->parent = x;
+
+  y->parent = x->parent;
+
+  if (x->parent == table->sentinel)
+    table->root = y;
+  else if (x == x->parent->right)
+    x->parent->right = y;
+  else
+    x->parent->left = y;
+
+  y->right = x;
+  x->parent = y;
+}
+
+/**
+ * Performs a left rotation on the specified table's RB tree at root <code>
+ * x</code>
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] x the node around which this operation is performed
+ */
+static void rotate_left(TreeTable *table, RBNode *x) {
+  RBNode *y = x->right;
+
+  x->right = y->left;
+
+  if (y->left != table->sentinel)
+    y->left->parent = x;
+
+  y->parent = x->parent;
+
+  if (x->parent == table->sentinel)
+    table->root = y;
+  else if (x == x->parent->left)
+    x->parent->left = y;
+  else
+    x->parent->right = y;
+
+  y->left = x;
+  x->parent = y;
+}
+
+/**
+ * Returns a tree node associated with the specified key.
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] key the key being looked up
+ *
+ * @return tree node associated with the key
+ */
+static RBNode *get_tree_node_by_key(TreeTable const *const table,
+                                    const void *key) {
+  if (table->size == 0)
+    return NULL;
+
+  RBNode *n = table->root;
+  RBNode *s = table->sentinel;
+
+  int cmp;
+  do {
+    cmp = table->cmp(key, n->key);
+
+    if (cmp < 0)
+      n = n->left;
+    else if (cmp > 0)
+      n = n->right;
+    else
+      return n;
+  } while (n != s && cmp != 0);
+
+  return NULL;
+}
+
+/**
+ * Returns a successor node of the node <code>x</code>
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] x the node whose successor is being returned
+ *
+ * @return successor node of x
+ */
+static RBNode *get_successor_node(TreeTable const *const table, RBNode *x) {
+  if (x == NULL)
+    return NULL;
+
+  if (x->right != table->sentinel)
+    return tree_min(table, x->right);
+
+  RBNode *y = x->parent;
+
+  while (y != table->sentinel && x == y->right) {
+    x = y;
+    y = y->parent;
+  }
+  return y;
+}
+
+/**
+ * Returns a predecessor node of the node <code>x</code>
+ *
+ * @param[in] table the table on which this operation is performed
+ * @param[in] x the node whose predecessor is being returned
+ *
+ * @return predecessor node of x
+ */
+static RBNode *get_predecessor_node(TreeTable const *const table, RBNode *x) {
+  if (x == NULL)
+    return NULL;
+
+  if (x->left != table->sentinel)
+    return tree_max(table, x->left);
+
+  RBNode *y = x->parent;
+
+  while (y != table->sentinel && x == y->left) {
+    x = y;
+    y = y->parent;
+  }
+  return y;
+}
+
+/**
+ * Applies the function fn to each key of the TreeTable.
+ *
+ * @note The operation function should not modify the key. Any modification
+ * of the key will invalidate the TreeTable.
+ *
+ * @param[in] table the table on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each key of the table
+ */
+void treetable_foreach_key(TreeTable *table, void (*fn)(const void *k)) {
+  RBNode *n = tree_min(table, table->root);
+
+  while (n != table->sentinel) {
+    fn(n->key);
+    n = get_successor_node(table, n);
+  }
+}
+
+/**
+ * Applies the function fn to each value of the TreeTable.
+ *
+ * @param[in] table the table on which this operation is being performed
+ * @param[in] fn the operation function that is invoked on each value of the
+ *               table
+ */
+void treetable_foreach_value(TreeTable *table, void (*fn)(void *k)) {
+  RBNode *n = tree_min(table, table->root);
+
+  while (n != table->sentinel) {
+    fn(n->value);
+    n = get_successor_node(table, n);
+  }
+}
+
+/**
+ * Initializes the TreeTableIter structure.
+ *
+ * @param[in] iter the iterator that is being initialized
+ * @param[in] table the table over whose entries the iterator is going to
+ * iterate
+ */
+void treetable_iter_init(TreeTableIter *iter, TreeTable *table) {
+  iter->table = table;
+  iter->current = table->sentinel;
+  iter->next = tree_min(table, table->root);
+}
+
+/**
+ * Advances the iterator and sets the out parameter to the value of the
+ * next TreeTableEntry.
+ *
+ * @param[in] iter the iterator that is being advanced
+ * @param[out] out Pointer to where the next entry is set
+ *
+ * @return CC_OK if the iterator was advanced, or CC_ITER_END if the
+ * end of the TreeTable has been reached.
+ */
+enum cc_stat treetable_iter_next(TreeTableIter *iter, TreeTableEntry *entry) {
+  if (iter->next == iter->table->sentinel)
+    return CC_ITER_END;
+
+  entry->value = iter->next->value;
+  entry->key = iter->next->key;
+
+  iter->current = iter->next;
+  iter->next = get_successor_node(iter->table, iter->current);
+
+  return CC_OK;
+}
+
+/**
+ * Removes the last returned entry by <code>treetable_iter_next()</code>
+ * function without invalidating the iterator and optionally sets the
+ * out parameter to the value of the removed entry.
+ *
+ * @note This Function should only ever be called after a call to <code>
+ * treetable_iter_next()</code>
+ *
+ * @param[in] iter The iterator on which this operation is performed
+ * @param[out] out Pointer to where the removed element is stored, or NULL
+ *                 if it is to be ignored
+ *
+ * @return CC_OK if the entry was successfully removed, or
+ * CC_ERR_KEY_NOT_FOUND if the entry was already removed.
+ */
+enum cc_stat treetable_iter_remove(TreeTableIter *iter, void **out) {
+  if (!iter->current)
+    return CC_ERR_KEY_NOT_FOUND;
+
+  if (out)
+    *out = iter->current->value;
+
+  remove_node(iter->table, iter->current);
+  iter->current = NULL;
+
+  return CC_OK;
+}
+
+#ifdef DEBUG
+static int treetable_test(TreeTable *table, RBNode *node, int *nb) {
+  if (node == table->sentinel) {
+    *nb = 1;
+    return RB_ERROR_OK;
+  }
+  /* check tree order */
+  if (node->left != table->sentinel) {
+    int cmp = table->cmp(node->left->key, node->key);
+    if (cmp >= 0)
+      return RB_ERROR_TREE_STRUCTURE;
+  }
+  if (node->right != table->sentinel) {
+    int cmp = table->cmp(node->right->key, node->key);
+    if (cmp <= 0)
+      return RB_ERROR_TREE_STRUCTURE;
+  }
+
+  /* check red rule */
+  if (node->color == RB_RED && node->parent->color == RB_RED) {
+    return RB_ERROR_CONSECUTIVE_RED;
+  }
+
+  int nb_left;
+  int nb_right;
+
+  int left_err = treetable_test(table, node->left, &nb_left);
+
+  /* propagate the descendant errors all the way up */
+  if (left_err != RB_ERROR_OK)
+    return left_err;
+
+  int right_err = treetable_test(table, node->right, &nb_right);
+
+  if (right_err != RB_ERROR_OK)
+    return right_err;
+
+  /* check black rule */
+  if (nb_left != nb_right)
+    return RB_ERROR_BLACK_HEIGHT;
+
+  if (node->color == RB_BLACK)
+    *nb = nb_left + 1;
+  else
+    *nb = nb_left;
+
+  return RB_ERROR_OK;
+}
+
+int treetable_assert_rb_rules(TreeTable *table) {
+  int x;
+  int status = treetable_test(table, table->root, &x);
+  return status;
+}
+#endif

--- a/test/c/collections-c/normal/src/utils.c
+++ b/test/c/collections-c/normal/src/utils.c
@@ -1,0 +1,24 @@
+#include "utils.h"
+
+void CHECK_EQUAL_C_STRING(char *s1, char *s2) {
+  owi_assert(strcmp(s1, s2) == 0);
+}
+
+void *copy(void *e1) {
+  int *cp = (int *)malloc(sizeof(int));
+  *cp = *((int *)e1);
+  return cp;
+}
+
+int cmp(void const *e1, void const *e2) {
+  int i = *((int *)e1);
+  int j = *((int *)e2);
+
+  if (i < j)
+    return -1;
+  if (i == j)
+    return 0;
+  return 1;
+}
+
+int zero_if_ptr_eq(void const *e1, void const *e2) { return !(e1 == e2); }

--- a/test/c/collections-c/normal/stack_tests.t
+++ b/test/c/collections-c/normal/stack_tests.t
@@ -1,0 +1,5 @@
+Stack tests:
+  $ owi c -I include src/stack.c src/array.c src/common.c src/utils.c testsuite/stack/stack_test_pop.c
+  All OK
+  $ owi c -I include src/stack.c src/array.c src/common.c src/utils.c testsuite/stack/stack_test_push.c
+  All OK

--- a/test/c/collections-c/normal/testsuite/array/array_test_add.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_add.c
@@ -1,0 +1,36 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+  owi_assert(stat == CC_OK);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  int *ar;
+  int *br;
+  int *cr;
+
+  array_get_at(v1, 0, (void *)&ar);
+  array_get_at(v1, 1, (void *)&br);
+  array_get_at(v1, 2, (void *)&cr);
+
+  owi_assert(a == *ar);
+  owi_assert(b == *br);
+  owi_assert(c == *cr);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_addAt2.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_addAt2.c
@@ -1,0 +1,19 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  owi_assert(0 == array_size(v1));
+  owi_assert(CC_ERR_OUT_OF_RANGE == array_add_at(v1, &a, 1));
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_contains.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_contains.c
@@ -1,0 +1,35 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  owi_assume(a != b && a != c && a != d && b != c && b != d && c != d);
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &c);
+
+  int cc = array_contains(v1, &c);
+  int ca = array_contains(v1, &a);
+  int cd = array_contains(v1, &d);
+
+  owi_assert(2 == cc);
+  owi_assert(1 == ca);
+  owi_assert(0 == cd);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_deepCopy.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_deepCopy.c
@@ -1,0 +1,34 @@
+#include "array.h"
+#include "owi.h"
+#include "utils.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  array_copy_deep(v1, copy, &v2);
+
+  owi_assert(array_size(v2) == array_size(v1));
+
+  int *ca;
+  array_get_at(v2, 0, (void *)&ca);
+
+  owi_assert(a == *ca);
+  array_destroy_cb(v2, free);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_getAt.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_getAt.c
@@ -1,0 +1,33 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int e = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &e);
+
+  int *ar;
+  int *cr;
+  array_get_at(v1, 0, (void *)&ar);
+  array_get_at(v1, 2, (void *)&cr);
+
+  owi_assert(a == *ar);
+  owi_assert(c == *cr);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_indexOf.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_indexOf.c
@@ -1,0 +1,32 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  size_t ai;
+  array_index_of(v1, &a, &ai);
+
+  size_t ci;
+  array_index_of(v1, &c, &ci);
+
+  owi_assert(0 == ai);
+  owi_assert(2 == ci);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_iterAdd.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_iterAdd.c
@@ -1,0 +1,48 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  int N = owi_i32();
+
+  owi_assume(c != a && c != b && c != d && c != N);
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &d);
+
+  ArrayIter iter;
+  array_iter_init(&iter, v1);
+
+  int *e;
+  while (array_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (*e == c)
+      array_iter_add(&iter, &N);
+  }
+
+  owi_assert(5 == array_size(v1));
+
+  void *n;
+  array_get_at(v1, 3, &n);
+  owi_assert(N == *((int *)n));
+  owi_assert(1 == array_contains(v1, &N));
+
+  array_get_at(v1, 4, (void *)&n);
+  owi_assert(d == *((int *)n));
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_iterRemove.c
@@ -1,0 +1,37 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &d);
+  owi_assume(c != a && c != b && c != d);
+
+  ArrayIter iter;
+  array_iter_init(&iter, v1);
+
+  int *e;
+  while (array_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (*e == c)
+      array_iter_remove(&iter, NULL);
+  }
+
+  owi_assert(0 == array_contains(v1, &c));
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_iterReplace.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_iterReplace.c
@@ -1,0 +1,45 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  int replacement = owi_i32();
+
+  owi_assume(c != a && c != b && c != d && c != replacement);
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &d);
+
+  ArrayIter iter;
+  array_iter_init(&iter, v1);
+
+  int *e;
+  int *old;
+  while (array_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (*e == c)
+      array_iter_replace(&iter, (void *)&replacement, (void *)&old);
+  }
+
+  size_t index;
+  array_index_of(v1, (void *)&replacement, &index);
+
+  owi_assert(2 == index);
+  owi_assert(0 == array_contains(v1, &c));
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_reduce.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_reduce.c
@@ -1,0 +1,42 @@
+#include "array.h"
+#include "owi.h"
+
+void reduce_add(void *e1, void *e2, void *result) {
+  int el1 = e1 ? *((int *)e1) : 0;
+  int el2 = e2 ? *((int *)e2) : 0;
+  *((int *)result) = el1 + el2;
+}
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int result;
+
+  array_add(v1, &a);
+  array_reduce(v1, reduce_add, (void *)&result);
+  owi_assert(a == result);
+
+  array_add(v1, &b);
+  array_reduce(v1, reduce_add, (void *)&result);
+  owi_assert(a + b == result);
+
+  array_add(v1, &c);
+  array_add(v1, &d);
+  array_add(v1, &e);
+  array_reduce(v1, reduce_add, (void *)&result);
+  owi_assert(a + b + c + d + e == result);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_remove.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_remove.c
@@ -1,0 +1,32 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+  int n = owi_i32();
+  owi_assume(n > 2);
+  owi_assume(n < 16);
+
+  int *last;
+  int *next_to_last;
+
+  for (int i = 0; i < n; i++) {
+    int *a = malloc(sizeof(int));
+    array_add(v1, a);
+    next_to_last = last;
+    last = a;
+  }
+
+  array_remove(v1, next_to_last, NULL);
+
+  owi_assert(array_size(v1) < n);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_removeAll.c
@@ -1,0 +1,32 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+  int n = owi_i32();
+  owi_assume(n > 2);
+  owi_assume(n < 16);
+
+  int *last;
+  int *next_to_last;
+
+  for (int i = 0; i < n; i++) {
+    int *a = malloc(sizeof(int));
+    array_add(v1, a);
+    next_to_last = last;
+    last = a;
+  }
+
+  array_remove_all(v1);
+
+  owi_assert(array_size(v1) == 0);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_removeAt.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_removeAt.c
@@ -1,0 +1,33 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int e = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &e);
+
+  array_remove_at(v1, 2, NULL);
+
+  owi_assert(3 == array_size(v1));
+
+  int *r;
+  array_get_at(v1, 2, (void *)&r);
+
+  owi_assert(r == &e);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_replaceAt.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_replaceAt.c
@@ -1,0 +1,32 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  int r = owi_i32();
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  array_replace_at(v1, &r, 2, NULL);
+
+  int *repl;
+  array_get_at(v1, 2, (void *)&repl);
+
+  owi_assert(*repl != c);
+  owi_assert(*repl == r);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_reverse.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_reverse.c
@@ -1,0 +1,36 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  array_reverse(v1);
+
+  int *i0;
+  int *i1;
+  int *i2;
+  array_get_at(v1, 0, (void *)&i0);
+  array_get_at(v1, 1, (void *)&i1);
+  array_get_at(v1, 2, (void *)&i2);
+
+  owi_assert(c == *i0);
+  owi_assert(b == *i1);
+  owi_assert(a == *i2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_shallowCopy.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_shallowCopy.c
@@ -1,0 +1,36 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+
+  array_copy_shallow(v1, &v2);
+
+  owi_assert(array_size(v2) == array_size(v1));
+
+  int *ga;
+  int *gb;
+  array_get_at(v1, 2, (void *)&ga);
+  array_get_at(v2, 2, (void *)&gb);
+
+  owi_assert(*ga == *gb);
+
+  array_destroy(v2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_subarray.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_subarray.c
@@ -1,0 +1,45 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  array_add(v1, &a);
+  array_add(v1, &b);
+  array_add(v1, &c);
+  array_add(v1, &e);
+  array_add(v1, &f);
+
+  Array *sub;
+  array_subarray(v1, 1, 3, &sub);
+
+  owi_assert(3 == array_size(sub));
+
+  int *s0;
+  int *s1;
+  int *s2;
+  array_get_at(sub, 0, (void *)&s0);
+  array_get_at(sub, 1, (void *)&s1);
+  array_get_at(sub, 2, (void *)&s2);
+
+  owi_assert(&b == s0);
+  owi_assert(&c == s1);
+  owi_assert(&e == s2);
+
+  array_destroy(sub);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_zipIterAdd.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_zipIterAdd.c
@@ -1,0 +1,93 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+
+  char str_i[] = {i, '\0'};
+
+  owi_assume((!(strcmp(str_a, str_b) == 0)) && (!(strcmp(str_c, str_b) == 0)) &&
+             (!(strcmp(str_c, str_a) == 0)) && (!(strcmp(str_c, str_d) == 0)) &&
+             (!(strcmp(str_d, str_b) == 0)) && (!(strcmp(str_a, str_h) == 0)) &&
+             (!(strcmp(str_c, str_h) == 0)) && (!(strcmp(str_d, str_h) == 0)) &&
+             (!(strcmp(str_b, str_h) == 0)) && (!(strcmp(str_i, str_e) == 0)) &&
+             (!(strcmp(str_i, str_g) == 0)) && (!(strcmp(str_i, str_f) == 0)));
+
+  array_add(v1, str_a);
+  array_add(v1, str_b);
+  array_add(v1, str_c);
+  array_add(v1, str_d);
+
+  array_new(&v2);
+
+  array_add(v2, str_e);
+  array_add(v2, str_f);
+  array_add(v2, str_g);
+
+  ArrayZipIter zip;
+  array_zip_iter_init(&zip, v1, v2);
+
+  void *e1, *e2;
+  while (array_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      array_zip_iter_add(&zip, str_h, str_i);
+  }
+
+  size_t index;
+
+  owi_assert(CC_OK == array_index_of(v1, str_h, &index));
+  owi_assert(2 == index);
+  owi_assert(CC_OK == array_index_of(v2, str_i, &index));
+  owi_assert(2 == index);
+  owi_assert(CC_OK == array_index_of(v1, str_c, &index));
+  owi_assert(3 == index);
+  owi_assert(1 == array_contains(v1, str_h));
+  owi_assert(1 == array_contains(v2, str_i));
+  owi_assert(5 == array_size(v1));
+  owi_assert(4 == array_size(v2));
+
+  array_destroy(v2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_zipIterNext.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_zipIterNext.c
@@ -1,0 +1,75 @@
+#include "array.h"
+#include "owi.h"
+#include "utils.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  array_add(v1, str_a);
+  array_add(v1, str_b);
+  array_add(v1, str_c);
+  array_add(v1, str_d);
+
+  array_new(&v2);
+
+  array_add(v2, str_e);
+  array_add(v2, str_f);
+  array_add(v2, str_g);
+
+  ArrayZipIter zip;
+  array_zip_iter_init(&zip, v1, v2);
+
+  size_t i = 0;
+
+  void *e1, *e2;
+  while (array_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (i == 0) {
+      CHECK_EQUAL_C_STRING(str_a, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_e, (char *)e2);
+    }
+    if (i == 2) {
+      CHECK_EQUAL_C_STRING(str_c, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_g, (char *)e2);
+    }
+    i++;
+  }
+  owi_assert(3 == i);
+  array_destroy(v2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_zipIterRemove.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_zipIterRemove.c
@@ -1,0 +1,75 @@
+#include "array.h"
+#include "owi.h"
+#include "utils.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  owi_assume((!(strcmp(str_a, str_b) == 0)) && (!(strcmp(str_c, str_b) == 0)) &&
+             (!(strcmp(str_d, str_b) == 0)));
+
+  array_add(v1, str_a);
+  array_add(v1, str_b);
+  array_add(v1, str_c);
+  array_add(v1, str_d);
+
+  array_new(&v2);
+
+  array_add(v2, str_e);
+  array_add(v2, str_f);
+  array_add(v2, str_g);
+
+  ArrayZipIter zip;
+  array_zip_iter_init(&zip, v1, v2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (array_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      array_zip_iter_remove(&zip, &r1, &r2);
+  }
+  CHECK_EQUAL_C_STRING(str_b, (char *)r1);
+  owi_assert(0 == array_contains(v1, str_b));
+  owi_assert(0 == array_contains(v2, str_f));
+  owi_assert(3 == array_size(v1));
+  owi_assert(2 == array_size(v2));
+
+  array_destroy(v2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/array/array_test_zipIterReplace.c
+++ b/test/c/collections-c/normal/testsuite/array/array_test_zipIterReplace.c
@@ -1,0 +1,91 @@
+#include "array.h"
+#include "owi.h"
+
+static Array *v1;
+static Array *v2;
+static ArrayConf vc;
+static int stat;
+
+int main() {
+  stat = array_new(&v1);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+
+  char str_i[] = {i, '\0'};
+
+  owi_assume((!(strcmp(str_a, str_b) == 0)) && (!(strcmp(str_c, str_b) == 0)) &&
+             (!(strcmp(str_c, str_a) == 0)) && (!(strcmp(str_c, str_d) == 0)) &&
+             (!(strcmp(str_d, str_b) == 0)) && (!(strcmp(str_a, str_h) == 0)) &&
+             (!(strcmp(str_c, str_h) == 0)) && (!(strcmp(str_d, str_h) == 0)) &&
+             (!(strcmp(str_b, str_h) == 0)) && (!(strcmp(str_i, str_e) == 0)) &&
+             (!(strcmp(str_i, str_g) == 0)) && (!(strcmp(str_i, str_f) == 0)));
+
+  array_add(v1, str_a);
+  array_add(v1, str_b);
+  array_add(v1, str_c);
+  array_add(v1, str_d);
+
+  array_new(&v2);
+
+  array_add(v2, str_e);
+  array_add(v2, str_f);
+  array_add(v2, str_g);
+
+  ArrayZipIter zip;
+  array_zip_iter_init(&zip, v1, v2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (array_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0) {
+      array_zip_iter_replace(&zip, str_h, str_i, &r1, &r2);
+    }
+  }
+
+  size_t index;
+
+  owi_assert(CC_OK == array_index_of(v1, str_h, &index));
+  owi_assert(1 == index);
+  owi_assert(CC_OK == array_index_of(v2, str_i, &index));
+  owi_assert(1 == index);
+  owi_assert(1 == array_contains(v1, str_h));
+  owi_assert(1 == array_contains(v2, str_i));
+
+  array_destroy(v2);
+
+  array_destroy(v1);
+
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addAt1.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addAt1.c
@@ -1,0 +1,43 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+
+  deque_add_at(deque, &g, 4);
+
+  const void *const *buff = deque_get_buffer(deque);
+
+  owi_assert(buff[4] == &g);
+
+  owi_assert(buff[5] == &e);
+
+  const void *elem = buff[6];
+  owi_assert(elem == &f);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addAt2.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addAt2.c
@@ -1,0 +1,48 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_first(deque, &c);
+  deque_add_first(deque, &d);
+  deque_add_first(deque, &e);
+  deque_add_first(deque, &f);
+
+  deque_add_at(deque, &g, 1);
+
+  const void *const *buff = deque_get_buffer(deque);
+  const void *elem = buff[5];
+
+  owi_assert(elem == &g);
+
+  const void *elem1 = buff[0];
+  owi_assert(elem1 == &a);
+
+  const void *elem2 = buff[7];
+  owi_assert(elem2 == &c);
+
+  const void *elem3 = buff[3];
+  owi_assert(elem3 == &f);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addAt3.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addAt3.c
@@ -1,0 +1,48 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_first(deque, &b);
+  deque_add_first(deque, &c);
+  deque_add_first(deque, &d);
+  deque_add_first(deque, &e);
+  deque_add_first(deque, &f);
+
+  deque_add_at(deque, &g, 3);
+
+  const void *const *buff = deque_get_buffer(deque);
+
+  const void *elem = buff[6];
+  owi_assert(elem == &g);
+
+  const void *elem1 = buff[0];
+  owi_assert(elem1 == &b);
+
+  const void *elem2 = buff[7];
+  owi_assert(elem2 == &c);
+
+  const void *elem3 = buff[1];
+  owi_assert(elem3 == &a);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addAt4.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addAt4.c
@@ -1,0 +1,48 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_first(deque, &f);
+
+  deque_add_at(deque, &g, 1);
+
+  const void *const *buff = deque_get_buffer(deque);
+  const int elem = *((int *)buff[0]);
+
+  owi_assert(elem == g);
+
+  const int elem1 = *((int *)buff[4]);
+  owi_assert(elem1 == e);
+
+  const int elem2 = *((int *)buff[6]);
+  owi_assert(elem2 == f);
+
+  const int elem3 = *((int *)buff[7]);
+  owi_assert(elem3 == a);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addAt5.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addAt5.c
@@ -1,0 +1,48 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+
+  deque_add_at(deque, &g, 1);
+
+  const void *const *buff = deque_get_buffer(deque);
+  const int elem = *((int *)buff[7]);
+
+  owi_assert(elem == a);
+
+  const int elem1 = *((int *)buff[0]);
+  owi_assert(elem1 == b);
+
+  const int elem2 = *((int *)buff[5]);
+  owi_assert(elem2 == f);
+
+  const int elem3 = *((int *)buff[1]);
+  owi_assert(elem3 == g);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addFirst.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addFirst.c
@@ -1,0 +1,39 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_first(deque, &b);
+  deque_add_first(deque, &c);
+
+  owi_assert(3 == deque_size(deque));
+
+  size_t m = deque_capacity(deque);
+  const void *const *u = deque_get_buffer(deque);
+  const void *e = u[m - 1];
+
+  owi_assert(e == &a);
+
+  e = u[m - 2];
+  owi_assert(e == &b);
+
+  e = u[m - 3];
+  owi_assert(e == &c);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_addLast.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_addLast.c
@@ -1,0 +1,38 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+
+  owi_assert(3 == deque_size(deque));
+
+  const void *const *u = deque_get_buffer(deque);
+  const void *e = u[0];
+
+  owi_assert(e == &a);
+
+  e = u[1];
+  owi_assert(e == &b);
+
+  e = u[2];
+  owi_assert(e == &c);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_bufferExpansion.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_bufferExpansion.c
@@ -1,0 +1,72 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() {
+  deque_conf_init(&conf);
+  conf.capacity = 4;
+  deque_new_conf(&conf, &deque);
+}
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_first(deque, &c);
+  deque_add_last(deque, &d);
+
+  size_t capacity = deque_capacity(deque);
+
+  owi_assert(4 == capacity);
+
+  /* Current layout:
+     _________________
+     | b | d | c | a |
+     -----------------
+           L   F
+  */
+  /* This line should trigger the buffer expansion */
+  deque_add_first(deque, &e);
+
+  capacity = deque_capacity(deque);
+  owi_assert(8 == capacity);
+
+  /* The expansion should align the elements.*/
+  const void *const *buff = deque_get_buffer(deque);
+  const int elem = *((int *)buff[0]);
+
+  owi_assert(elem == c);
+
+  const int elem1 = *((int *)buff[1]);
+  owi_assert(elem1 == a);
+
+  const int elem2 = *((int *)buff[2]);
+  owi_assert(elem2 == b);
+
+  const int elem3 = *((int *)buff[3]);
+  owi_assert(elem3 == d);
+
+  const int elem4 = *((int *)buff[7]);
+  owi_assert(elem4 == e);
+
+  deque_add_last(deque, &f);
+
+  const int elem5 = *((int *)buff[4]);
+  owi_assert(elem5 == f);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_capacity.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_capacity.c
@@ -1,0 +1,37 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  DequeConf conf;
+  deque_conf_init(&conf);
+
+  conf.capacity = 2;
+
+  Deque *deque;
+  deque_new_conf(&conf, &deque);
+
+  owi_assert(2 == deque_capacity(deque));
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+
+  owi_assert(4 == deque_capacity(deque));
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_contains.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_contains.c
@@ -1,0 +1,38 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+  deque_add(deque, &d);
+  deque_add(deque, &e);
+  deque_add(deque, &f);
+  deque_add(deque, &a);
+
+  owi_assert(2 == deque_contains(deque, &a));
+  owi_assert(0 == deque_contains(deque, &g));
+  owi_assert(1 == deque_contains(deque, &e));
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_copyDeep.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_copyDeep.c
@@ -1,0 +1,55 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int *a = malloc(sizeof(int));
+  int *b = malloc(sizeof(int));
+  int *c = malloc(sizeof(int));
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+
+  *a = x;
+  *b = y;
+  *c = z;
+
+  deque_add_last(deque, a);
+  deque_add_last(deque, b);
+  deque_add_last(deque, c);
+
+  Deque *cpy;
+  deque_copy_deep(deque, copy, &cpy);
+
+  int size = deque_size(cpy);
+  owi_assert(3 == size);
+
+  int *ca;
+  deque_get_at(cpy, 0, (void *)&ca);
+  int *cb;
+  deque_get_at(cpy, 1, (void *)&cb);
+  int *cc;
+  deque_get_at(cpy, 2, (void *)&cc);
+
+  owi_assert(x == *ca);
+  owi_assert(y == *cb);
+  owi_assert(z == *cc);
+  deque_destroy_cb(cpy, free);
+  free(a);
+  free(b);
+  free(c);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_copyShallow.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_copyShallow.c
@@ -1,0 +1,45 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+
+  Deque *copy;
+  deque_copy_shallow(deque, &copy);
+
+  int size = deque_size(copy);
+  owi_assert(3 == size);
+
+  int *ca;
+  deque_get_at(copy, 0, (void *)&ca);
+
+  int *cb;
+  deque_get_at(copy, 1, (void *)&cb);
+
+  int *cc;
+  deque_get_at(copy, 2, (void *)&cc);
+
+  owi_assert(a == *ca);
+  owi_assert(b == *cb);
+  owi_assert(c == *cc);
+  deque_destroy(copy);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filter1.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filter1.c
@@ -1,0 +1,53 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(!pred1(&d) && !pred1(&e) && !pred1(&f) && pred1(&a) && pred1(&b) &&
+             pred1(&c));
+
+  deque_add_last(deque, (void *)&a);
+  deque_add_last(deque, (void *)&b);
+  deque_add_last(deque, (void *)&c);
+  deque_add_last(deque, (void *)&d);
+  deque_add_last(deque, (void *)&e);
+  deque_add_last(deque, (void *)&f);
+  owi_assert(6 == deque_size(deque));
+
+  Deque *filter = NULL;
+  deque_filter(deque, pred1, &filter);
+  owi_assert(3 == deque_size(filter));
+  const void *const *buff = deque_get_buffer(filter);
+
+  owi_assert(buff[0] == &a);
+  owi_assert(buff[1] == &b);
+
+  const void *elem = buff[2];
+  owi_assert(elem == &c);
+  free(filter);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filter2.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filter2.c
@@ -1,0 +1,52 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(pred2(&d) && pred2(&e) && pred2(&f) && !pred2(&a) && !pred2(&b) &&
+             !pred2(&c));
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+  owi_assert(6 == deque_size(deque));
+
+  Deque *filter = NULL;
+  deque_filter(deque, pred2, &filter);
+  const void *const *buff = deque_get_buffer(filter);
+
+  owi_assert(3 == deque_size(filter));
+  owi_assert(buff[0] == &d);
+  owi_assert(buff[1] == &e);
+  owi_assert(buff[2] == &f);
+
+  free(filter);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filter3.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filter3.c
@@ -1,0 +1,50 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(!pred3(&d) && !pred3(&e) && pred3(&f) && !pred3(&a) &&
+             !pred3(&b) && !pred3(&c));
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+  owi_assert(6 == deque_size(deque));
+
+  Deque *filter = NULL;
+  deque_filter(deque, pred3, &filter);
+  const void *const *buff = deque_get_buffer(filter);
+
+  owi_assert(1 == deque_size(filter));
+  owi_assert(buff[0] == &f);
+
+  free(filter);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut1.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut1.c
@@ -1,0 +1,54 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(!pred1(&d) && !pred1(&e) && !pred1(&f) && pred1(&a) && pred1(&b) &&
+             pred1(&c));
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+  owi_assert(6 == deque_size(deque));
+
+  deque_filter_mut(deque, pred1);
+  owi_assert(3 == deque_size(deque));
+
+  int *removed = NULL;
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(a == *removed);
+
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(b == *removed);
+
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(c == *removed);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut2.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut2.c
@@ -1,0 +1,54 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(pred2(&d) && pred2(&e) && pred2(&f) && !pred2(&a) && !pred2(&b) &&
+             !pred2(&c));
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+  owi_assert(6 == deque_size(deque));
+
+  deque_filter_mut(deque, pred2);
+  owi_assert(3 == deque_size(deque));
+
+  int *removed = NULL;
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(d == *removed);
+
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(e == *removed);
+
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(f == *removed);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut3.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_filterMut3.c
@@ -1,0 +1,47 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+bool pred1(const void *e) { return *(int *)e <= 3; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+bool pred3(const void *e) { return *(int *)e > 5; }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  owi_assume(!pred3(&d) && !pred3(&e) && pred3(&f) && !pred3(&a) &&
+             !pred3(&b) && !pred3(&c));
+
+  deque_add_last(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+  deque_add_last(deque, &e);
+  deque_add_last(deque, &f);
+  owi_assert(6 == deque_size(deque));
+
+  deque_filter_mut(deque, pred3);
+  owi_assert(1 == deque_size(deque));
+
+  int *removed = NULL;
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(f == *removed);
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_getAt.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_getAt.c
@@ -1,0 +1,33 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+
+  void *e;
+  deque_get_at(deque, 1, &e);
+  void *n;
+  int status = deque_get_at(deque, 42, &n);
+
+  owi_assert(b == *(int *)e);
+  owi_assert(CC_ERR_OUT_OF_RANGE == status);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_getFirst.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_getFirst.c
@@ -1,0 +1,30 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_first(deque, &c);
+
+  int *first;
+  deque_get_first(deque, (void *)&first);
+
+  owi_assert(c == *first);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_getLast.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_getLast.c
@@ -1,0 +1,30 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_first(deque, &c);
+
+  int *last;
+  deque_get_last(deque, (void *)&last);
+
+  owi_assert(b == *last);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_iterAdd.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_iterAdd.c
@@ -1,0 +1,57 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  int g = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+  deque_add(deque, &d);
+  deque_add(deque, &e);
+  deque_add(deque, &f);
+
+  owi_assume(d != a && d != b && d != c && d != e && d != f);
+
+  DequeIter iter;
+  deque_iter_init(&iter, deque);
+
+  size_t i = 0;
+
+  int *el;
+
+  owi_assert(6 == deque_size(deque));
+
+  while (deque_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (*el == d)
+      deque_iter_add(&iter, &g);
+    if (i >= 3) {
+      owi_assert(i == deque_iter_index(&iter) - 1);
+    }
+    i++;
+  }
+  owi_assert(7 == deque_size(deque));
+
+  void *ret_;
+  deque_get_at(deque, 4, &ret_);
+  owi_assert(g == *(int *)ret_);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_iterNext.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_iterNext.c
@@ -1,0 +1,48 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+  deque_add(deque, &d);
+  deque_add(deque, &e);
+  deque_add(deque, &f);
+
+  owi_assume(d != a && d != b && d != c && d != e && d != f);
+
+  DequeIter iter;
+  deque_iter_init(&iter, deque);
+
+  size_t i = 0;
+
+  void *el;
+  while (deque_iter_next(&iter, &el) != CC_ITER_END) {
+    void *k;
+    deque_get_at(deque, i, &k);
+    owi_assert(k == el);
+    i++;
+
+    owi_assert(i == iter.index);
+  }
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_iterRemove.c
@@ -1,0 +1,53 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+  deque_add(deque, &d);
+  deque_add(deque, &e);
+  deque_add(deque, &f);
+
+  owi_assume(d != a && d != b && d != c && d != e && d != f);
+
+  DequeIter iter;
+  deque_iter_init(&iter, deque);
+
+  size_t i = 0;
+  void *el;
+  while (deque_iter_next(&iter, &el) != CC_ITER_END) {
+    if (i == 3)
+      deque_iter_remove(&iter, NULL);
+
+    if (i > 2) {
+      owi_assert(5 == deque_size(deque));
+    } else {
+      owi_assert(6 == deque_size(deque));
+    }
+    if (i >= 3) {
+      owi_assert(i - 1 == deque_iter_index(&iter));
+    }
+    i++;
+  }
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_removeAll.c
@@ -1,0 +1,37 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+
+  deque_remove_all(deque);
+
+  void *first;
+  int stat1 = deque_get_first(deque, &first);
+  void *last;
+  int stat2 = deque_get_last(deque, &last);
+
+  owi_assert(CC_ERR_OUT_OF_RANGE == stat1);
+  owi_assert(CC_ERR_OUT_OF_RANGE == stat2);
+
+  owi_assert(0 == deque_size(deque));
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_removeFirst.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_removeFirst.c
@@ -1,0 +1,38 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_last(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+
+  int *first;
+  deque_get_first(deque, (void *)&first);
+  owi_assert(a == *first);
+
+  int *removed;
+  deque_remove_first(deque, (void *)&removed);
+  owi_assert(a == *removed);
+
+  deque_get_first(deque, (void *)&first);
+  owi_assert(b == *first);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_removeLast.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_removeLast.c
@@ -1,0 +1,38 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  deque_add_first(deque, &a);
+  deque_add_first(deque, &b);
+  deque_add_last(deque, &c);
+  deque_add_last(deque, &d);
+
+  int *last;
+  deque_get_last(deque, (void *)&last);
+  owi_assert(d == *last);
+
+  int *removed;
+  deque_remove_last(deque, (void *)&removed);
+  owi_assert(d == *removed);
+
+  deque_get_last(deque, (void *)&last);
+  owi_assert(c == *last);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_reverse.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_reverse.c
@@ -1,0 +1,38 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+
+  deque_reverse(deque);
+
+  int *ra;
+  deque_get_at(deque, 0, (void *)&ra);
+  int *rb;
+  deque_get_at(deque, 1, (void *)&rb);
+  int *rc;
+  deque_get_at(deque, 2, (void *)&rc);
+
+  owi_assert(c == *ra);
+  owi_assert(b == *rb);
+  owi_assert(a == *rc);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_size.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_size.c
@@ -1,0 +1,30 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+  deque_add(deque, &d);
+
+  size_t size = deque_size(deque);
+  owi_assert(4 == size);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_trimCapacity.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_trimCapacity.c
@@ -1,0 +1,31 @@
+#include "deque.h"
+#include "owi.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  deque_add(deque, &a);
+  deque_add(deque, &b);
+  deque_add(deque, &c);
+
+  owi_assert(8 == deque_capacity(deque));
+
+  deque_trim_capacity(deque);
+
+  owi_assert(4 == deque_capacity(deque));
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterAdd.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterAdd.c
@@ -1,0 +1,95 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+
+  deque_add(deque, str_a);
+  deque_add(deque, str_b);
+  deque_add(deque, str_c);
+  deque_add(deque, str_d);
+
+  Deque *d2;
+  deque_new(&d2);
+
+  deque_add(d2, str_e);
+  deque_add(d2, str_f);
+  deque_add(d2, str_g);
+
+  symb_str(h);
+  symb_str(i);
+
+  DequeZipIter zip;
+  deque_zip_iter_init(&zip, deque, d2);
+
+  void *e1, *e2;
+  while (deque_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      deque_zip_iter_add(&zip, str_h, str_i);
+  }
+
+  size_t index;
+  deque_index_of(deque, str_h, &index);
+
+  owi_assert(2 == index);
+
+  deque_index_of(deque, str_i, &index);
+  owi_assert(2 == index);
+
+  deque_index_of(deque, str_c, &index);
+  owi_assert(3 == index);
+  owi_assert(1 == deque_contains(deque, str_h));
+  owi_assert(1 == deque_contains(d2, str_i));
+  owi_assert(5 == deque_size(deque));
+  owi_assert(4 == deque_size(d2));
+  deque_destroy(d2);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterNext.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterNext.c
@@ -1,0 +1,73 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  char str_g[] = {g, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+
+  deque_add(deque, str_a);
+  deque_add(deque, str_b);
+  deque_add(deque, str_c);
+  deque_add(deque, str_d);
+
+  Deque *d2;
+  deque_new(&d2);
+
+  deque_add(d2, str_e);
+  deque_add(d2, str_f);
+  deque_add(d2, str_g);
+
+  DequeZipIter zip;
+  deque_zip_iter_init(&zip, deque, d2);
+
+  size_t i = 0;
+
+  void *e1, *e2;
+  while (deque_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (i == 0) {
+      owi_assert(strcmp(str_a, (char *)e1) == 0);
+      owi_assert(strcmp(str_e, (char *)e2) == 0);
+    }
+    if (i == 2) {
+      owi_assert(strcmp(str_c, (char *)e1) == 0);
+      owi_assert(strcmp(str_g, (char *)e2) == 0);
+    }
+    i++;
+  }
+  owi_assert(3 == i);
+  deque_destroy(d2);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterRemove.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterRemove.c
@@ -1,0 +1,84 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+
+  deque_add(deque, str_a);
+  deque_add(deque, str_b);
+  deque_add(deque, str_c);
+  deque_add(deque, str_d);
+
+  Deque *d2;
+  deque_new(&d2);
+
+  deque_add(d2, str_e);
+  deque_add(d2, str_f);
+  deque_add(d2, str_g);
+
+  DequeZipIter zip;
+  deque_zip_iter_init(&zip, deque, d2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (deque_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      deque_zip_iter_remove(&zip, &r1, &r2);
+  }
+  owi_assert(strcmp(str_b, (char *)r1) == 0);
+  owi_assert(strcmp(str_f, (char *)r2) == 0);
+  owi_assert(0 == deque_contains(deque, str_b));
+  owi_assert(0 == deque_contains(deque, str_f));
+  owi_assert(3 == deque_size(deque));
+  owi_assert(2 == deque_size(d2));
+  deque_destroy(d2);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterReplace.c
+++ b/test/c/collections-c/normal/testsuite/deque/deque_test_zipIterReplace.c
@@ -1,0 +1,91 @@
+#include "deque.h"
+#include "owi.h"
+#include "utils.h"
+
+static Deque *deque;
+static DequeConf conf;
+int stat;
+
+void setup_tests() { stat = deque_new(&deque); }
+
+void teardown_tests() { deque_destroy(deque); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+
+  deque_add(deque, str_a);
+  deque_add(deque, str_b);
+  deque_add(deque, str_c);
+  deque_add(deque, str_d);
+
+  Deque *d2;
+  deque_new(&d2);
+
+  deque_add(d2, str_e);
+  deque_add(d2, str_f);
+  deque_add(d2, str_g);
+
+  symb_str(h);
+  symb_str(i);
+
+  DequeZipIter zip;
+  deque_zip_iter_init(&zip, deque, d2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (deque_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      deque_zip_iter_replace(&zip, str_h, str_i, &r1, &r2);
+  }
+
+  size_t index;
+  deque_index_of(deque, str_h, &index);
+
+  owi_assert(1 == index);
+
+  deque_index_of(deque, str_i, &index);
+  owi_assert(1 == index);
+  owi_assert(1 == deque_contains(deque, str_h));
+  owi_assert(1 == deque_contains(d2, str_i));
+  deque_destroy(d2);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_add.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_add.c
@@ -1,0 +1,42 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  owi_assert(CC_OK == list_add(list1, str_a));
+  owi_assert(CC_OK == list_add(list1, str_b));
+  owi_assert(CC_OK == list_add(list1, str_c));
+  owi_assert(CC_OK == list_add(list1, str_d));
+
+  void *e;
+  list_get_first(list1, &e);
+  owi_assert(e != NULL);
+
+  list_get_last(list1, &e);
+  owi_assert(e != NULL);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_addAll.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_addAll.c
@@ -1,0 +1,72 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  list_add_all(list2, list1);
+
+  owi_assert(8 == list_size(list2));
+
+  int *l1last;
+  list_get_last(list1, (void *)&l1last);
+
+  int *l2last;
+  list_get_last(list2, (void *)&l2last);
+  owi_assert(*l1last == *l2last);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_addAllAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_addAllAt.c
@@ -1,0 +1,74 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  list_add_all_at(list1, list2, 2);
+  owi_assert(4 == list_size(list2));
+  owi_assert(8 == list_size(list1));
+
+  int *last;
+  list_get_last(list1, (void *)&last);
+  int *l1i4;
+  list_get_at(list1, 4, (void *)&l1i4);
+  int *l2i2;
+  list_get_at(list2, 2, (void *)&l2i2);
+  owi_assert(d == *last);
+  owi_assert(*l1i4 == *l2i2);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_addAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_addAt.c
@@ -1,0 +1,73 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int i = owi_i32();
+  int *ii = (int *)malloc(sizeof(int));
+
+  *ii = i;
+
+  list_add_at(list1, ii, 3);
+  owi_assert(5 == list_size(list1));
+
+  int *new;
+  list_get_at(list1, 3, (void *)&new);
+  owi_assert(*ii == *new);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_addFirst.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_addFirst.c
@@ -1,0 +1,41 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int p = owi_i32();
+
+  list_add(list1, &a);
+  list_add(list1, &b);
+  list_add(list1, &c);
+  list_add(list1, &d);
+
+  owi_assert(4 == list_size(list1));
+
+  int *first;
+  list_get_first(list1, (void *)&first);
+  owi_assert(a == *first);
+
+  list_add_last(list1, &p);
+  owi_assert(5 == list_size(list1));
+
+  list_get_last(list1, (void *)&first);
+  owi_assert(p == *first);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_addLast.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_addLast.c
@@ -1,0 +1,41 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int p = owi_i32();
+
+  list_add(list1, &a);
+  list_add(list1, &b);
+  list_add(list1, &c);
+  list_add(list1, &d);
+
+  owi_assert(4 == list_size(list1));
+
+  int *last;
+  list_get_last(list1, (void *)&last);
+  owi_assert(d == *last);
+
+  list_add_last(list1, &p);
+  owi_assert(5 == list_size(list1));
+
+  list_get_last(list1, (void *)&last);
+  owi_assert(p == *last);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_contains.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_contains.c
@@ -1,0 +1,37 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+
+  owi_assume(a != b && a != c && a != d && a != e && b != c && b != d &&
+             b != e && c != d && c != e && d != e);
+
+  list_add(list1, &a);
+  list_add(list1, &b);
+  list_add(list1, &b);
+  list_add(list1, &c);
+  list_add(list1, &d);
+
+  owi_assert(2 == list_contains(list1, &b));
+  owi_assert(1 == list_contains(list1, &d));
+  owi_assert(0 == list_contains(list1, &e));
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_copyDeep.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_copyDeep.c
@@ -1,0 +1,79 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  List *cp;
+  list_copy_deep(list1, copy, &cp);
+  owi_assert(4 == list_size(cp));
+
+  int *e;
+  list_get_at(cp, 2, (void *)&e);
+
+  int *le;
+  list_get_at(list1, 2, (void *)&le);
+  owi_assert(*e == *le);
+
+  list_get_at(cp, 2, (void *)&e);
+  list_get_at(list1, 2, (void *)&le);
+  owi_assert(e != le);
+
+  list_destroy_cb(cp, free);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_copyShallow.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_copyShallow.c
@@ -1,0 +1,73 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  List *cp;
+  list_copy_shallow(list1, &cp);
+  owi_assert(4 == list_size(cp));
+
+  void *f1;
+  void *f2;
+  for (int i = 0; i < list_size(list1); i++) {
+    list_get_at(cp, i, &f1);
+    list_get_at(list1, i, &f2);
+    owi_assert(f1 == f2);
+  }
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_filter1.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_filter1.c
@@ -1,0 +1,81 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(a != 0 && b != 0 && c != 0 && d != 0);
+
+  List *filter = NULL;
+  list_filter(list1, pred1, &filter);
+
+  owi_assert(4 == list_size(list1));
+  owi_assert(0 == list_size(filter));
+
+  void *e = NULL;
+  list_get_first(filter, &e);
+  owi_assert(e == NULL);
+
+  list_get_last(filter, &e);
+  owi_assert(e == NULL);
+  free(filter);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_filter2.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_filter2.c
@@ -1,0 +1,77 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(a <= 3 && b <= 3 && c <= 3 && d > 3);
+
+  List *filter = NULL;
+  list_filter(list1, pred2, &filter);
+
+  owi_assert(4 == list_size(list1));
+  owi_assert(1 == list_size(filter));
+
+  int *i0;
+  owi_assert(list_get_at(filter, 0, (void **)&i0) == CC_OK);
+  owi_assert(*i0 == d);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_getAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_getAt.c
@@ -1,0 +1,65 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *e;
+  list_get_at(list1, 1, (void *)&e);
+  owi_assert(b == *e);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_getLast.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_getLast.c
@@ -1,0 +1,65 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *e;
+  list_get_last(list1, (void *)&e);
+  owi_assert(d == *e);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_indexOf.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_indexOf.c
@@ -1,0 +1,38 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  owi_assume(a != b && a != c && a != d && b != c && b != d && c != d);
+
+  list_add(list1, &a);
+  list_add(list1, &b);
+  list_add(list1, &c);
+  list_add(list1, &d);
+
+  size_t idx;
+  list_index_of(list1, &a, zero_if_ptr_eq, &idx);
+  owi_assert(0 == idx);
+
+  list_index_of(list1, &c, zero_if_ptr_eq, &idx);
+  owi_assert(2 == idx);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_iterAdd.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_iterAdd.c
@@ -1,0 +1,105 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int i = owi_i32();
+  int *ins = (int *)malloc(sizeof(int));
+  *ins = i;
+
+  owi_assume(i != d);
+
+  ListIter iter;
+  list_iter_init(&iter, list1);
+
+  owi_assume(c != a && c != b && c != d && d != a && d != b);
+
+  int *el;
+  while (list_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (*el == c)
+      list_iter_add(&iter, ins);
+  }
+
+  owi_assert(5 == list_size(list1));
+
+  int *li3;
+  list_get_at(list1, 3, (void *)&li3);
+
+  owi_assert(*li3 == *ins);
+
+  int *li4;
+  list_get_at(list1, 4, (void *)&li4);
+  owi_assert(d == *li4);
+
+  list_iter_init(&iter, list1);
+
+  int x = owi_i32();
+  ins = (int *)malloc(sizeof(int));
+  *ins = x;
+
+  while (list_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (*el == d) {
+      list_iter_add(&iter, ins);
+    }
+  }
+
+  void *e;
+  list_get_last(list1, &e);
+  owi_assert(*ins == *((int *)e));
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_iterDescAdd.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_iterDescAdd.c
@@ -1,0 +1,96 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *px = (int *)malloc(sizeof(int));
+  int *py = (int *)malloc(sizeof(int));
+  int x = owi_i32();
+  int y = owi_i32();
+
+  *px = x, *py = y;
+
+  owi_assume(c != a && c != b && c != d && d != a && d != b);
+
+  ListIter iter;
+  list_diter_init(&iter, list1);
+
+  int *i;
+  while (list_diter_next(&iter, (void *)&i) != CC_ITER_END) {
+    if (*i == d) // add to tail
+      list_diter_add(&iter, px);
+
+    if (*i == c)
+      list_diter_add(&iter, py);
+  }
+
+  owi_assert(6 == list_size(list1));
+  int *el;
+  list_get_first(list1, (void *)&el);
+  owi_assert(a == *el);
+
+  list_get_last(list1, (void *)&el);
+  owi_assert(d == *el);
+
+  list_get_at(list1, 2, (void *)&el);
+  owi_assert(*py == *el);
+
+  list_get_at(list1, 4, (void *)&el);
+  owi_assert(*px == *el);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_iterDescRemove.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_iterDescRemove.c
@@ -1,0 +1,88 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  ListIter iter;
+  list_diter_init(&iter, list1);
+
+  owi_assume(a != b && a != c && a != d && c != b && c != d);
+
+  int *i;
+  while (list_diter_next(&iter, (void *)&i) != CC_ITER_END) {
+    if (*i == a || *i == c) {
+      list_diter_remove(&iter, NULL);
+      free(i);
+    }
+  }
+  owi_assert(2 == list_size(list1));
+
+  int *first;
+  list_get_first(list1, (void *)&first);
+
+  int *last;
+  list_get_last(list1, (void *)&last);
+
+  int *i1;
+  list_get_at(list1, 1, (void *)&i1);
+
+  owi_assert(b == *first);
+  owi_assert(d == *last);
+  owi_assert(d == *i1);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_iterRemove.c
@@ -1,0 +1,78 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(c != a && c != b && c != d);
+
+  int *rm;
+  list_get_at(list1, 2, (void *)&rm);
+
+  ListIter iter;
+  list_iter_init(&iter, list1);
+
+  int *e;
+  while (list_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (*e == c) {
+      list_iter_remove(&iter, NULL);
+    }
+  }
+  owi_assert(3 == list_size(list1));
+  owi_assert(0 == list_contains(list1, rm));
+  free(rm);
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_mutFilter1.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_mutFilter1.c
@@ -1,0 +1,77 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(a != 0 && b != 0 && c != 0 && d != 0);
+
+  owi_assert(4 == list_size(list1));
+  list_filter_mut(list1, pred1);
+  owi_assert(0 == list_size(list1));
+
+  void *e = NULL;
+  list_get_first(list1, &e);
+  owi_assert(e == NULL);
+
+  list_get_last(list1, &e);
+  owi_assert(e == NULL);
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_mutFilter2.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_mutFilter2.c
@@ -1,0 +1,75 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e > 3; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(a <= 3 && b <= 3 && c <= 3 && d > 3);
+
+  owi_assert(4 == list_size(list1));
+  list_filter_mut(list1, pred2);
+  owi_assert(1 == list_size(list1));
+
+  int *i0;
+  owi_assert(list_get_at(list1, 0, (void **)&i0) == CC_OK);
+  owi_assert(*i0 == d);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_new.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_new.c
@@ -1,0 +1,31 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assert(list1 != NULL);
+  owi_assert(list2 != NULL);
+
+  void *e = NULL;
+  list_get_first(list1, &e);
+  owi_assert(e == NULL);
+
+  list_get_last(list1, &e);
+  owi_assert(e == NULL);
+
+  owi_assert(0 == list_size(list1));
+  owi_assert(list1 != list2);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_remove.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_remove.c
@@ -1,0 +1,71 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  owi_assume(b != a && b != c && b != d);
+
+  int *e;
+  list_get_at(list1, 1, (void *)&e);
+  list_remove(list1, e, NULL);
+
+  owi_assert(3 == list_size(list1));
+  owi_assert(0 == list_contains(list1, e));
+  free(e);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_removeAll.c
@@ -1,0 +1,72 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *e;
+  list_get_first(list1, (void *)&e);
+  owi_assert(a == *e);
+
+  list_remove_all_cb(list1, free);
+  owi_assert(0 == list_size(list1));
+
+  e = NULL;
+  list_get_first(list1, (void *)&e);
+  owi_assert(e == NULL);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_removeAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_removeAt.c
@@ -1,0 +1,74 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *e;
+  list_remove_at(list1, 2, (void *)&e);
+  free(e);
+
+  list_get_at(list1, 2, (void *)&e);
+  owi_assert(d == *e);
+  owi_assert(3 == list_size(list1));
+  list_remove_at(list1, 0, (void *)&e);
+  free(e);
+
+  list_get_at(list1, 0, (void *)&e);
+  owi_assert(b == *e);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_removeFirst.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_removeFirst.c
@@ -1,0 +1,70 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *el;
+  list_remove_first(list1, (void *)&el);
+  free(el);
+
+  owi_assert(3 == list_size(list1));
+
+  list_get_first(list1, (void *)&el);
+  owi_assert(b == *el);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_removeLast.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_removeLast.c
@@ -1,0 +1,69 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *el;
+  list_remove_last(list1, (void *)&el);
+  free(el);
+  owi_assert(3 == list_size(list1));
+
+  owi_assert(CC_OK == list_get_last(list1, (void *)&el));
+  owi_assert(c == *el);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_replaceAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_replaceAt.c
@@ -1,0 +1,73 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int r = owi_i32();
+  int *rr = (int *)malloc(sizeof(int));
+
+  *rr = r;
+
+  int *e;
+  list_replace_at(list1, rr, 2, (void *)&e);
+  free(e);
+
+  list_get_at(list1, 2, (void *)&e);
+  owi_assert((int *)rr == e);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_reverse.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_reverse.c
@@ -1,0 +1,76 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int *last_old;
+  list_get_last(list1, (void *)&last_old);
+
+  list_reverse(list1);
+
+  int *el;
+  list_get_at(list1, 0, (void *)&el);
+  owi_assert(d == *el);
+
+  list_get_at(list1, 2, (void *)&el);
+  owi_assert(b == *el);
+
+  list_get_first(list1, (void *)&el);
+  owi_assert(el == last_old);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_sort.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_sort.c
@@ -1,0 +1,52 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+static int cmp(void const *e1, void const *e2) {
+  int i = *(*((int **)e1));
+  int j = *(*((int **)e2));
+
+  if (i < j)
+    return -1;
+  if (i == j)
+    return 0;
+  return 1;
+}
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  list_add(list1, &a);
+  list_add(list1, &b);
+  list_add(list1, &c);
+  list_add(list1, &d);
+
+  list_sort(list1, cmp);
+
+  ListIter iter;
+  list_iter_init(&iter, list1);
+
+  void *prev;
+  void *e;
+  list_iter_next(&iter, &prev);
+  while (list_iter_next(&iter, &e) != CC_ITER_END) {
+    owi_assert(*((int *)prev) <= *((int *)e));
+    prev = e;
+  }
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_splice.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_splice.c
@@ -1,0 +1,75 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  list_splice(list1, list2);
+  owi_assert(8 == list_size(list1));
+  owi_assert(0 == list_size(list2));
+
+  int *el;
+  list_get_last(list1, (void *)&el);
+  owi_assert(h == *el);
+
+  list_get_first(list1, (void *)&el);
+  owi_assert(a == *el);
+
+  list_get_at(list1, 4, (void *)&el);
+  owi_assert(e == *el);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_spliceAt.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_spliceAt.c
@@ -1,0 +1,76 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  list_splice_at(list1, list2, 2);
+
+  owi_assert(8 == list_size(list1));
+  owi_assert(0 == list_size(list2));
+
+  int *el;
+  list_get_first(list1, (void *)&el);
+  owi_assert(a == *el);
+
+  list_get_last(list1, (void *)&el);
+  owi_assert(d == *el);
+
+  list_get_at(list1, 2, (void *)&el);
+  owi_assert(e == *el);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_sublist.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_sublist.c
@@ -1,0 +1,74 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  List *sub;
+  list_sublist(list1, 1, 2, &sub);
+  owi_assert(2 == list_size(sub));
+
+  int *s1;
+  list_get_at(sub, 1, (void *)&s1);
+
+  int *l2;
+  list_get_at(list1, 2, (void *)&l2);
+  owi_assert(*s1 == *l2);
+
+  list_destroy(sub);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_toArray.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_toArray.c
@@ -1,0 +1,72 @@
+#include "list.h"
+#include "owi.h"
+
+static List *list1;
+static List *list2;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_tests() {
+  list_new(&list1), list_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  list_add(list1, va);
+  list_add(list1, vb);
+  list_add(list1, vc);
+  list_add(list1, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  list_add(list2, va);
+  list_add(list2, vb);
+  list_add(list2, vc);
+  list_add(list2, vd);
+}
+
+void teardown_test() {
+  list_destroy_cb(list1, free);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int **array;
+  list_to_array(list1, (void *)&array);
+
+  void *e;
+  for (int i = 0; i < 4; i++) {
+    list_get_at(list1, i, &e);
+    owi_assert(array[i] == e);
+  }
+
+  free(array);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_zipIterAdd.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_zipIterAdd.c
@@ -1,0 +1,128 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  owi_assume(h > 0);
+  owi_assume(h < 127);
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  owi_assume(i > 0);
+  owi_assume(i < 127);
+  char str_i[] = {i, '\0'};
+
+  int x = owi_i32();
+  owi_assume(x > 0);
+  owi_assume(x < 127);
+  char str_x[] = {x, '\0'};
+
+  int y = owi_i32();
+  owi_assume(y > 0);
+  owi_assume(y < 127);
+  char str_y[] = {y, '\0'};
+
+  owi_assume(a != b && a != c && a != d && a != h && a != x);
+  owi_assume(b != c && b != d && b != h && b != x);
+  owi_assume(c != d && c != h && c != x);
+  owi_assume(d != h && d != x && h != x);
+
+  owi_assume(e != f && e != g && e != i && e != y && f != g && f != i &&
+             f != y && g != i && g != y && i != y);
+
+  list_add(list1, str_a);
+  list_add(list1, str_b);
+  list_add(list1, str_c);
+  list_add(list1, str_d);
+
+  list_add(list2, str_e);
+  list_add(list2, str_f);
+  list_add(list2, str_g);
+
+  ListZipIter zip;
+  list_zip_iter_init(&zip, list1, list2);
+
+  void *e1, *e2;
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      list_zip_iter_add(&zip, str_h, str_i);
+  }
+
+  size_t index;
+  owi_assert(CC_OK == list_index_of(list1, str_h, zero_if_ptr_eq, &index));
+  owi_assert(2 == index);
+
+  owi_assert(CC_OK == list_index_of(list2, str_i, zero_if_ptr_eq, &index));
+  owi_assert(2 == index);
+
+  owi_assert(CC_OK == list_index_of(list1, str_c, zero_if_ptr_eq, &index));
+  owi_assert(3 == index);
+
+  owi_assert(1 == list_contains(list1, str_h));
+  owi_assert(1 == list_contains(list2, str_i));
+  owi_assert(5 == list_size(list1));
+  owi_assert(4 == list_size(list2));
+
+  list_zip_iter_init(&zip, list1, list2);
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e2, str_g) == 0)
+      list_zip_iter_add(&zip, str_x, str_y);
+  }
+
+  char *last;
+  list_get_last(list1, (void *)&last);
+  CHECK_EQUAL_C_STRING(str_d, last);
+
+  list_get_last(list2, (void *)&last);
+  CHECK_EQUAL_C_STRING(str_y, last);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_zipIterNext.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_zipIterNext.c
@@ -1,0 +1,75 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+
+  char str_g[] = {g, '\0'};
+
+  list_add(list1, str_a);
+  list_add(list1, str_b);
+  list_add(list1, str_c);
+  list_add(list1, str_d);
+
+  list_add(list2, str_e);
+  list_add(list2, str_f);
+  list_add(list2, str_g);
+
+  ListZipIter zip;
+  list_zip_iter_init(&zip, list1, list2);
+
+  size_t i = 0;
+
+  void *e1, *e2;
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (i == 0) {
+      CHECK_EQUAL_C_STRING(str_a, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_e, (char *)e2);
+    }
+    if (i == 2) {
+      CHECK_EQUAL_C_STRING(str_c, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_g, (char *)e2);
+    }
+    i++;
+  }
+  owi_assert(3 == i);
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_zipIterRemove.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_zipIterRemove.c
@@ -1,0 +1,84 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  owi_assume(a != b && a != c && a != d && a != e && a != f && a != g &&
+             b != c && b != d && b != e && b != f && b != g && c != d &&
+             c != e && c != f && c != g && d != e && d != f && d != g &&
+             e != f && e != g && f != g);
+
+  list_add(list1, str_a);
+  list_add(list1, str_b);
+  list_add(list1, str_c);
+  list_add(list1, str_d);
+
+  list_add(list2, str_e);
+  list_add(list2, str_f);
+  list_add(list2, str_g);
+
+  ListZipIter zip;
+  list_zip_iter_init(&zip, list1, list2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      list_zip_iter_remove(&zip, &r1, &r2);
+  }
+  CHECK_EQUAL_C_STRING(str_b, (char *)r1);
+  CHECK_EQUAL_C_STRING(str_f, (char *)r2);
+  owi_assert(0 == list_contains(list1, str_b));
+  owi_assert(0 == list_contains(list2, str_f));
+  owi_assert(3 == list_size(list1));
+  owi_assert(2 == list_size(list2));
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/list/list_test_zipIterReplace.c
+++ b/test/c/collections-c/normal/testsuite/list/list_test_zipIterReplace.c
@@ -1,0 +1,97 @@
+#include "list.h"
+#include "owi.h"
+#include "utils.h"
+
+static List *list1;
+static List *list2;
+
+void setup_tests() { list_new(&list1), list_new(&list2); }
+
+void teardown_test() {
+  list_destroy(list1);
+  list_destroy(list2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  owi_assume(h > 0);
+  owi_assume(h < 127);
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  owi_assume(i > 0);
+  owi_assume(i < 127);
+  char str_i[] = {i, '\0'};
+
+  owi_assume(a != b && a != c && a != d && a != h && b != c && b != d &&
+             b != h && c != d && c != h && d != h);
+
+  owi_assume(e != f && e != g && e != i && f != g && f != i && g != i);
+
+  list_add(list1, str_a);
+  list_add(list1, str_b);
+  list_add(list1, str_c);
+  list_add(list1, str_d);
+
+  list_add(list2, str_e);
+  list_add(list2, str_f);
+  list_add(list2, str_g);
+
+  ListZipIter zip;
+  list_zip_iter_init(&zip, list1, list2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (list_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      list_zip_iter_replace(&zip, str_h, str_i, &r1, &r2);
+  }
+
+  size_t index;
+  owi_assert(CC_OK == list_index_of(list1, str_h, zero_if_ptr_eq, &index));
+  owi_assert(1 == index);
+
+  owi_assert(CC_OK == list_index_of(list2, str_i, zero_if_ptr_eq, &index));
+  owi_assert(1 == index);
+  owi_assert(1 == list_contains(list1, str_h));
+  owi_assert(1 == list_contains(list2, str_i));
+
+  teardown_test();
+}

--- a/test/c/collections-c/normal/testsuite/pqueue/pqueue_test_enqueue.c
+++ b/test/c/collections-c/normal/testsuite/pqueue/pqueue_test_enqueue.c
@@ -1,0 +1,79 @@
+#include "owi.h"
+#include "pqueue.h"
+
+static struct Pair {
+  int a, b;
+} A, B, C;
+
+static int comp(const void *a, const void *b) {
+  int alpha1 = ((struct Pair *)a)->a, beta1 = ((struct Pair *)a)->b;
+  int alpha2 = ((struct Pair *)b)->a, beta2 = ((struct Pair *)b)->b;
+  if (alpha1 != alpha2)
+    return alpha1 - alpha2;
+  else
+    return beta1 - beta2;
+}
+
+static int comp2(const void *a, const void *b) {
+  return *((int *)a) - *((int *)b);
+}
+
+static PQueue *p1, *p2;
+
+void setup_tests() {
+  pqueue_new(&p1, comp2);
+  PQueueConf cfg;
+  pqueue_conf_init(&cfg, comp);
+  pqueue_new_conf(&cfg, &p2);
+}
+
+void teardown_tests() {
+  pqueue_destroy(p1);
+  pqueue_destroy(p2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  int e = owi_i32();
+  int f = owi_i32();
+  int *ptr;
+
+  owi_assume(e < 8388608 && e > -8388608);
+  owi_assume(f < 8388608 && f > -8388608);
+
+  pqueue_push(p1, (void *)&f);
+  pqueue_top(p1, (void *)&ptr);
+  owi_assert(&f == ptr);
+
+  pqueue_push(p1, (void *)&e);
+  pqueue_top(p1, (void *)&ptr);
+  owi_assert(((e > f) && (e == *ptr)) || ((e <= f) && (f == *ptr)));
+
+  owi_assume(a < 8388608 && a > -8388608);
+  owi_assume(b < 8388608 && b > -8388608);
+  owi_assume(c < 8388608 && c > -8388608);
+  owi_assume(d < 8388608 && d > -8388608);
+
+  struct Pair *ptr2;
+  A.a = a, A.b = b;
+  B.a = c, B.b = d;
+
+  pqueue_push(p2, (void *)&A);
+  pqueue_top(p2, (void *)&ptr2);
+  owi_assert(&A == ptr2);
+
+  pqueue_push(p2, (void *)&B);
+  pqueue_top(p2, (void *)&ptr2);
+
+  owi_assert(((comp(&A, &B) >= 0) && ((a == ptr2->a) && (b == ptr2->b))) ||
+             ((comp(&A, &B) < 0) && ((c == ptr2->a) && (d == ptr2->b))));
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/pqueue/pqueue_test_pop.c
+++ b/test/c/collections-c/normal/testsuite/pqueue/pqueue_test_pop.c
@@ -1,0 +1,91 @@
+#include "owi.h"
+#include "pqueue.h"
+
+static struct Pair {
+  int a, b;
+} A, B, C;
+
+static int comp(const void *a, const void *b) {
+  int alpha1 = ((struct Pair *)a)->a, beta1 = ((struct Pair *)a)->b;
+  int alpha2 = ((struct Pair *)b)->a, beta2 = ((struct Pair *)b)->b;
+  if (alpha1 != alpha2)
+    return alpha1 - alpha2;
+  else
+    return beta1 - beta2;
+}
+
+static int comp2(const void *a, const void *b) {
+  return *((int *)a) - *((int *)b);
+}
+
+static PQueue *p1, *p2;
+
+void setup_tests() {
+  pqueue_new(&p1, comp2);
+  PQueueConf cfg;
+  pqueue_conf_init(&cfg, comp);
+  pqueue_new_conf(&cfg, &p2);
+}
+
+void teardown_tests() {
+  pqueue_destroy(p1);
+  pqueue_destroy(p2);
+}
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int *ptr;
+
+  owi_assume(x < 8388608 && x > -8388608);
+  owi_assume(y < 8388608 && y > -8388608);
+  owi_assume(z < 8388608 && z > -8388608);
+
+  owi_assume(x > z && z > y);
+
+  pqueue_push(p1, (void *)&y);
+  pqueue_push(p1, (void *)&x);
+  pqueue_push(p1, (void *)&z);
+
+  pqueue_pop(p1, (void *)&ptr);
+  owi_assert(&x == ptr);
+
+  pqueue_pop(p1, (void *)&ptr);
+  owi_assert(&z == ptr);
+
+  pqueue_pop(p1, (void *)&ptr);
+  owi_assert(&y == ptr);
+
+  struct Pair *ptr2;
+  A.a = a, A.b = b;
+  B.a = c, B.b = d;
+  C.a = e, C.b = f;
+
+  owi_assume(comp(&C, &A) > 0 && comp(&A, &B) > 0);
+
+  pqueue_push(p2, (void *)&A);
+  pqueue_push(p2, (void *)&B);
+  pqueue_push(p2, (void *)&C);
+
+  pqueue_pop(p2, (void *)&ptr2);
+  owi_assert(&C == ptr2);
+
+  pqueue_pop(p2, (void *)&ptr2);
+  owi_assert(&A == ptr2);
+
+  pqueue_pop(p2, (void *)&ptr2);
+  owi_assert(&B == ptr2);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/queue/queue_test_enqueue.c
+++ b/test/c/collections-c/normal/testsuite/queue/queue_test_enqueue.c
@@ -1,0 +1,41 @@
+#include "queue.h"
+#include "owi.h"
+
+static Queue *q;
+static Queue *q2;
+static int stat;
+
+void setup_test() {
+  stat = queue_new(&q);
+  queue_new(&q2);
+}
+
+void teardown_test() {
+  queue_destroy(q);
+  queue_destroy(q2);
+}
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  queue_enqueue(q, &a);
+  queue_enqueue(q, &b);
+
+  owi_assert(2 == queue_size(q));
+
+  void *p;
+  queue_peek(q, &p);
+  owi_assert(&a == p);
+
+  queue_enqueue(q, &c);
+
+  queue_peek(q, &p);
+  owi_assert(&a == p);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/queue/queue_test_iter.c
+++ b/test/c/collections-c/normal/testsuite/queue/queue_test_iter.c
@@ -1,0 +1,54 @@
+#include "owi.h"
+#include "queue.h"
+
+static Queue *q;
+static Queue *q2;
+static int stat;
+
+void setup_test() {
+  stat = queue_new(&q);
+  queue_new(&q2);
+}
+
+void teardown_test() {
+  queue_destroy(q);
+  queue_destroy(q2);
+}
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  queue_enqueue(q, &a);
+  queue_enqueue(q, &b);
+  queue_enqueue(q, &c);
+
+  size_t x = 0;
+  size_t y = 0;
+  size_t z = 0;
+
+  QueueIter iter;
+  queue_iter_init(&iter, q);
+
+  int *e;
+  while (queue_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (e == &a)
+      x++;
+
+    if (e == &b)
+      y++;
+
+    if (e == &c)
+      z++;
+  }
+
+  owi_assert(1 == x);
+  owi_assert(1 == y);
+  owi_assert(1 == z);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/queue/queue_test_poll.c
+++ b/test/c/collections-c/normal/testsuite/queue/queue_test_poll.c
@@ -1,0 +1,45 @@
+#include "owi.h"
+#include "queue.h"
+
+static Queue *q;
+static Queue *q2;
+static int stat;
+
+void setup_test() {
+  stat = queue_new(&q);
+  queue_new(&q2);
+}
+
+void teardown_test() {
+  queue_destroy(q);
+  queue_destroy(q2);
+}
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  queue_enqueue(q, &a);
+  queue_enqueue(q, &b);
+  queue_enqueue(q, &c);
+
+  void *p;
+
+  queue_poll(q, &p);
+  owi_assert(&a == p);
+
+  queue_peek(q, &p);
+  owi_assert(&b == p);
+
+  queue_poll(q, &p);
+  owi_assert(&b == p);
+
+  queue_peek(q, &p);
+  owi_assert(&c == p);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/queue/queue_test_zipIterNext.c
+++ b/test/c/collections-c/normal/testsuite/queue/queue_test_zipIterNext.c
@@ -1,0 +1,73 @@
+#include "owi.h"
+#include "queue.h"
+#include "utils.h"
+
+static Queue *q;
+static Queue *q2;
+static int stat;
+
+void setup_test() {
+  stat = queue_new(&q);
+  queue_new(&q2);
+}
+
+void teardown_test() {
+  queue_destroy(q);
+  queue_destroy(q2);
+}
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  char str_g[] = {g, '\0'};
+
+  queue_enqueue(q, str_a);
+  queue_enqueue(q, str_b);
+  queue_enqueue(q, str_c);
+  queue_enqueue(q, str_d);
+
+  queue_enqueue(q2, str_e);
+  queue_enqueue(q2, str_f);
+  queue_enqueue(q2, str_g);
+
+  QueueZipIter zip;
+  queue_zip_iter_init(&zip, q, q2);
+
+  size_t i = 0;
+
+  void *e1, *e2;
+  while (queue_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (i == 0) {
+      owi_assert(strcmp(str_d, (char *)e1) == 0);
+      owi_assert(strcmp(str_g, (char *)e2) == 0);
+    }
+    if (i == 2) {
+      owi_assert(strcmp(str_b, (char *)e1) == 0);
+      owi_assert(strcmp(str_e, (char *)e2) == 0);
+    }
+    i++;
+  }
+  owi_assert(3 == i);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_capacity.c
+++ b/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_capacity.c
@@ -1,0 +1,87 @@
+#include "owi.h"
+#include "ring_buffer.h"
+#include "utils.h"
+
+static int stat;
+static Rbuf *rbuf;
+
+void setup_test() { stat = rbuf_new(&rbuf); }
+
+void teardown_test() { rbuf_destroy(rbuf); }
+
+int main() {
+  setup_test();
+
+  uint64_t items[10];
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  char str_i[] = {i, '\0'};
+
+  int j = owi_i32();
+  char str_j[] = {j, '\0'};
+  rbuf_enqueue(rbuf, a);
+  rbuf_enqueue(rbuf, b);
+  rbuf_enqueue(rbuf, c);
+  rbuf_enqueue(rbuf, d);
+  rbuf_enqueue(rbuf, e);
+  rbuf_enqueue(rbuf, f);
+  rbuf_enqueue(rbuf, g);
+  rbuf_enqueue(rbuf, h);
+  rbuf_enqueue(rbuf, i);
+  rbuf_enqueue(rbuf, j);
+  memset(items, 0, sizeof(uint64_t) * 10);
+  items[0] = a;
+  items[1] = b;
+  items[2] = c;
+  items[3] = d;
+  items[4] = e;
+  items[5] = f;
+  items[6] = g;
+  items[7] = h;
+  items[8] = i;
+  items[9] = j;
+
+  owi_assert(items[0] == rbuf_peek(rbuf, 0));
+  owi_assert(items[1] == rbuf_peek(rbuf, 1));
+
+  int x = owi_i32();
+  char str_x[] = {x, '\0'};
+
+  int y = owi_i32();
+  char str_y[] = {y, '\0'};
+
+  rbuf_enqueue(rbuf, str_x);
+  rbuf_enqueue(rbuf, str_y);
+
+  owi_assert((void *)rbuf_peek(rbuf, 0) == (void *)str_x);
+  owi_assert((void *)rbuf_peek(rbuf, 1) == (void *)str_y);
+  uint64_t out;
+  rbuf_dequeue(rbuf, &out);
+  owi_assert(items[2] == out);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_dequeue.c
+++ b/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_dequeue.c
@@ -1,0 +1,75 @@
+#include "owi.h"
+#include "ring_buffer.h"
+#include "utils.h"
+
+static int stat;
+static Rbuf *rbuf;
+
+void setup_test() { stat = rbuf_new(&rbuf); }
+
+void teardown_test() { rbuf_destroy(rbuf); }
+
+int main() {
+  setup_test();
+
+  uint64_t items[10];
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  char str_i[] = {i, '\0'};
+
+  int j = owi_i32();
+  char str_j[] = {j, '\0'};
+  rbuf_enqueue(rbuf, a);
+  rbuf_enqueue(rbuf, b);
+  rbuf_enqueue(rbuf, c);
+  rbuf_enqueue(rbuf, d);
+  rbuf_enqueue(rbuf, e);
+  rbuf_enqueue(rbuf, f);
+  rbuf_enqueue(rbuf, g);
+  rbuf_enqueue(rbuf, h);
+  rbuf_enqueue(rbuf, i);
+  rbuf_enqueue(rbuf, j);
+  memset(items, 0, sizeof(uint64_t) * 10);
+  items[0] = a;
+  items[1] = b;
+  items[2] = c;
+  items[3] = d;
+  items[4] = e;
+  items[5] = f;
+  items[6] = g;
+  items[7] = h;
+  items[8] = i;
+  items[9] = j;
+  uint64_t out;
+  for (int i = 0; i < 10; i++) {
+    rbuf_dequeue(rbuf, &out);
+    owi_assert(items[i] == out);
+    memset(&out, 0, sizeof(uint64_t));
+  }
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_enqueue.c
+++ b/test/c/collections-c/normal/testsuite/ring_buffer/ring_buffer_test_enqueue.c
@@ -1,0 +1,71 @@
+#include "owi.h"
+#include "ring_buffer.h"
+#include "utils.h"
+
+static int stat;
+static Rbuf *rbuf;
+
+void setup_test() { stat = rbuf_new(&rbuf); }
+
+void teardown_test() { rbuf_destroy(rbuf); }
+
+int main() {
+  setup_test();
+
+  uint64_t items[10];
+  int a = owi_i32();
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  char str_i[] = {i, '\0'};
+
+  int j = owi_i32();
+  char str_j[] = {j, '\0'};
+  rbuf_enqueue(rbuf, a);
+  rbuf_enqueue(rbuf, b);
+  rbuf_enqueue(rbuf, c);
+  rbuf_enqueue(rbuf, d);
+  rbuf_enqueue(rbuf, e);
+  rbuf_enqueue(rbuf, f);
+  rbuf_enqueue(rbuf, g);
+  rbuf_enqueue(rbuf, h);
+  rbuf_enqueue(rbuf, i);
+  rbuf_enqueue(rbuf, j);
+  memset(items, 0, sizeof(uint64_t) * 10);
+  items[0] = a;
+  items[1] = b;
+  items[2] = c;
+  items[3] = d;
+  items[4] = e;
+  items[5] = f;
+  items[6] = g;
+  items[7] = h;
+  items[8] = i;
+  items[9] = j;
+  for (int i = 0; i < 10; i++)
+    owi_assert(rbuf_peek(rbuf, i) == items[i]);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_add.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_add.c
@@ -1,0 +1,51 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assert(CC_OK == slist_add(list, str_a));
+  owi_assert(CC_OK == slist_add(list, str_b));
+  owi_assert(CC_OK == slist_add(list, str_c));
+  owi_assert(CC_OK == slist_add(list, str_d));
+
+  void *e;
+  slist_get_first(list, &e);
+  owi_assert(e != NULL);
+
+  slist_get_last(list, &e);
+  owi_assert(e != NULL);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_addAll.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_addAll.c
@@ -1,0 +1,74 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  slist_add_all(list2, list);
+
+  owi_assert(8 == slist_size(list2));
+
+  int *l1last;
+  slist_get_last(list, (void *)&l1last);
+
+  int *l2last;
+  slist_get_last(list2, (void *)&l2last);
+  owi_assert(*l1last == *l2last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_addAllAt.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_addAllAt.c
@@ -1,0 +1,78 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  slist_add_all_at(list, list2, 2);
+  owi_assert(4 == slist_size(list2));
+  owi_assert(8 == slist_size(list));
+
+  int *last;
+  slist_get_last(list, (void *)&last);
+  owi_assert(d == *last);
+
+  int *l1i5;
+  slist_get_at(list, 5, (void *)&l1i5);
+
+  int *l2i3;
+  slist_get_at(list2, 3, (void *)&l2i3);
+  owi_assert(*l1i5 == *l2i3);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_addAt.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_addAt.c
@@ -1,0 +1,84 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int i = owi_i32();
+  int *ii = (int *)malloc(sizeof(int));
+
+  *ii = i;
+
+  slist_add_at(list, ii, 2);
+  owi_assert(5 == slist_size(list));
+
+  int *new;
+  slist_get_at(list, 2, (void *)&new);
+  owi_assert(*ii == *new);
+  owi_assert(CC_OK == slist_add_at(list, ii, 4));
+  owi_assert(CC_OK == slist_add_at(list, ii, 0));
+
+  void *el;
+  slist_get_first(list, &el);
+  owi_assert(*ii == *((int *)el));
+
+  slist_get_first(list, &el);
+  owi_assert(*ii == *((int *)el));
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_addFirst.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_addFirst.c
@@ -1,0 +1,47 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  int p = owi_i32();
+
+  slist_add(list, &a);
+  slist_add(list, &b);
+  slist_add(list, &c);
+  slist_add(list, &d);
+
+  owi_assert(4 == slist_size(list));
+
+  int *first;
+  slist_get_first(list, (void *)&first);
+  owi_assert(a == *first);
+
+  slist_add_first(list, &p);
+
+  owi_assert(5 == slist_size(list));
+  slist_get_first(list, (void *)&first);
+  owi_assert(p == *first);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_addLast.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_addLast.c
@@ -1,0 +1,47 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  int p = owi_i32();
+
+  slist_add(list, &a);
+  slist_add(list, &b);
+  slist_add(list, &c);
+  slist_add(list, &d);
+
+  owi_assert(4 == slist_size(list));
+
+  int *last;
+  slist_get_last(list, (void *)&last);
+  owi_assert(d == *last);
+
+  slist_add_last(list, &p);
+  owi_assert(5 == slist_size(list));
+
+  slist_get_last(list, (void *)&last);
+  owi_assert(p == *last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_contains.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_contains.c
@@ -1,0 +1,39 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+
+  slist_add(list, &a);
+  slist_add(list, &b);
+  slist_add(list, &b);
+  slist_add(list, &c);
+  slist_add(list, &d);
+
+  owi_assert(2 == slist_contains(list, &b));
+  owi_assert(1 == slist_contains(list, &d));
+  owi_assert(0 == slist_contains(list, &e));
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_copyDeep.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_copyDeep.c
@@ -1,0 +1,81 @@
+#include "owi.h"
+#include "slist.h"
+#include "utils.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  SList *cp;
+  slist_copy_deep(list, copy, &cp);
+  owi_assert(4 == slist_size(cp));
+
+  int *e;
+  slist_get_at(cp, 2, (void *)&e);
+
+  void *e2;
+  slist_get_at(list, 2, &e2);
+  owi_assert(*e == *(int *)e2);
+
+  slist_get_at(list, 2, &e2);
+  slist_get_at(cp, 2, (void *)&e);
+  owi_assert(e != e2);
+
+  slist_destroy_cb(cp, free);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_copyShallow.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_copyShallow.c
@@ -1,0 +1,84 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  SList *cp;
+  slist_copy_shallow(list, &cp);
+  owi_assert(4 == slist_size(cp));
+
+  void *e1;
+  void *e2;
+
+  slist_get_first(cp, &e1);
+  slist_get_first(list, &e2);
+  owi_assert(e1 == e2);
+
+  slist_get_last(cp, &e1);
+  slist_get_last(list, &e2);
+  owi_assert(e1 == e2);
+
+  slist_get_at(cp, 3, &e1);
+  slist_get_at(list, 3, &e2);
+  owi_assert(e1 == e2);
+
+  slist_destroy(cp);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filter1.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filter1.c
@@ -1,0 +1,80 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(a != 0 && b != 0 && c != 0 && d != 0);
+
+  SList *filter = NULL;
+  owi_assert(4 == slist_size(list));
+  slist_filter(list, pred1, &filter);
+
+  owi_assert(0 == slist_size(filter));
+
+  void *e = NULL;
+  slist_get_first(filter, &e);
+  owi_assert(e == NULL);
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filter2.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filter2.c
@@ -1,0 +1,92 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(!pred2(&a) && !pred2(&b) && pred2(&c) && pred2(&d));
+
+  SList *filter = NULL;
+  owi_assert(4 == slist_size(list));
+  slist_filter(list, pred2, &filter);
+  owi_assert(2 == slist_size(filter));
+
+  SListIter iter;
+  int *el = NULL;
+  int i = 0;
+  slist_iter_init(&iter, filter);
+  while (slist_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (i == 0)
+      owi_assert(*el == c);
+
+    if (i == 1)
+      owi_assert(*el == d);
+
+    if (i > 1)
+      owi_assert(false);
+    i++;
+  }
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filter3.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filter3.c
@@ -1,0 +1,88 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+void CHECK_EQ_LIST(SList *l1, SList *l2) {
+  owi_assert(slist_size(l1) == slist_size(l2));
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, l1, l2);
+  void *e1, *e2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    owi_assert(e1 == e2);
+  }
+}
+
+int main() {
+  setup_test();
+
+  owi_assume(pred3(&a) && pred3(&b) && pred3(&c) && pred3(&d));
+
+  SList *filter = NULL;
+  owi_assert(4 == slist_size(list));
+  slist_filter(list, pred3, &filter);
+  owi_assert(4 == slist_size(filter));
+
+  CHECK_EQ_LIST(list, filter);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut1.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut1.c
@@ -1,0 +1,90 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+void CHECK_EQ_LIST(SList *l1, SList *l2) {
+  owi_assert(slist_size(l1) == slist_size(l2));
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, l1, l2);
+  void *e1, *e2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    owi_assert(e1 == e2);
+  }
+}
+
+int main() {
+  setup_test();
+
+  owi_assume(a != 0 && b != 0 && c != 0 && d != 0);
+
+  owi_assert(4 == slist_size(list));
+  slist_filter_mut(list, pred1);
+
+  owi_assert(0 == slist_size(list));
+
+  void *e = NULL;
+  slist_get_first(list, &e);
+  owi_assert(e == NULL);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut2.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut2.c
@@ -1,0 +1,90 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(!pred2(&a) && !pred2(&b) && pred2(&c) && pred2(&d));
+
+  owi_assert(4 == slist_size(list));
+  slist_filter_mut(list, pred2);
+  owi_assert(2 == slist_size(list));
+
+  SListIter iter;
+  int *el = NULL;
+  int i = 0;
+  slist_iter_init(&iter, list);
+  while (slist_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (i == 0)
+      owi_assert(*el == c);
+
+    if (i == 1)
+      owi_assert(*el == d);
+
+    if (i > 1)
+      owi_assert(false);
+    i++;
+  }
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut3.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_filterMut3.c
@@ -1,0 +1,75 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+bool pred1(const void *e) { return *(int *)e == 0; }
+
+bool pred2(const void *e) { return *(int *)e >= 3; }
+
+bool pred3(const void *e) { return *(int *)e > 0; }
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(pred3(&a) && pred3(&b) && pred3(&c) && pred3(&d));
+
+  owi_assert(4 == slist_size(list));
+  slist_filter_mut(list, pred3);
+  owi_assert(4 == slist_size(list));
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_get.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_get.c
@@ -1,0 +1,67 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *e;
+  slist_get_at(list, 1, (void *)&e);
+  owi_assert(b == *e);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_getFirst.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_getFirst.c
@@ -1,0 +1,67 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *first;
+  slist_get_first(list, (void *)&first);
+  owi_assert(a == *first);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_getLast.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_getLast.c
@@ -1,0 +1,67 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *last;
+  slist_get_last(list, (void *)&last);
+  owi_assert(d == *last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_indexOf.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_indexOf.c
@@ -1,0 +1,41 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+
+  slist_add(list, &a);
+  slist_add(list, &b);
+  slist_add(list, &c);
+  slist_add(list, &d);
+
+  size_t idx;
+  slist_index_of(list, &a, &idx);
+  owi_assert(0 == idx);
+
+  slist_index_of(list, &c, &idx);
+  owi_assert(2 == idx);
+  ;
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_iterAdd.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_iterAdd.c
@@ -1,0 +1,104 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int i = owi_i32();
+  int *i1 = (int *)malloc(sizeof(int));
+
+  *i1 = i;
+
+  SListIter iter;
+  slist_iter_init(&iter, list);
+
+  owi_assume(c != a && c != b && c != d && d != a && d != b && d != i);
+
+  int *el;
+  while (slist_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (*el == c)
+      slist_iter_add(&iter, i1);
+  }
+  owi_assert(5 == slist_size(list));
+
+  int *li3;
+  slist_get_at(list, 3, (void *)&li3);
+  owi_assert(*li3 == i);
+
+  int *li4;
+  slist_get_at(list, 4, (void *)&li4);
+  owi_assert(d == *li4);
+
+  int x = owi_i32();
+  int *i2 = (int *)malloc(sizeof(int));
+
+  *i2 = x;
+
+  slist_iter_init(&iter, list);
+  while (slist_iter_next(&iter, (void *)&el) != CC_ITER_END) {
+    if (*el == d)
+      slist_iter_add(&iter, i2);
+  }
+
+  void *e;
+  slist_get_last(list, &e);
+  owi_assert(x == *(int *)e);
+  owi_assert(6 == slist_size(list));
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_iterRemove.c
@@ -1,0 +1,81 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(c != a && c != b && c != d);
+
+  int *rm;
+  slist_get_at(list, 2, (void *)&rm);
+
+  SListIter iter;
+  slist_iter_init(&iter, list);
+
+  int *e;
+  while (slist_iter_next(&iter, (void *)&e) != CC_ITER_END) {
+    if (*e == c) {
+      slist_iter_remove(&iter, NULL);
+    }
+  }
+  owi_assert(3 == slist_size(list));
+  owi_assert(0 == slist_contains(list, rm));
+  free(rm);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_new.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_new.c
@@ -1,0 +1,37 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  SList *list2 = NULL;
+  slist_new(&list2);
+  owi_assert(list != NULL);
+  owi_assert(list2 != NULL);
+
+  void *e = NULL;
+  slist_get_first(list, &e);
+  owi_assert(NULL == e);
+
+  slist_get_last(list, &e);
+  owi_assert(NULL == e);
+  owi_assert(0 == slist_size(list));
+  owi_assert(list != list2);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_remove.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_remove.c
@@ -1,0 +1,73 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  owi_assume(b != a && b != c && b != d);
+  int *e;
+
+  owi_assert(CC_OK == slist_get_at(list, 1, (void *)&e));
+
+  slist_remove(list, e, NULL);
+  owi_assert(3 == slist_size(list));
+  owi_assert(0 == slist_contains(list, e));
+  free(e);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_removeAll.c
@@ -1,0 +1,70 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  slist_remove_all_cb(list, free);
+  owi_assert(0 == slist_size(list));
+
+  void *e = NULL;
+  slist_get_first(list, &e);
+  owi_assert(e == NULL);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_removeAt.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_removeAt.c
@@ -1,0 +1,77 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *e;
+  slist_remove_at(list, 2, (void *)&e);
+  free(e);
+
+  slist_get_at(list, 2, (void *)&e);
+  owi_assert(d == *e);
+  owi_assert(3 == slist_size(list));
+
+  slist_remove_at(list, 0, (void *)&e);
+  free(e);
+
+  slist_get_at(list, 0, (void *)&e);
+  owi_assert(b == *e);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_removeFirst.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_removeFirst.c
@@ -1,0 +1,71 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *first;
+  slist_remove_first(list, (void *)&first);
+  free(first);
+  owi_assert(3 == slist_size(list));
+
+  slist_get_first(list, (void *)&first);
+  owi_assert(b == *first);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_removeLast.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_removeLast.c
@@ -1,0 +1,72 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int *last;
+  slist_remove_last(list, (void *)&last);
+  free(last);
+
+  owi_assert(3 == slist_size(list));
+
+  slist_get_last(list, (void *)&last);
+  owi_assert(c == *last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_replaceAt.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_replaceAt.c
@@ -1,0 +1,75 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int r = owi_i32();
+  int *rr = (int *)malloc(sizeof(int));
+
+  *rr = r;
+
+  int *e;
+  slist_replace_at(list, rr, 2, (void *)&e);
+  free(e);
+
+  slist_get_at(list, 2, (void *)&e);
+  owi_assert(rr == e);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_reverse.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_reverse.c
@@ -1,0 +1,49 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  int e = owi_i32();
+  int f = owi_i32();
+  slist_add(list, &a);
+  slist_add(list, &b);
+  slist_add(list, &c);
+  slist_add(list, &d);
+  slist_add(list, &e);
+  slist_add(list, &f);
+
+  slist_reverse(list);
+
+  int reverse_ar[] = {f, e, d, c, b, a};
+
+  SListIter i;
+  slist_iter_init(&i, list);
+
+  void *el;
+  int ind = 0;
+  while (slist_iter_next(&i, &el) != CC_ITER_END) {
+    owi_assert(reverse_ar[ind] == *(int *)el);
+    ind++;
+  }
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_splice.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_splice.c
@@ -1,0 +1,77 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  slist_splice(list, list2);
+  owi_assert(8 == slist_size(list));
+  owi_assert(0 == slist_size(list2));
+
+  int *ee;
+  slist_get_last(list, (void *)&ee);
+  owi_assert(h == *ee);
+
+  slist_get_first(list, (void *)&ee);
+  owi_assert(a == *ee);
+
+  slist_get_at(list, 4, (void *)&ee);
+  owi_assert(e == *ee);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_spliceAt.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_spliceAt.c
@@ -1,0 +1,77 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  slist_splice_at(list, list2, 2);
+  owi_assert(8 == slist_size(list));
+  owi_assert(0 == slist_size(list2));
+
+  int *ptr_e;
+  slist_get_first(list, (void *)&ptr_e);
+  owi_assert(a == *ptr_e);
+
+  slist_get_last(list, (void *)&ptr_e);
+  owi_assert(d == *ptr_e);
+
+  slist_get_at(list, 2, (void *)&ptr_e);
+  owi_assert(e == *ptr_e);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_sublist.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_sublist.c
@@ -1,0 +1,76 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  SList *sub;
+  slist_sublist(list, 1, 2, &sub);
+  owi_assert(2 == slist_size(sub));
+
+  int *s1;
+  slist_get_at(sub, 1, (void *)&s1);
+
+  int *l2;
+  slist_get_at(list, 2, (void *)&l2);
+  owi_assert(*s1 == *l2);
+
+  slist_destroy(sub);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_toArray.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_toArray.c
@@ -1,0 +1,77 @@
+#include "owi.h"
+#include "slist.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+int a, b, c, d, e, f, g, h;
+
+void setup_test() {
+  slist_new(&list), slist_new(&list2);
+
+  a = owi_i32();
+  b = owi_i32();
+  c = owi_i32();
+  d = owi_i32();
+  e = owi_i32();
+  f = owi_i32();
+  g = owi_i32();
+  h = owi_i32();
+
+  int *va = (int *)malloc(sizeof(int));
+  int *vb = (int *)malloc(sizeof(int));
+  int *vc = (int *)malloc(sizeof(int));
+  int *vd = (int *)malloc(sizeof(int));
+
+  *va = a;
+  *vb = b;
+  *vc = c;
+  *vd = d;
+
+  slist_add(list, va);
+  slist_add(list, vb);
+  slist_add(list, vc);
+  slist_add(list, vd);
+
+  va = (int *)malloc(sizeof(int));
+  vb = (int *)malloc(sizeof(int));
+  vc = (int *)malloc(sizeof(int));
+  vd = (int *)malloc(sizeof(int));
+
+  *va = e;
+  *vb = f;
+  *vc = g;
+  *vd = h;
+
+  slist_add(list2, va);
+  slist_add(list2, vb);
+  slist_add(list2, vc);
+  slist_add(list2, vd);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int **array;
+  slist_to_array(list, (void *)&array);
+
+  void *e;
+  slist_get_at(list, 0, &e);
+  owi_assert(e == array[0]);
+
+  slist_get_at(list, 2, &e);
+  owi_assert(e == array[2]);
+
+  slist_get_at(list, 3, &e);
+  owi_assert(e == array[3]);
+  free(array);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterAdd.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterAdd.c
@@ -1,0 +1,129 @@
+#include "owi.h"
+#include "slist.h"
+#include "utils.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  owi_assume(h > 0);
+  owi_assume(h < 127);
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  owi_assume(i > 0);
+  owi_assume(i < 127);
+  char str_i[] = {i, '\0'};
+
+  int x = owi_i32();
+  owi_assume(x > 0);
+  owi_assume(x < 127);
+  char str_x[] = {x, '\0'};
+
+  int y = owi_i32();
+  owi_assume(y > 0);
+  owi_assume(y < 127);
+  char str_y[] = {y, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+  owi_assume(h != a && h != b && h != c && h != d);
+  owi_assume(c != a && c != d);
+  owi_assume(i != e && i != f && i != g);
+
+  slist_add(list, str_a);
+  slist_add(list, str_b);
+  slist_add(list, str_c);
+  slist_add(list, str_d);
+
+  slist_add(list2, str_e);
+  slist_add(list2, str_f);
+  slist_add(list2, str_g);
+
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, list, list2);
+
+  void *e1, *e2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      slist_zip_iter_add(&zip, str_h, str_i);
+  }
+
+  size_t index;
+  slist_index_of(list, str_h, &index);
+  owi_assert(2 == index);
+
+  slist_index_of(list2, str_i, &index);
+  owi_assert(2 == index);
+
+  slist_index_of(list, str_c, &index);
+  owi_assert(3 == index);
+
+  owi_assert(1 == slist_contains(list, str_h));
+  owi_assert(1 == slist_contains(list2, str_i));
+  owi_assert(5 == slist_size(list));
+  owi_assert(4 == slist_size(list2));
+
+  slist_zip_iter_init(&zip, list, list2);
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e2, str_g) == 0)
+      slist_zip_iter_add(&zip, str_x, str_y);
+  }
+
+  char *last;
+  slist_get_last(list2, (void *)&last);
+  owi_assert(str_y == last);
+
+  slist_get_last(list, (void *)&last);
+  owi_assert(str_d == last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterNext.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterNext.c
@@ -1,0 +1,87 @@
+#include "owi.h"
+#include "slist.h"
+#include "utils.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  slist_add(list, str_a);
+  slist_add(list, str_b);
+  slist_add(list, str_c);
+  slist_add(list, str_d);
+
+  slist_add(list2, str_e);
+  slist_add(list2, str_f);
+  slist_add(list2, str_g);
+
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, list, list2);
+
+  size_t i = 0;
+
+  void *e1, *e2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (i == 0) {
+      CHECK_EQUAL_C_STRING(str_a, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_e, (char *)e2);
+    }
+    if (i == 2) {
+      CHECK_EQUAL_C_STRING(str_c, (char *)e1);
+      CHECK_EQUAL_C_STRING(str_g, (char *)e2);
+    }
+    i++;
+  }
+  owi_assert(3 == i);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterRemove.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterRemove.c
@@ -1,0 +1,122 @@
+#include "owi.h"
+#include "slist.h"
+#include "utils.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  owi_assume(h > 0);
+  owi_assume(h < 127);
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  owi_assume(i > 0);
+  owi_assume(i < 127);
+  char str_i[] = {i, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+  owi_assume(f != e && f != g);
+  owi_assume(e != g);
+  // ASSUME(h != a && h != b && h != c && h != d);
+  // ASSUME(c != a && c != d);
+  // ASSUME(i != e && i != f && i != g);
+
+  slist_add(list, str_a);
+  slist_add(list, str_b);
+  slist_add(list, str_c);
+  slist_add(list, str_d);
+
+  slist_add(list2, str_e);
+  slist_add(list2, str_f);
+  slist_add(list2, str_g);
+
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, list, list2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      slist_zip_iter_remove(&zip, &r1, &r2);
+  }
+
+  CHECK_EQUAL_C_STRING(str_b, (char *)r1);
+  CHECK_EQUAL_C_STRING(str_f, (char *)r2);
+  owi_assert(0 == slist_contains(list, str_b));
+  owi_assert(0 == slist_contains(list2, str_c));
+  owi_assert(3 == slist_size(list));
+  owi_assert(2 == slist_size(list2));
+
+  slist_zip_iter_init(&zip, list, list2);
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e2, str_e) == 0)
+      slist_zip_iter_remove(&zip, &r1, &r2);
+
+    if (strcmp((char *)e2, str_g) == 0)
+      slist_zip_iter_remove(&zip, &r1, &r2);
+  }
+
+  char *first = "";
+  char *last = "";
+
+  owi_assert(CC_ERR_VALUE_NOT_FOUND == slist_get_first(list2, (void *)&first));
+  owi_assert(CC_ERR_VALUE_NOT_FOUND == slist_get_last(list2, (void *)&last));
+
+  slist_get_first(list, (void *)&first);
+  CHECK_EQUAL_C_STRING(str_d, first);
+
+  slist_get_last(list, (void *)&last);
+  CHECK_EQUAL_C_STRING(str_d, last);
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterReplace.c
+++ b/test/c/collections-c/normal/testsuite/slist/slist_test_zipIterReplace.c
@@ -1,0 +1,111 @@
+#include "owi.h"
+#include "slist.h"
+#include "utils.h"
+
+static SList *list;
+static SList *list2;
+static int stat;
+
+void setup_test() {
+  stat = slist_new(&list);
+  slist_new(&list2);
+};
+
+void teardown_test() {
+  slist_destroy(list);
+  slist_destroy(list2);
+};
+
+int main() {
+  setup_test();
+
+  int a = owi_i32();
+  owi_assume(a > 0);
+  owi_assume(a < 127);
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+  owi_assume(b > 0);
+  owi_assume(b < 127);
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+  owi_assume(c > 0);
+  owi_assume(c < 127);
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+  owi_assume(d > 0);
+  owi_assume(d < 127);
+  char str_d[] = {d, '\0'};
+
+  int e = owi_i32();
+  owi_assume(e > 0);
+  owi_assume(e < 127);
+  char str_e[] = {e, '\0'};
+
+  int f = owi_i32();
+  owi_assume(f > 0);
+  owi_assume(f < 127);
+  char str_f[] = {f, '\0'};
+
+  int g = owi_i32();
+  owi_assume(g > 0);
+  owi_assume(g < 127);
+  char str_g[] = {g, '\0'};
+
+  int h = owi_i32();
+  owi_assume(h > 0);
+  owi_assume(h < 127);
+  char str_h[] = {h, '\0'};
+
+  int i = owi_i32();
+  owi_assume(i > 0);
+  owi_assume(i < 127);
+  char str_i[] = {i, '\0'};
+
+  int x = owi_i32();
+  owi_assume(x > 0);
+  owi_assume(x < 127);
+  char str_x[] = {x, '\0'};
+
+  int y = owi_i32();
+  owi_assume(y > 0);
+  owi_assume(y < 127);
+  char str_y[] = {y, '\0'};
+
+  owi_assume(b != a && b != c && b != d);
+  owi_assume(h != a && h != b && h != c && h != d);
+  owi_assume(i != e && i != f && i != g);
+
+  slist_add(list, str_a);
+  slist_add(list, str_b);
+  slist_add(list, str_c);
+  slist_add(list, str_d);
+
+  slist_add(list2, str_e);
+  slist_add(list2, str_f);
+  slist_add(list2, str_g);
+
+  SListZipIter zip;
+  slist_zip_iter_init(&zip, list, list2);
+
+  void *e1, *e2;
+  void *r1, *r2;
+  while (slist_zip_iter_next(&zip, &e1, &e2) != CC_ITER_END) {
+    if (strcmp((char *)e1, str_b) == 0)
+      slist_zip_iter_replace(&zip, str_h, str_i, &r1, &r2);
+  }
+
+  size_t index;
+  slist_index_of(list, str_h, &index);
+  owi_assert(1 == index);
+
+  slist_index_of(list, str_i, &index);
+  owi_assert(1 == index);
+  owi_assert(1 == slist_contains(list, str_h));
+  owi_assert(1 == slist_contains(list2, str_i));
+
+  teardown_test();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/stack/stack_test_pop.c
+++ b/test/c/collections-c/normal/testsuite/stack/stack_test_pop.c
@@ -1,0 +1,32 @@
+#include "owi.h"
+#include "stack.h"
+
+static Stack *s;
+
+void setup_tests() { stack_new(&s); }
+
+void teardown_tests() { stack_destroy(s); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  stack_push(s, (void *)&a);
+  stack_push(s, (void *)&b);
+  stack_push(s, (void *)&c);
+
+  int *pop;
+  int *peek;
+
+  stack_pop(s, (void *)&pop);
+  owi_assert(&c == pop);
+
+  stack_peek(s, (void *)&peek);
+  owi_assert(&b == peek);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/stack/stack_test_push.c
+++ b/test/c/collections-c/normal/testsuite/stack/stack_test_push.c
@@ -1,0 +1,33 @@
+#include "owi.h"
+#include "stack.h"
+
+static Stack *s;
+
+void setup_tests() { stack_new(&s); }
+
+void teardown_tests() { stack_destroy(s); }
+
+int main() {
+  setup_tests();
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+
+  int *p;
+
+  stack_push(s, (void *)&a);
+  stack_peek(s, (void *)&p);
+  owi_assert(&a == p);
+
+  stack_push(s, (void *)&b);
+  stack_peek(s, (void *)&p);
+  owi_assert(&b == p);
+
+  stack_push(s, (void *)&c);
+  stack_peek(s, (void *)&p);
+  owi_assert(&c == p);
+
+  teardown_tests();
+  return 0;
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_add.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_add.c
@@ -1,0 +1,23 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  owi_assume(a != b && a != c && b != c);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+  treeset_add(set, &c);
+
+  owi_assert(3 == treeset_size(set));
+  owi_assert(1 == treeset_contains(set, &a));
+  owi_assert(1 == treeset_contains(set, &b));
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_iterNext.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_iterNext.c
@@ -1,0 +1,48 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  int d = owi_i32();
+  owi_assume(a < b && b < c && c < d);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+  treeset_add(set, &d);
+
+  int one = 0;
+  int two = 0;
+  int three = 0;
+  int four = 0;
+
+  TreeSetIter iter;
+  treeset_iter_init(&iter, set);
+
+  void *e;
+  while (treeset_iter_next(&iter, &e) != CC_ITER_END) {
+    if (*((int *)e) == a)
+      one++;
+
+    if (*((int *)e) == b)
+      two++;
+
+    if (*((int *)e) == c)
+      three++;
+
+    if (*((int *)e) == d)
+      four++;
+  }
+
+  owi_assert(1 == one);
+  owi_assert(1 == two);
+  owi_assert(1 == three);
+  owi_assert(1 == four);
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_iterRemove.c
@@ -1,0 +1,29 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  owi_assume(a != b && a != c && b != c);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+
+  TreeSetIter iter;
+  treeset_iter_init(&iter, set);
+
+  void *e;
+  while (treeset_iter_next(&iter, &e) != CC_ITER_END) {
+    if (*((int *)e) == b)
+      treeset_iter_remove(&iter, NULL);
+  }
+  owi_assert(2 == treeset_size(set));
+  owi_assert(0 == treeset_contains(set, &b));
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_remove.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_remove.c
@@ -1,0 +1,23 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  owi_assume(a != b && a != c && b != c);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+
+  treeset_remove(set, &a, NULL);
+
+  owi_assert(2 == treeset_size(set));
+  owi_assert(0 == treeset_contains(set, &a));
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_removeAll.c
@@ -1,0 +1,25 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  owi_assume(a != b && a != c && b != c);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+
+  treeset_remove_all(set);
+
+  owi_assert(0 == treeset_size(set));
+  owi_assert(0 == treeset_contains(set, &a));
+  owi_assert(0 == treeset_contains(set, &b));
+  owi_assert(0 == treeset_contains(set, &c));
+}

--- a/test/c/collections-c/normal/testsuite/treeset/treeset_test_size.c
+++ b/test/c/collections-c/normal/testsuite/treeset/treeset_test_size.c
@@ -1,0 +1,20 @@
+#include "owi.h"
+#include "treeset.h"
+#include "utils.h"
+
+static TreeSet *set;
+
+int main() {
+  treeset_new(cmp, &set);
+
+  int a = owi_i32();
+  int b = owi_i32();
+  int c = owi_i32();
+  owi_assume(a != b && a != c && b != c);
+
+  treeset_add(set, &a);
+  treeset_add(set, &b);
+  treeset_add(set, &c);
+
+  owi_assert(3 == treeset_size(set));
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_add.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_add.c
@@ -1,0 +1,37 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  owi_assume(a < b);
+  owi_assume(b < c);
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+  treetable_add(table, &z, str_c);
+
+  owi_assert(1 == treetable_contains_key(table, &x));
+  owi_assert(1 == treetable_contains_key(table, &z));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_get.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_get.c
@@ -1,0 +1,37 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  owi_assume(x != y);
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+
+  char *ra;
+  char *rb;
+
+  treetable_get(table, &x, (void *)&ra);
+  treetable_get(table, &y, (void *)&rb);
+
+  owi_assert(strcmp(ra, str_a) == 0);
+  owi_assert(strcmp(rb, str_b) == 0);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_getFirst.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_getFirst.c
@@ -1,0 +1,44 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  int *first;
+  treetable_get_first_key(table, (void *)&first);
+
+  owi_assert(x == *first);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_getGreaterThan.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_getGreaterThan.c
@@ -1,0 +1,44 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  int *g;
+  treetable_get_greater_than(table, &y, (void *)&g);
+
+  owi_assert(z == *g);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_getLast.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_getLast.c
@@ -1,0 +1,44 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  int *last;
+  treetable_get_last_key(table, (void *)&last);
+
+  owi_assert(w == *last);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_getLessThan.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_getLessThan.c
@@ -1,0 +1,44 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  int *g;
+  treetable_get_lesser_than(table, &y, (void *)&g);
+
+  owi_assert(x == *g);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_iterNext.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_iterNext.c
@@ -1,0 +1,69 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  owi_assume(x < y && y < w && w < z);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  int one = 0;
+  int two = 0;
+  int three = 0;
+  int four = 0;
+
+  TreeTableIter iter;
+  treetable_iter_init(&iter, table);
+
+  TreeTableEntry entry;
+  while (treetable_iter_next(&iter, &entry) != CC_ITER_END) {
+    int const *key = entry.key;
+
+    if (*key == x)
+      one++;
+
+    if (*key == y)
+      two++;
+
+    if (*key == z)
+      three++;
+
+    if (*key == w)
+      four++;
+  }
+
+  owi_assert(1 == one);
+  owi_assert(1 == two);
+  owi_assert(1 == three);
+  owi_assert(1 == four);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_iterRemove.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_iterRemove.c
@@ -1,0 +1,50 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+
+  owi_assume(x < y && y < z);
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+  treetable_add(table, &z, str_c);
+
+  TreeTableIter iter;
+  treetable_iter_init(&iter, table);
+
+  TreeTableEntry entry;
+  while (treetable_iter_next(&iter, &entry) != CC_ITER_END) {
+    int const *key = entry.key;
+
+    if (*key == y) {
+      owi_assert(CC_OK == treetable_iter_remove(&iter, NULL));
+
+      owi_assert(CC_ERR_KEY_NOT_FOUND == treetable_iter_remove(&iter, NULL));
+    }
+  }
+
+  owi_assert(2 == treetable_size(table));
+  owi_assert(0 == treetable_contains_key(table, &y));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_remove.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_remove.c
@@ -1,0 +1,38 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  owi_assume(z != x && z != y);
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+  treetable_add(table, &z, str_c);
+
+  treetable_remove(table, &z, NULL);
+
+  owi_assert(0 == treetable_contains_key(table, &z));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeAll.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeAll.c
@@ -1,0 +1,38 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+  treetable_add(table, &z, str_c);
+
+  treetable_remove_all(table);
+
+  owi_assert(0 == treetable_contains_key(table, &x));
+  owi_assert(0 == treetable_contains_key(table, &y));
+  owi_assert(0 == treetable_contains_key(table, &z));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeFirst.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeFirst.c
@@ -1,0 +1,43 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  treetable_remove_first(table, NULL);
+
+  owi_assert(0 == treetable_contains_key(table, &x));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeLast.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_removeLast.c
@@ -1,0 +1,43 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+  int w = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  int d = owi_i32();
+
+  char str_d[] = {d, '\0'};
+
+  owi_assume(x < y && y < z && z < w);
+
+  treetable_add(table, &z, str_a);
+  treetable_add(table, &w, str_b);
+  treetable_add(table, &y, str_c);
+  treetable_add(table, &x, str_d);
+
+  treetable_remove_last(table, NULL);
+
+  owi_assert(0 == treetable_contains_key(table, &w));
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/testsuite/treetable/treetable_test_size.c
+++ b/test/c/collections-c/normal/testsuite/treetable/treetable_test_size.c
@@ -1,0 +1,35 @@
+#include "owi.h"
+#include "treetable.h"
+#include "utils.h"
+
+static TreeTable *table;
+
+int main() {
+  treetable_new(cmp, &table);
+
+  int x = owi_i32();
+  int y = owi_i32();
+  int z = owi_i32();
+
+  int a = owi_i32();
+
+  char str_a[] = {a, '\0'};
+
+  int b = owi_i32();
+
+  char str_b[] = {b, '\0'};
+
+  int c = owi_i32();
+
+  char str_c[] = {c, '\0'};
+
+  owi_assume(x != y && x != z && y != z);
+
+  treetable_add(table, &x, str_a);
+  treetable_add(table, &y, str_b);
+  treetable_add(table, &z, str_c);
+
+  owi_assert(treetable_size(table) == 3);
+
+  treetable_destroy(table);
+}

--- a/test/c/collections-c/normal/treeset_tests.t
+++ b/test/c/collections-c/normal/treeset_tests.t
@@ -1,0 +1,13 @@
+Treeset tests:
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_remove.c
+  All OK
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_iterNext.c
+  All OK
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_removeAll.c
+  All OK
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_iterRemove.c
+  All OK
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_add.c
+  All OK
+  $ owi c -I include src/treeset.c src/treetable.c src/common.c src/utils.c testsuite/treeset/treeset_test_size.c
+  All OK

--- a/test/c/collections-c/normal/treetable_tests.t
+++ b/test/c/collections-c/normal/treetable_tests.t
@@ -1,0 +1,27 @@
+Treetable tests:
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_getFirst.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_remove.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_iterNext.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_removeFirst.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_getGreaterThan.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_getLessThan.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_size.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_removeAll.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_iterRemove.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_add.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_get.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_removeLast.c
+  All OK
+  $ owi c -I include src/treetable.c src/common.c src/utils.c testsuite/treetable/treetable_test_getLast.c
+  All OK


### PR DESCRIPTION
This adds approximately 30 seconds to the total testsuite execution time.

This was my main testsuite when I was developing WASP. It isn't very exhaustive of all symbolic execution primitives, but it's a nice testsuite to check whether the tool can detect a few simple memory bugs and provide early signs of performance issues. Before the hashconsing, this testsuite ran in 10 to 12 seconds; currently, it takes 30 seconds on my computer.

Edit: this should only be merged after #148 as the `bugs` tests are quite random 