### PR TITLE
Reset solver before model check

### DIFF
--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -225,6 +225,7 @@ let cmd profiling debug unsafe optimize workers no_stop_at_failure
         let pc = Thread.pc thread in
         if print_path_condition then
           Format.pp_std "PATH CONDITION:@\n%a@\n" Expr.pp_list pc;
+        Thread.Solver.reset solver;
         let model = get_model solver pc in
         let result =
           match result with


### PR DESCRIPTION
This should help make tests more deterministic. Given some arbitrary sequence of paths, if we have only one failing condition, this model is now always generated with the same solver (the empty solver). Therefore, it should always produce the same result. However, for multiple failing conditions in the same program, we might depend on issue #148 for determinism.