### PR TITLE
Use explicit string interpolation in cache-hit check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           opam depext -y owi
       - name: setup
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: ${{ steps.cache-opam.outputs.cache-hit != 'true' }}
         run: |
           opam install -y ./*.opam --deps-only --with-test --with-doc
       - name: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           opam depext -y owi
       - name: setup-deploy
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: ${{ steps.cache-opam.outputs.cache-hit != 'true' }}
         run: |
           opam install -y ./*.opam --deps-only --with-test --with-doc
       - name: api


### PR DESCRIPTION
Done to fix the failling macOS CI where cache hits are not detected and ocaml-setup is attempted and fails.