### PR TITLE
Add symbolic interpreter for fuzzing

### DIFF
--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -159,7 +159,7 @@ let simplify_then_link_then_run ~unsafe ~optimize (pc : unit Result.t Choice.t)
       ([], link_state) file
   in
   let f (pc : (unit, _) result Choice.t) to_run =
-    let c = (Interpret.Symbolic.modul link_state.envs) to_run in
+    let c = (Interpret.SymbolicP.modul link_state.envs) to_run in
     let results =
       Choice.bind pc (fun r ->
           match r with Error _ -> Choice.return r | Ok () -> c )

--- a/src/interpret.ml
+++ b/src/interpret.ml
@@ -1566,4 +1566,5 @@ module Make (P : Interpret_intf.P) :
 end
 
 module Concrete = Make (Concrete.P) [@@inlined hint]
-module Symbolic = Make (Symbolic.P) [@@inlined hint]
+module SymbolicP = Make (Symbolic.P) [@@inlined hint]
+module SymbolicM = Make (Symbolic.M) [@@inlined hint]

--- a/src/interpret.mli
+++ b/src/interpret.mli
@@ -36,9 +36,16 @@ module Concrete : sig
   val exec_freinterpreti : V.t list -> Types.nn -> Types.nn -> V.t list
 end
 
-module Symbolic : sig
+module SymbolicP : sig
   val modul :
        Symbolic.P.env Env_id.collection
     -> Symbolic.P.Module_to_run.t
     -> unit Result.t Symbolic.P.Choice.t
+end
+
+module SymbolicM : sig
+  val modul :
+       Symbolic.M.env Env_id.collection
+    -> Symbolic.M.Module_to_run.t
+    -> unit Result.t Symbolic.M.Choice.t
 end

--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -286,5 +286,13 @@ end
 
 module P' : Interpret_intf.P = P
 
+module M = struct
+  include MakeP (Thread) (Symbolic_choice.Minimalist) [@@inlined hint]
+  module Choice = Symbolic_choice.Minimalist
+end
+
 let convert_module_to_run (m : 'f Link.module_to_run) =
   P.Module_to_run.{ modul = m.modul; env = m.env; to_run = m.to_run }
+
+let convert_module_to_run_minimalist (m : 'f Link.module_to_run) =
+  M.Module_to_run.{ modul = m.modul; env = m.env; to_run = m.to_run }

--- a/src/symbolic_choice.mli
+++ b/src/symbolic_choice.mli
@@ -1,5 +1,18 @@
 exception Assertion of Encoding.Expr.t * Thread.t
 
+module Minimalist : sig
+  include
+    Choice_intf.Complete_without_run
+      with type thread := Thread.t
+       and module V := Symbolic_value.S
+
+  type err = private
+    | Assert_fail
+    | Trap of Trap.t
+
+  val run_minimalist : 'a t -> Thread.t -> ('a, err) Stdlib.Result.t * Thread.t
+end
+
 module MT :
   Choice_intf.Complete_with_trap
     with type thread := Thread.t


### PR DESCRIPTION
We have decided with @chambart to fuzz a simpler version of the symbolic interpreter where every branch can only have one possible choice, which is implemented in the Minimalist monad.