### PR TITLE
In tests, change dune exec for direct binary call

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -18,7 +18,7 @@
 ## Man page
 
 ```sh
-$ dune exec -- owi --help=plain
+$ owi --help=plain
 NAME
        owi - OCaml WebAssembly Interpreter
 

--- a/example/c/README.md
+++ b/example/c/README.md
@@ -31,7 +31,7 @@ We are defining one symbolic variable `x` using the function `owi_i32(void)`. Th
 Then we use `owi_assert(poly != 0)`. Which should fail as this polynomial has multiple roots. Let's see what owi says about it:
 
 ```sh
-$ dune exec owi -- c ./poly.c -w1
+$ owi c ./poly.c -w1
 ...
 Model:
   (model
@@ -77,7 +77,7 @@ Let's run owi on this new input:
 
 
 ```sh
-$ dune exec owi -- c ./poly2.c
+$ owi c ./poly2.c
 ...
 Model:
   (model
@@ -172,7 +172,7 @@ int main (void) {
 ```
 
 ```sh
-$ dune exec owi -- c ./maze.c
+$ owi c ./maze.c
 Assert failure: false
 Model:
   (model
@@ -211,7 +211,7 @@ Reached problem!
 ## Man page
 
 ```sh
-$ dune exec owi -- c --help=plain
+$ owi c --help=plain
 NAME
        owi-c - Compile a C file to Wasm and run the symbolic interpreter on
        it

--- a/example/define_host_function/README.md
+++ b/example/define_host_function/README.md
@@ -99,7 +99,7 @@ let () =
 You'll get the expected result:
 
 ```sh
-$ dune exec -- ./extern.exe
+$ ./extern.exe
 42
 13
 ```

--- a/example/fmt/README.md
+++ b/example/fmt/README.md
@@ -42,7 +42,7 @@ i32.lt_s
 Owi will format it like this:
 
 ```sh
-$ dune exec -- owi fmt horrible.wat
+$ owi fmt horrible.wat
 (module
   (memory 10)
   (func $f (param $n i32) (result i32)
@@ -99,7 +99,7 @@ Are you able to recognize the program now?
 ## Man page
 
 ```sh
-$ dune exec owi -- fmt --help=plain
+$ owi fmt --help=plain
 NAME
        owi-fmt - Format a .wat or .wast file
 

--- a/example/opt/README.md
+++ b/example/opt/README.md
@@ -337,7 +337,7 @@ Given the useless program `useless.wat`:
 Owi is able to get rid of most of the code:
 
 ```sh
-$ dune exec -- owi opt useless.wat
+$ owi opt useless.wat
 (module
   (func $i32binop
 
@@ -364,7 +364,7 @@ $ dune exec -- owi opt useless.wat
 ## Man page
 
 ```sh
-$ dune exec owi -- opt --help=plain
+$ owi opt --help=plain
 NAME
        owi-opt - Optimize a module
 

--- a/example/run/README.md
+++ b/example/run/README.md
@@ -20,13 +20,13 @@ Given a file `42.wat` with the following content:
 Running the interpreter is as simple as:
 
 ```sh
-$ dune exec owi -- run ./42.wat
+$ owi run ./42.wat
 ```
 
 Nothing is happening, so you can add the `--debug` option to print an execution trace:
 
 ```sh
-$ dune exec owi -- run ./42.wat --debug
+$ owi run ./42.wat --debug
 parsing      ...
 checking     ...
 grouping     ...
@@ -53,7 +53,7 @@ stack        : [  ]
 ## Man page
 
 ```sh
-$ dune exec owi -- run --help=plain
+$ owi run --help=plain
 NAME
        owi-run - Run the concrete interpreter
 

--- a/example/script/README.md
+++ b/example/script/README.md
@@ -14,6 +14,6 @@ Given the following `print.wast` file:
 You can print the value thanks to the `print_i32` function imported from the `spectest` module:
 
 ```sh
-$ dune exec owi -- script ./print.wast
+$ owi script ./print.wast
 42
 ```

--- a/example/sym/README.md
+++ b/example/sym/README.md
@@ -24,7 +24,7 @@ In the following file, we define `x` as a symbolic variable. Then if `5 < x`, we
 Let's see if owi is able to find a value for `x` that lead to an error:
 
 ```sh
-$ dune exec owi -- sym ./mini.wat
+$ owi sym ./mini.wat
 Trap: unreachable
 Model:
   (model
@@ -42,7 +42,7 @@ TODO
 ## Man page
 
 ```sh
-$ dune exec owi -- sym --help=plain
+$ owi sym --help=plain
 NAME
        owi-sym - Run the symbolic interpreter
 

--- a/example/validate/README.md
+++ b/example/validate/README.md
@@ -21,7 +21,7 @@ Given a file `type_error.wat` with the following content:
 Running the validator is as simple as:
 
 ```sh
-$ dune exec owi -- validate ./type_error.wat
+$ owi validate ./type_error.wat
 type mismatch (pop)
 [35]
 ```
@@ -29,7 +29,7 @@ type mismatch (pop)
 You can also print a more detailed trace with the `--debug` option:
 
 ```sh
-$ dune exec owi -- validate ./type_error.wat --debug
+$ owi validate ./type_error.wat --debug
 parsing      ...
 checking     ...
 grouping     ...
@@ -43,7 +43,7 @@ type mismatch (pop)
 ## Man page
 
 ```sh
-$ dune exec owi -- validate --help=plain
+$ owi validate --help=plain
 NAME
        owi-validate - Validate a module
 

--- a/test/c/malloc_aligned.t
+++ b/test/c/malloc_aligned.t
@@ -1,2 +1,2 @@
-  $ dune exec owi -- c ./malloc_aligned.c
+  $ owi c ./malloc_aligned.c
   All OK

--- a/test/c/not_exists.t
+++ b/test/c/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi c idontexist.wat
+  $ owi c idontexist.wat
   owi: no file 'idontexist.wat'
   Usage: owi c [OPTION]… [ARG]…
   Try 'owi c --help' or 'owi --help' for more information.

--- a/test/c/test-comp/simple.t
+++ b/test/c/test-comp/simple.t
@@ -1,4 +1,4 @@
-  $ dune exec owi -- c --testcomp ./simple.c
+  $ owi c --testcomp ./simple.c
   Assert failure: (i32.ne (i32.mul symbol_0 symbol_0) (i32 0))
   Model:
     (model

--- a/test/fmt/done.t
+++ b/test/fmt/done.t
@@ -1,2 +1,2 @@
 inplace:
-  $ dune exec owi -- fmt --inplace done.wat
+  $ owi fmt --inplace done.wat

--- a/test/fmt/locals.t
+++ b/test/fmt/locals.t
@@ -1,5 +1,5 @@
 print optimized locals:
-  $ dune exec owi -- opt locals.wat
+  $ owi opt locals.wat
   (module
     (func $f1 (param $a1 i32) (param $a2 i32) (param $a3 i32) (local $l1 i32) (local $l2 i32)
       local.get 3

--- a/test/fmt/locals_drop.t
+++ b/test/fmt/locals_drop.t
@@ -1,5 +1,5 @@
 print optimized locals:
-  $ dune exec owi -- opt locals_drop.wat
+  $ owi opt locals_drop.wat
   (module
     (func $f1 (param $a1 i32) (param $a2 i32) (param $a3 i32)
       

--- a/test/fmt/not_exists.t
+++ b/test/fmt/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi fmt idontexist.wat
+  $ owi fmt idontexist.wat
   owi: no file 'idontexist.wat'
   Usage: owi fmt [--inplace] [OPTION]… [ARG]…
   Try 'owi fmt --help' or 'owi --help' for more information.

--- a/test/fmt/print.t
+++ b/test/fmt/print.t
@@ -1,5 +1,5 @@
 print symbolic:
-  $ dune exec owi -- fmt m.wat
+  $ owi fmt m.wat
   (module
     (func $f (param $x i32) (param $y i32) (result i32)
       local.get $x

--- a/test/fmt/script.t
+++ b/test/fmt/script.t
@@ -1,5 +1,5 @@
 print script:
-  $ dune exec owi -- fmt script.wast
+  $ owi fmt script.wast
   (module
     (func (param $x i32) (param $y i32) (result i32)
       local.get $x

--- a/test/help/help.t
+++ b/test/help/help.t
@@ -1,5 +1,5 @@
 no subcommand should print help
-  $ dune exec -- owi
+  $ owi
   NAME
          owi - OCaml WebAssembly Interpreter
   

--- a/test/opt/binop.t
+++ b/test/opt/binop.t
@@ -1,5 +1,5 @@
 binary operations instructions:
-  $ dune exec -- owi opt binop.wat
+  $ owi opt binop.wat
   (module
     (func $i32binop
       

--- a/test/opt/block_loop.t
+++ b/test/opt/block_loop.t
@@ -1,5 +1,5 @@
 block loop instructions:
-  $ dune exec -- owi opt block_loop.wat
+  $ owi opt block_loop.wat
   (module
     (func $start
       

--- a/test/opt/br.t
+++ b/test/opt/br.t
@@ -1,5 +1,5 @@
 br instructions:
-  $ dune exec -- owi opt br.wat
+  $ owi opt br.wat
   (module
     (func $br
       i32.const 42

--- a/test/opt/convert.t
+++ b/test/opt/convert.t
@@ -1,5 +1,5 @@
 f**.convert_i** instructions:
-  $ dune exec -- owi opt convert.wat
+  $ owi opt convert.wat
   (module
     (func $start
       

--- a/test/opt/demote_promote.t
+++ b/test/opt/demote_promote.t
@@ -1,5 +1,5 @@
 f32.demote_f64 f64.promote_f32 instructions:
-  $ dune exec -- owi opt demote_promote.wat
+  $ owi opt demote_promote.wat
   (module
     (func $start
       

--- a/test/opt/drop.t
+++ b/test/opt/drop.t
@@ -1,5 +1,5 @@
 drop instruction:
-  $ dune exec -- owi opt drop.wat
+  $ owi opt drop.wat
   (module
     (func $start
       call 1

--- a/test/opt/extend_wrap.t
+++ b/test/opt/extend_wrap.t
@@ -1,5 +1,5 @@
 i**.extend_** i32.wrap_i64 instructions:
-  $ dune exec -- owi opt extend_wrap.wat
+  $ owi opt extend_wrap.wat
   (module
     (func $extend
       

--- a/test/opt/fbinop.t
+++ b/test/opt/fbinop.t
@@ -1,5 +1,5 @@
 f32 / f64 binary operations:
-  $ dune exec -- owi opt fbinop.wat
+  $ owi opt fbinop.wat
   (module
     (func $start
       

--- a/test/opt/ibinop.t
+++ b/test/opt/ibinop.t
@@ -1,5 +1,5 @@
 i32 / i64 binary operations:
-  $ dune exec -- owi opt ibinop.wat
+  $ owi opt ibinop.wat
   (module
     (func $start
       

--- a/test/opt/if.t
+++ b/test/opt/if.t
@@ -1,5 +1,5 @@
 if then else instruction:
-  $ dune exec -- owi opt if.wat
+  $ owi opt if.wat
   (module
     (func $start
       (block (result i32)

--- a/test/opt/local.t
+++ b/test/opt/local.t
@@ -1,5 +1,5 @@
 unused local variables:
-  $ dune exec -- owi opt local.wat
+  $ owi opt local.wat
   (module
     (func $f0 (local i32)
       i32.const 0

--- a/test/opt/not_exists.t
+++ b/test/opt/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi opt not_exists.wat --debug
+  $ owi opt not_exists.wat --debug
   owi: no file 'not_exists.wat'
   Usage: owi opt [--debug] [--unsafe] [OPTION]… [ARG]…
   Try 'owi opt --help' or 'owi --help' for more information.

--- a/test/opt/ref_nop.t
+++ b/test/opt/ref_nop.t
@@ -1,5 +1,5 @@
 ref.null ref.is_null nop instructions:
-  $ dune exec -- owi opt ref_nop.wat
+  $ owi opt ref_nop.wat
   (module
     (func $start
       

--- a/test/opt/reinterpret.t
+++ b/test/opt/reinterpret.t
@@ -1,5 +1,5 @@
 f**.reinterpret_i** i**.reinterpret_f** instructions:
-  $ dune exec -- owi opt reinterpret.wat
+  $ owi opt reinterpret.wat
   (module
     (func $start
       

--- a/test/opt/relop_testop.t
+++ b/test/opt/relop_testop.t
@@ -1,5 +1,5 @@
 **.eq eqz lt gt ...  instructions:
-  $ dune exec -- owi opt relop_testop.wat
+  $ owi opt relop_testop.wat
   (module
     (func $i32relop
       

--- a/test/opt/return.t
+++ b/test/opt/return.t
@@ -1,5 +1,5 @@
 return instructions:
-  $ dune exec -- owi opt return.wat
+  $ owi opt return.wat
   (module
     (func $return (result i32)
       i32.const 42

--- a/test/opt/select.t
+++ b/test/opt/select.t
@@ -1,5 +1,5 @@
 select instruction:
-  $ dune exec -- owi opt select.wat
+  $ owi opt select.wat
   (module
     (func $start
       

--- a/test/opt/tee.t
+++ b/test/opt/tee.t
@@ -1,5 +1,5 @@
 set get tee simplification:
-  $ dune exec -- owi opt tee.wat
+  $ owi opt tee.wat
   (module
     (func $start (local $x i32)
       i32.const 41

--- a/test/opt/trunc.t
+++ b/test/opt/trunc.t
@@ -1,5 +1,5 @@
 **.trunc_** **.trunc_sat_** instructions:
-  $ dune exec -- owi opt trunc.wat
+  $ owi opt trunc.wat
   (module
     (func $trunc
       

--- a/test/opt/unop.t
+++ b/test/opt/unop.t
@@ -1,5 +1,5 @@
 unop () instructions:
-  $ dune exec -- owi opt unop.wat
+  $ owi opt unop.wat
   (module
     (func $iunop
       

--- a/test/run/not_exists.t
+++ b/test/run/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi run not_exists.wat
+  $ owi run not_exists.wat
   owi: no file 'not_exists.wat'
   Usage: owi run [OPTION]… [ARG]…
   Try 'owi run --help' or 'owi --help' for more information.

--- a/test/script/gc.t
+++ b/test/script/gc.t
@@ -1,15 +1,15 @@
-  $ dune exec owi -- script --no-exhaustion gc/array.wast
+  $ owi script --no-exhaustion gc/array.wast
   no error
-  $ dune exec owi -- script --no-exhaustion gc/br_on_cast_fail.wast
+  $ owi script --no-exhaustion gc/br_on_cast_fail.wast
   unexpected token
   [40]
-  $ dune exec owi -- script --no-exhaustion gc/br_on_cast.wast
+  $ owi script --no-exhaustion gc/br_on_cast.wast
   unexpected token
   [40]
-  $ dune exec owi -- script --no-exhaustion gc/call_ref.wast
+  $ owi script --no-exhaustion gc/call_ref.wast
   unknown type
   [49]
-  $ dune exec owi -- script --no-exhaustion gc/extern.wast
+  $ owi script --no-exhaustion gc/extern.wast
   owi: internal error, uncaught exception:
        File "src/typecheck.ml", line 478, characters 4-10: Assertion failed
        Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 478, characters 4-16
@@ -30,7 +30,7 @@
        Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
        Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
   [125]
-  $ dune exec owi -- script --no-exhaustion gc/i31.wast
+  $ owi script --no-exhaustion gc/i31.wast
   owi: internal error, uncaught exception:
        File "src/script.ml", line 103, characters 4-10: Assertion failed
        Raised at Owi__Script.compare_result_const in file "src/script.ml", line 103, characters 4-16
@@ -44,7 +44,7 @@
        Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
        Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
   [125]
-  $ dune exec owi -- script --no-exhaustion gc/ref_cast.wast
+  $ owi script --no-exhaustion gc/ref_cast.wast
   owi: internal error, uncaught exception:
        File "src/typecheck.ml", line 478, characters 4-10: Assertion failed
        Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 478, characters 4-16
@@ -65,7 +65,7 @@
        Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
        Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
   [125]
-  $ dune exec owi -- script --no-exhaustion gc/ref_eq.wast
+  $ owi script --no-exhaustion gc/ref_eq.wast
   owi: internal error, uncaught exception:
        File "src/typecheck.ml", line 478, characters 4-10: Assertion failed
        Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 478, characters 4-16
@@ -86,7 +86,7 @@
        Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
        Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
   [125]
-  $ dune exec owi -- script --no-exhaustion gc/ref_test.wast
+  $ owi script --no-exhaustion gc/ref_test.wast
   owi: internal error, uncaught exception:
        File "src/typecheck.ml", line 478, characters 4-10: Assertion failed
        Raised at Owi__Typecheck.typecheck_instr in file "src/typecheck.ml", line 478, characters 4-16
@@ -107,11 +107,11 @@
        Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
        Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
   [125]
-  $ dune exec owi -- script --no-exhaustion gc/return_call_ref.wast
+  $ owi script --no-exhaustion gc/return_call_ref.wast
   unknown type
   [49]
-  $ dune exec owi -- script --no-exhaustion gc/struct.wast
+  $ owi script --no-exhaustion gc/struct.wast
   no error
-  $ dune exec owi -- script --no-exhaustion gc/type-subtyping.wast
+  $ owi script --no-exhaustion gc/type-subtyping.wast
   unknown type
   [49]

--- a/test/script/not_exists.t
+++ b/test/script/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi script not_exists.wat
+  $ owi script not_exists.wat
   owi: no file 'not_exists.wat'
   Usage: owi script [OPTION]… [ARG]…
   Try 'owi script --help' or 'owi --help' for more information.

--- a/test/script/passing.t
+++ b/test/script/passing.t
@@ -1,15 +1,15 @@
-  $ dune exec owi -- script --no-exhaustion passing/42.wast
-  $ dune exec owi -- script --no-exhaustion passing/arith.wast
-  $ dune exec owi -- script --no-exhaustion passing/drop.wast
-  $ dune exec owi -- script --no-exhaustion passing/duplicated_mod_name.wast
-  $ dune exec owi -- script --no-exhaustion passing/duplicated_register.wast
-  $ dune exec owi -- script --no-exhaustion passing/elem_simple.wast
-  $ dune exec owi -- script --no-exhaustion passing/elem.wast
-  $ dune exec owi -- script --no-exhaustion passing/emptydata.wast
-  $ dune exec owi -- script --no-exhaustion passing/fact.wast
-  $ dune exec owi -- script --no-exhaustion passing/fibo.wast
-  $ dune exec owi -- script --no-exhaustion passing/fuzz01.wast
-  $ dune exec owi -- script --no-exhaustion passing/imports_simple.wast
+  $ owi script --no-exhaustion passing/42.wast
+  $ owi script --no-exhaustion passing/arith.wast
+  $ owi script --no-exhaustion passing/drop.wast
+  $ owi script --no-exhaustion passing/duplicated_mod_name.wast
+  $ owi script --no-exhaustion passing/duplicated_register.wast
+  $ owi script --no-exhaustion passing/elem_simple.wast
+  $ owi script --no-exhaustion passing/elem.wast
+  $ owi script --no-exhaustion passing/emptydata.wast
+  $ owi script --no-exhaustion passing/fact.wast
+  $ owi script --no-exhaustion passing/fibo.wast
+  $ owi script --no-exhaustion passing/fuzz01.wast
+  $ owi script --no-exhaustion passing/imports_simple.wast
   13
   14
   42
@@ -22,24 +22,24 @@
   24
   24
   24
-  $ dune exec owi -- script --no-exhaustion passing/interpret.wast
-  $ dune exec owi -- script --no-exhaustion passing/itestop.wast
-  $ dune exec owi -- script --no-exhaustion passing/linking_min2.wast
-  $ dune exec owi -- script --no-exhaustion passing/linking_min.wast
-  $ dune exec owi -- script --no-exhaustion passing/localfun.wast
-  $ dune exec owi -- script --no-exhaustion passing/loop.wast
-  $ dune exec owi -- script --no-exhaustion passing/memory_fill.wast
-  $ dune exec owi -- script --no-exhaustion passing/memory.wast
-  $ dune exec owi -- script --no-exhaustion passing/modtest.wast
+  $ owi script --no-exhaustion passing/interpret.wast
+  $ owi script --no-exhaustion passing/itestop.wast
+  $ owi script --no-exhaustion passing/linking_min2.wast
+  $ owi script --no-exhaustion passing/linking_min.wast
+  $ owi script --no-exhaustion passing/localfun.wast
+  $ owi script --no-exhaustion passing/loop.wast
+  $ owi script --no-exhaustion passing/memory_fill.wast
+  $ owi script --no-exhaustion passing/memory.wast
+  $ owi script --no-exhaustion passing/modtest.wast
   98
   99
-  $ dune exec owi -- script --no-exhaustion passing/multiple_table.wast
-  $ dune exec owi -- script --no-exhaustion passing/neg_memory_grow.wast
-  $ dune exec owi -- script --no-exhaustion passing/quickstart.wast
-  $ dune exec owi -- script --no-exhaustion passing/relop.wast
-  $ dune exec owi -- script --no-exhaustion passing/stringinitmsg.wast
-  $ dune exec owi -- script --no-exhaustion passing/type_abbreviations.wast
-  $ dune exec owi -- script --no-exhaustion passing/typecheck3.wast
-  $ dune exec owi -- script --no-exhaustion passing/typecheck4.wast
-  $ dune exec owi -- script --no-exhaustion passing/typecheckbis.wast
-  $ dune exec owi -- script --no-exhaustion passing/typecheck.wast
+  $ owi script --no-exhaustion passing/multiple_table.wast
+  $ owi script --no-exhaustion passing/neg_memory_grow.wast
+  $ owi script --no-exhaustion passing/quickstart.wast
+  $ owi script --no-exhaustion passing/relop.wast
+  $ owi script --no-exhaustion passing/stringinitmsg.wast
+  $ owi script --no-exhaustion passing/type_abbreviations.wast
+  $ owi script --no-exhaustion passing/typecheck3.wast
+  $ owi script --no-exhaustion passing/typecheck4.wast
+  $ owi script --no-exhaustion passing/typecheckbis.wast
+  $ owi script --no-exhaustion passing/typecheck.wast

--- a/test/script/reference.t
+++ b/test/script/reference.t
@@ -1,42 +1,42 @@
-  $ dune exec owi -- script --no-exhaustion reference/address.wast
-  $ dune exec owi -- script --no-exhaustion reference/align.wast
-  $ dune exec owi -- script --no-exhaustion reference/binary-leb128.wast
-  $ dune exec owi -- script --no-exhaustion reference/binary.wast
-  $ dune exec owi -- script --no-exhaustion reference/block.wast
-  $ dune exec owi -- script --no-exhaustion reference/br_if.wast
-  $ dune exec owi -- script --no-exhaustion reference/br_table.wast
-  $ dune exec owi -- script --no-exhaustion reference/br.wast
-  $ dune exec owi -- script --no-exhaustion reference/bulk.wast
-  $ dune exec owi -- script --no-exhaustion reference/call_indirect.wast
-  $ dune exec owi -- script --no-exhaustion reference/call.wast
-  $ dune exec owi -- script --no-exhaustion reference/comments.wast
-  $ dune exec owi -- script --no-exhaustion reference/const.wast
-  $ dune exec owi -- script --no-exhaustion reference/conversions.wast
-  $ dune exec owi -- script --no-exhaustion reference/custom.wast
-  $ dune exec owi -- script --no-exhaustion reference/data.wast
-  $ dune exec owi -- script --no-exhaustion reference/elem.wast
-  $ dune exec owi -- script --no-exhaustion reference/endianness.wast
-  $ dune exec owi -- script --no-exhaustion reference/exports.wast
-  $ dune exec owi -- script --no-exhaustion reference/f32_bitwise.wast
-  $ dune exec owi -- script --no-exhaustion reference/f32_cmp.wast
-  $ dune exec owi -- script --no-exhaustion reference/f32.wast
-  $ dune exec owi -- script --no-exhaustion reference/f64_bitwise.wast
-  $ dune exec owi -- script --no-exhaustion reference/f64_cmp.wast
-  $ dune exec owi -- script --no-exhaustion reference/f64.wast
-  $ dune exec owi -- script --no-exhaustion reference/fac.wast
-  $ dune exec owi -- script --no-exhaustion reference/float_exprs.wast
-  $ dune exec owi -- script --no-exhaustion reference/float_literals.wast
-  $ dune exec owi -- script --no-exhaustion reference/float_memory.wast
-  $ dune exec owi -- script --no-exhaustion reference/float_misc.wast
-  $ dune exec owi -- script --no-exhaustion reference/forward.wast
-  $ dune exec owi -- script --no-exhaustion reference/func_ptrs.wast
+  $ owi script --no-exhaustion reference/address.wast
+  $ owi script --no-exhaustion reference/align.wast
+  $ owi script --no-exhaustion reference/binary-leb128.wast
+  $ owi script --no-exhaustion reference/binary.wast
+  $ owi script --no-exhaustion reference/block.wast
+  $ owi script --no-exhaustion reference/br_if.wast
+  $ owi script --no-exhaustion reference/br_table.wast
+  $ owi script --no-exhaustion reference/br.wast
+  $ owi script --no-exhaustion reference/bulk.wast
+  $ owi script --no-exhaustion reference/call_indirect.wast
+  $ owi script --no-exhaustion reference/call.wast
+  $ owi script --no-exhaustion reference/comments.wast
+  $ owi script --no-exhaustion reference/const.wast
+  $ owi script --no-exhaustion reference/conversions.wast
+  $ owi script --no-exhaustion reference/custom.wast
+  $ owi script --no-exhaustion reference/data.wast
+  $ owi script --no-exhaustion reference/elem.wast
+  $ owi script --no-exhaustion reference/endianness.wast
+  $ owi script --no-exhaustion reference/exports.wast
+  $ owi script --no-exhaustion reference/f32_bitwise.wast
+  $ owi script --no-exhaustion reference/f32_cmp.wast
+  $ owi script --no-exhaustion reference/f32.wast
+  $ owi script --no-exhaustion reference/f64_bitwise.wast
+  $ owi script --no-exhaustion reference/f64_cmp.wast
+  $ owi script --no-exhaustion reference/f64.wast
+  $ owi script --no-exhaustion reference/fac.wast
+  $ owi script --no-exhaustion reference/float_exprs.wast
+  $ owi script --no-exhaustion reference/float_literals.wast
+  $ owi script --no-exhaustion reference/float_memory.wast
+  $ owi script --no-exhaustion reference/float_misc.wast
+  $ owi script --no-exhaustion reference/forward.wast
+  $ owi script --no-exhaustion reference/func_ptrs.wast
   83
-  $ dune exec owi -- script --no-exhaustion reference/func.wast
-  $ dune exec owi -- script --no-exhaustion reference/global.wast
-  $ dune exec owi -- script --no-exhaustion reference/i32.wast
-  $ dune exec owi -- script --no-exhaustion reference/i64.wast
-  $ dune exec owi -- script --no-exhaustion reference/if.wast
-  $ dune exec owi -- script --no-exhaustion reference/imports.wast
+  $ owi script --no-exhaustion reference/func.wast
+  $ owi script --no-exhaustion reference/global.wast
+  $ owi script --no-exhaustion reference/i32.wast
+  $ owi script --no-exhaustion reference/i64.wast
+  $ owi script --no-exhaustion reference/if.wast
+  $ owi script --no-exhaustion reference/imports.wast
   13
   14
   42
@@ -52,61 +52,61 @@
   24
   24
   13
-  $ dune exec owi -- script --no-exhaustion reference/inline-module.wast
-  $ dune exec owi -- script --no-exhaustion reference/int_exprs.wast
-  $ dune exec owi -- script --no-exhaustion reference/int_literals.wast
-  $ dune exec owi -- script --no-exhaustion reference/labels.wast
-  $ dune exec owi -- script --no-exhaustion reference/left-to-right.wast
-  $ dune exec owi -- script --no-exhaustion reference/linking.wast
-  $ dune exec owi -- script --no-exhaustion reference/load.wast
-  $ dune exec owi -- script --no-exhaustion reference/local_get.wast
-  $ dune exec owi -- script --no-exhaustion reference/local_set.wast
-  $ dune exec owi -- script --no-exhaustion reference/local_tee.wast
-  $ dune exec owi -- script --no-exhaustion reference/loop.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_copy.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_fill.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_grow.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_init.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_redundancy.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_size.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory_trap.wast
-  $ dune exec owi -- script --no-exhaustion reference/memory.wast
-  $ dune exec owi -- script --no-exhaustion reference/names.wast
+  $ owi script --no-exhaustion reference/inline-module.wast
+  $ owi script --no-exhaustion reference/int_exprs.wast
+  $ owi script --no-exhaustion reference/int_literals.wast
+  $ owi script --no-exhaustion reference/labels.wast
+  $ owi script --no-exhaustion reference/left-to-right.wast
+  $ owi script --no-exhaustion reference/linking.wast
+  $ owi script --no-exhaustion reference/load.wast
+  $ owi script --no-exhaustion reference/local_get.wast
+  $ owi script --no-exhaustion reference/local_set.wast
+  $ owi script --no-exhaustion reference/local_tee.wast
+  $ owi script --no-exhaustion reference/loop.wast
+  $ owi script --no-exhaustion reference/memory_copy.wast
+  $ owi script --no-exhaustion reference/memory_fill.wast
+  $ owi script --no-exhaustion reference/memory_grow.wast
+  $ owi script --no-exhaustion reference/memory_init.wast
+  $ owi script --no-exhaustion reference/memory_redundancy.wast
+  $ owi script --no-exhaustion reference/memory_size.wast
+  $ owi script --no-exhaustion reference/memory_trap.wast
+  $ owi script --no-exhaustion reference/memory.wast
+  $ owi script --no-exhaustion reference/names.wast
   42
   123
-  $ dune exec owi -- script --no-exhaustion reference/nop.wast
-  $ dune exec owi -- script --no-exhaustion reference/ref_func.wast
-  $ dune exec owi -- script --no-exhaustion reference/ref_is_null.wast
-  $ dune exec owi -- script --no-exhaustion reference/ref_null.wast
-  $ dune exec owi -- script --no-exhaustion reference/return_call_indirect.wast
-  $ dune exec owi -- script --no-exhaustion reference/return_call.wast
-  $ dune exec owi -- script --no-exhaustion reference/return.wast
-  $ dune exec owi -- script --no-exhaustion reference/select.wast
-  $ dune exec owi -- script --no-exhaustion reference/skip-stack-guard-page.wast
-  $ dune exec owi -- script --no-exhaustion reference/stack.wast
-  $ dune exec owi -- script --no-exhaustion reference/start.wast
+  $ owi script --no-exhaustion reference/nop.wast
+  $ owi script --no-exhaustion reference/ref_func.wast
+  $ owi script --no-exhaustion reference/ref_is_null.wast
+  $ owi script --no-exhaustion reference/ref_null.wast
+  $ owi script --no-exhaustion reference/return_call_indirect.wast
+  $ owi script --no-exhaustion reference/return_call.wast
+  $ owi script --no-exhaustion reference/return.wast
+  $ owi script --no-exhaustion reference/select.wast
+  $ owi script --no-exhaustion reference/skip-stack-guard-page.wast
+  $ owi script --no-exhaustion reference/stack.wast
+  $ owi script --no-exhaustion reference/start.wast
   1
   2
-  $ dune exec owi -- script --no-exhaustion reference/store.wast
-  $ dune exec owi -- script --no-exhaustion reference/switch.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_copy.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_fill.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_get.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_grow.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_init.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_set.wast
-  $ dune exec owi -- script --no-exhaustion reference/table_size.wast
-  $ dune exec owi -- script --no-exhaustion reference/table-sub.wast
-  $ dune exec owi -- script --no-exhaustion reference/table.wast
-  $ dune exec owi -- script --no-exhaustion reference/tokens.wast
-  $ dune exec owi -- script --no-exhaustion reference/token.wast
-  $ dune exec owi -- script --no-exhaustion reference/traps.wast
-  $ dune exec owi -- script --no-exhaustion reference/type.wast
-  $ dune exec owi -- script --no-exhaustion reference/unreachable.wast
-  $ dune exec owi -- script --no-exhaustion reference/unreached-invalid.wast
-  $ dune exec owi -- script --no-exhaustion reference/unreached-valid.wast
-  $ dune exec owi -- script --no-exhaustion reference/unwind.wast
-  $ dune exec owi -- script --no-exhaustion reference/utf8-custom-section-id.wast
-  $ dune exec owi -- script --no-exhaustion reference/utf8-import-field.wast
-  $ dune exec owi -- script --no-exhaustion reference/utf8-import-module.wast
-  $ dune exec owi -- script --no-exhaustion reference/utf8-invalid-encoding.wast
+  $ owi script --no-exhaustion reference/store.wast
+  $ owi script --no-exhaustion reference/switch.wast
+  $ owi script --no-exhaustion reference/table_copy.wast
+  $ owi script --no-exhaustion reference/table_fill.wast
+  $ owi script --no-exhaustion reference/table_get.wast
+  $ owi script --no-exhaustion reference/table_grow.wast
+  $ owi script --no-exhaustion reference/table_init.wast
+  $ owi script --no-exhaustion reference/table_set.wast
+  $ owi script --no-exhaustion reference/table_size.wast
+  $ owi script --no-exhaustion reference/table-sub.wast
+  $ owi script --no-exhaustion reference/table.wast
+  $ owi script --no-exhaustion reference/tokens.wast
+  $ owi script --no-exhaustion reference/token.wast
+  $ owi script --no-exhaustion reference/traps.wast
+  $ owi script --no-exhaustion reference/type.wast
+  $ owi script --no-exhaustion reference/unreachable.wast
+  $ owi script --no-exhaustion reference/unreached-invalid.wast
+  $ owi script --no-exhaustion reference/unreached-valid.wast
+  $ owi script --no-exhaustion reference/unwind.wast
+  $ owi script --no-exhaustion reference/utf8-custom-section-id.wast
+  $ owi script --no-exhaustion reference/utf8-import-field.wast
+  $ owi script --no-exhaustion reference/utf8-import-module.wast
+  $ owi script --no-exhaustion reference/utf8-invalid-encoding.wast

--- a/test/script/reference_opt.t
+++ b/test/script/reference_opt.t
@@ -1,42 +1,42 @@
-  $ dune exec owi -- script --no-exhaustion --optimize reference/address.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/align.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/binary-leb128.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/binary.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/block.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/br_if.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/br_table.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/br.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/bulk.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/call_indirect.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/call.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/comments.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/const.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/conversions.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/custom.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/data.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/elem.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/endianness.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/exports.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f32_bitwise.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f32_cmp.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f32.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f64_bitwise.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f64_cmp.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/f64.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/fac.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/float_exprs.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/float_literals.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/float_memory.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/float_misc.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/forward.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/func_ptrs.wast
+  $ owi script --no-exhaustion --optimize reference/address.wast
+  $ owi script --no-exhaustion --optimize reference/align.wast
+  $ owi script --no-exhaustion --optimize reference/binary-leb128.wast
+  $ owi script --no-exhaustion --optimize reference/binary.wast
+  $ owi script --no-exhaustion --optimize reference/block.wast
+  $ owi script --no-exhaustion --optimize reference/br_if.wast
+  $ owi script --no-exhaustion --optimize reference/br_table.wast
+  $ owi script --no-exhaustion --optimize reference/br.wast
+  $ owi script --no-exhaustion --optimize reference/bulk.wast
+  $ owi script --no-exhaustion --optimize reference/call_indirect.wast
+  $ owi script --no-exhaustion --optimize reference/call.wast
+  $ owi script --no-exhaustion --optimize reference/comments.wast
+  $ owi script --no-exhaustion --optimize reference/const.wast
+  $ owi script --no-exhaustion --optimize reference/conversions.wast
+  $ owi script --no-exhaustion --optimize reference/custom.wast
+  $ owi script --no-exhaustion --optimize reference/data.wast
+  $ owi script --no-exhaustion --optimize reference/elem.wast
+  $ owi script --no-exhaustion --optimize reference/endianness.wast
+  $ owi script --no-exhaustion --optimize reference/exports.wast
+  $ owi script --no-exhaustion --optimize reference/f32_bitwise.wast
+  $ owi script --no-exhaustion --optimize reference/f32_cmp.wast
+  $ owi script --no-exhaustion --optimize reference/f32.wast
+  $ owi script --no-exhaustion --optimize reference/f64_bitwise.wast
+  $ owi script --no-exhaustion --optimize reference/f64_cmp.wast
+  $ owi script --no-exhaustion --optimize reference/f64.wast
+  $ owi script --no-exhaustion --optimize reference/fac.wast
+  $ owi script --no-exhaustion --optimize reference/float_exprs.wast
+  $ owi script --no-exhaustion --optimize reference/float_literals.wast
+  $ owi script --no-exhaustion --optimize reference/float_memory.wast
+  $ owi script --no-exhaustion --optimize reference/float_misc.wast
+  $ owi script --no-exhaustion --optimize reference/forward.wast
+  $ owi script --no-exhaustion --optimize reference/func_ptrs.wast
   83
-  $ dune exec owi -- script --no-exhaustion --optimize reference/func.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/global.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/i32.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/i64.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/if.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/imports.wast
+  $ owi script --no-exhaustion --optimize reference/func.wast
+  $ owi script --no-exhaustion --optimize reference/global.wast
+  $ owi script --no-exhaustion --optimize reference/i32.wast
+  $ owi script --no-exhaustion --optimize reference/i64.wast
+  $ owi script --no-exhaustion --optimize reference/if.wast
+  $ owi script --no-exhaustion --optimize reference/imports.wast
   13
   14
   42
@@ -52,61 +52,61 @@
   24
   24
   13
-  $ dune exec owi -- script --no-exhaustion --optimize reference/inline-module.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/int_exprs.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/int_literals.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/labels.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/left-to-right.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/linking.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/load.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/local_get.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/local_set.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/local_tee.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/loop.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_copy.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_fill.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_grow.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_init.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_redundancy.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_size.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory_trap.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/memory.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/names.wast
+  $ owi script --no-exhaustion --optimize reference/inline-module.wast
+  $ owi script --no-exhaustion --optimize reference/int_exprs.wast
+  $ owi script --no-exhaustion --optimize reference/int_literals.wast
+  $ owi script --no-exhaustion --optimize reference/labels.wast
+  $ owi script --no-exhaustion --optimize reference/left-to-right.wast
+  $ owi script --no-exhaustion --optimize reference/linking.wast
+  $ owi script --no-exhaustion --optimize reference/load.wast
+  $ owi script --no-exhaustion --optimize reference/local_get.wast
+  $ owi script --no-exhaustion --optimize reference/local_set.wast
+  $ owi script --no-exhaustion --optimize reference/local_tee.wast
+  $ owi script --no-exhaustion --optimize reference/loop.wast
+  $ owi script --no-exhaustion --optimize reference/memory_copy.wast
+  $ owi script --no-exhaustion --optimize reference/memory_fill.wast
+  $ owi script --no-exhaustion --optimize reference/memory_grow.wast
+  $ owi script --no-exhaustion --optimize reference/memory_init.wast
+  $ owi script --no-exhaustion --optimize reference/memory_redundancy.wast
+  $ owi script --no-exhaustion --optimize reference/memory_size.wast
+  $ owi script --no-exhaustion --optimize reference/memory_trap.wast
+  $ owi script --no-exhaustion --optimize reference/memory.wast
+  $ owi script --no-exhaustion --optimize reference/names.wast
   42
   123
-  $ dune exec owi -- script --no-exhaustion --optimize reference/nop.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/ref_func.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/ref_is_null.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/ref_null.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/return_call_indirect.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/return_call.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/return.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/select.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/skip-stack-guard-page.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/stack.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/start.wast
+  $ owi script --no-exhaustion --optimize reference/nop.wast
+  $ owi script --no-exhaustion --optimize reference/ref_func.wast
+  $ owi script --no-exhaustion --optimize reference/ref_is_null.wast
+  $ owi script --no-exhaustion --optimize reference/ref_null.wast
+  $ owi script --no-exhaustion --optimize reference/return_call_indirect.wast
+  $ owi script --no-exhaustion --optimize reference/return_call.wast
+  $ owi script --no-exhaustion --optimize reference/return.wast
+  $ owi script --no-exhaustion --optimize reference/select.wast
+  $ owi script --no-exhaustion --optimize reference/skip-stack-guard-page.wast
+  $ owi script --no-exhaustion --optimize reference/stack.wast
+  $ owi script --no-exhaustion --optimize reference/start.wast
   1
   2
-  $ dune exec owi -- script --no-exhaustion --optimize reference/store.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/switch.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_copy.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_fill.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_get.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_grow.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_init.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_set.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table_size.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table-sub.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/table.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/tokens.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/token.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/traps.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/type.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/unreachable.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/unreached-invalid.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/unreached-valid.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/unwind.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/utf8-custom-section-id.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/utf8-import-field.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/utf8-import-module.wast
-  $ dune exec owi -- script --no-exhaustion --optimize reference/utf8-invalid-encoding.wast
+  $ owi script --no-exhaustion --optimize reference/store.wast
+  $ owi script --no-exhaustion --optimize reference/switch.wast
+  $ owi script --no-exhaustion --optimize reference/table_copy.wast
+  $ owi script --no-exhaustion --optimize reference/table_fill.wast
+  $ owi script --no-exhaustion --optimize reference/table_get.wast
+  $ owi script --no-exhaustion --optimize reference/table_grow.wast
+  $ owi script --no-exhaustion --optimize reference/table_init.wast
+  $ owi script --no-exhaustion --optimize reference/table_set.wast
+  $ owi script --no-exhaustion --optimize reference/table_size.wast
+  $ owi script --no-exhaustion --optimize reference/table-sub.wast
+  $ owi script --no-exhaustion --optimize reference/table.wast
+  $ owi script --no-exhaustion --optimize reference/tokens.wast
+  $ owi script --no-exhaustion --optimize reference/token.wast
+  $ owi script --no-exhaustion --optimize reference/traps.wast
+  $ owi script --no-exhaustion --optimize reference/type.wast
+  $ owi script --no-exhaustion --optimize reference/unreachable.wast
+  $ owi script --no-exhaustion --optimize reference/unreached-invalid.wast
+  $ owi script --no-exhaustion --optimize reference/unreached-valid.wast
+  $ owi script --no-exhaustion --optimize reference/unwind.wast
+  $ owi script --no-exhaustion --optimize reference/utf8-custom-section-id.wast
+  $ owi script --no-exhaustion --optimize reference/utf8-import-field.wast
+  $ owi script --no-exhaustion --optimize reference/utf8-import-module.wast
+  $ owi script --no-exhaustion --optimize reference/utf8-invalid-encoding.wast

--- a/test/sym/add.t
+++ b/test/sym/add.t
@@ -1,5 +1,5 @@
 add binop:
-  $ dune exec owi -- sym add_i32.wat --no-value --deterministic-result-order
+  $ owi sym add_i32.wat --no-value --deterministic-result-order
   Assert failure: (i32.le (i32 0) (i32.add symbol_0 symbol_1))
   Model:
     (model
@@ -7,7 +7,7 @@ add binop:
       (symbol_1 i32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym add_i64.wat --no-value --deterministic-result-order
+  $ owi sym add_i64.wat --no-value --deterministic-result-order
   Assert failure: (i64.le (i64 0) (i64.add symbol_0 symbol_1))
   Model:
     (model
@@ -15,7 +15,7 @@ add binop:
       (symbol_1 i64))
   Reached problem!
   [13]
-  $ dune exec owi -- sym add_f32.wat --no-value --deterministic-result-order
+  $ owi sym add_f32.wat --no-value --deterministic-result-order
   Assert failure: (f32.eq (f32.add symbol_0 symbol_1) (f32.add symbol_0 symbol_1))
   Model:
     (model
@@ -23,7 +23,7 @@ add binop:
       (symbol_1 f32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym add_f64.wat --no-value --deterministic-result-order
+  $ owi sym add_f64.wat --no-value --deterministic-result-order
   Assert failure: (f64.eq (f64.add symbol_0 symbol_1) (f64.add symbol_0 symbol_1))
   Model:
     (model

--- a/test/sym/assume.t
+++ b/test/sym/assume.t
@@ -1,5 +1,5 @@
 symbolic extern module (assume and assert test):
-  $ dune exec owi -- sym assume.wat --no-value --deterministic-result-order
+  $ owi sym assume.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model

--- a/test/sym/binop.t
+++ b/test/sym/binop.t
@@ -1,5 +1,5 @@
 binop i32:
-  $ dune exec owi -- sym binop_i32.wat --no-value --deterministic-result-order
+  $ owi sym binop_i32.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -39,7 +39,7 @@ binop i32:
   Reached 9 problems!
   [13]
 binop i32 (2):
-  $ dune exec owi -- sym binop_i32-2.wat --no-value --deterministic-result-order
+  $ owi sym binop_i32-2.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -78,7 +78,7 @@ binop i32 (2):
   Reached 5 problems!
   [13]
 binop i64:
-  $ dune exec owi -- sym binop_i64.wat --no-value --deterministic-result-order
+  $ owi sym binop_i64.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -118,7 +118,7 @@ binop i64:
   Reached 9 problems!
   [13]
 binop i64 (2):
-  $ dune exec owi -- sym binop_i64-2.wat --no-value --deterministic-result-order
+  $ owi sym binop_i64-2.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -157,7 +157,7 @@ binop i64 (2):
   Reached 5 problems!
   [13]
 binop f32:
-  $ dune exec owi -- sym binop_f32.wat --no-value --deterministic-result-order
+  $ owi sym binop_f32.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -189,7 +189,7 @@ binop f32:
   Reached 7 problems!
   [13]
 binop f64:
-  $ dune exec owi -- sym binop_f64.wat --no-value --deterministic-result-order
+  $ owi sym binop_f64.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model

--- a/test/sym/copysign.t
+++ b/test/sym/copysign.t
@@ -1,7 +1,7 @@
 float copysign:
-  $ dune exec owi -- sym copysign_f32.wat --deterministic-result-order
+  $ owi sym copysign_f32.wat --deterministic-result-order
   All OK
 ;; Deactivated for now as pretty time consuming and a bit
 ;; redundant with the 32 bit version
-;;  $ dune exec owi -- sym copysign_f64.wat
+;;  $ owi sym copysign_f64.wat
 ;;  All OK

--- a/test/sym/div.t
+++ b/test/sym/div.t
@@ -1,5 +1,5 @@
 div binop:
-  $ dune exec owi -- sym div_i32.wat --no-value --deterministic-result-order -w1
+  $ owi sym div_i32.wat --no-value --deterministic-result-order -w1
   Trap: integer overflow
   Model:
     (model
@@ -12,7 +12,7 @@ div binop:
       (symbol_1 i32))
   Reached 2 problems!
   [13]
-  $ dune exec owi -- sym div_i64.wat --no-value --deterministic-result-order -w1
+  $ owi sym div_i64.wat --no-value --deterministic-result-order -w1
   Trap: integer overflow
   Model:
     (model
@@ -25,7 +25,7 @@ div binop:
       (symbol_1 i64))
   Reached 2 problems!
   [13]
-  $ dune exec owi -- sym div_f32.wat --no-value --deterministic-result-order -w1
+  $ owi sym div_f32.wat --no-value --deterministic-result-order -w1
   Assert failure: (f32.eq (f32.div symbol_0 symbol_1) (f32.div symbol_0 symbol_1))
   Model:
     (model
@@ -33,7 +33,7 @@ div binop:
       (symbol_1 f32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym div_f64.wat --no-value --deterministic-result-order -w1
+  $ owi sym div_f64.wat --no-value --deterministic-result-order -w1
   Assert failure: (f64.eq (f64.div symbol_0 symbol_1) (f64.div symbol_0 symbol_1))
   Model:
     (model
@@ -41,7 +41,7 @@ div binop:
       (symbol_1 f64))
   Reached problem!
   [13]
-  $ dune exec owi -- sym div_zero.wat --deterministic-result-order -w1
+  $ owi sym div_zero.wat --deterministic-result-order -w1
   Trap: integer divide by zero
   Model:
     (model

--- a/test/sym/global.t
+++ b/test/sym/global.t
@@ -1,3 +1,3 @@
 global vars stuff:
-  $ dune exec owi -- sym global.wat --deterministic-result-order
+  $ owi sym global.wat --deterministic-result-order
   All OK

--- a/test/sym/memory.t
+++ b/test/sym/memory.t
@@ -1,19 +1,19 @@
 memory stuff:
-  $ dune exec owi -- sym memory.wat --deterministic-result-order
+  $ owi sym memory.wat --deterministic-result-order
   All OK
-  $ dune exec owi -- sym grow.wat --deterministic-result-order
+  $ owi sym grow.wat --deterministic-result-order
   Trap: out of bounds memory access
   Model:
     (model
       (symbol_0 (i32 1)))
   Reached problem!
   [13]
-  $ dune exec owi -- sym store.wat --no-value --deterministic-result-order
+  $ owi sym store.wat --no-value --deterministic-result-order
   Trap: out of bounds memory access
   Model:
     (model
       (symbol_0 i32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym memory2.wat --deterministic-result-order
+  $ owi sym memory2.wat --deterministic-result-order
   All OK

--- a/test/sym/mini_test.t
+++ b/test/sym/mini_test.t
@@ -1,5 +1,5 @@
 mini test:
-  $ dune exec owi -- sym mini_test.wat --deterministic-result-order
+  $ owi sym mini_test.wat --deterministic-result-order
   Trap: unreachable
   Model:
     (model

--- a/test/sym/mul.t
+++ b/test/sym/mul.t
@@ -1,5 +1,5 @@
 mul binop:
-  $ dune exec owi -- sym mul_i32.wat --no-value --deterministic-result-order
+  $ owi sym mul_i32.wat --no-value --deterministic-result-order
   Assert failure: (i32.ge (i32.mul symbol_0 symbol_1) (i32 0))
   Model:
     (model
@@ -7,7 +7,7 @@ mul binop:
       (symbol_1 i32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym mul_i64.wat --no-value --deterministic-result-order
+  $ owi sym mul_i64.wat --no-value --deterministic-result-order
   Assert failure: (i64.ge (i64.mul symbol_0 symbol_1) (i64 0))
   Model:
     (model
@@ -15,7 +15,7 @@ mul binop:
       (symbol_1 i64))
   Reached problem!
   [13]
-  $ dune exec owi -- sym mul_f32.wat --no-value --deterministic-result-order
+  $ owi sym mul_f32.wat --no-value --deterministic-result-order
   Assert failure: (f32.eq (f32.mul symbol_0 symbol_1) (f32.mul symbol_0 symbol_1))
   Model:
     (model
@@ -23,7 +23,7 @@ mul binop:
       (symbol_1 f32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym mul_f64.wat --no-value --deterministic-result-order
+  $ owi sym mul_f64.wat --no-value --deterministic-result-order
   Assert failure: (f64.eq (f64.mul symbol_0 symbol_1) (f64.mul symbol_0 symbol_1))
   Model:
     (model

--- a/test/sym/not_exists.t
+++ b/test/sym/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec owi -- sym not_exists.wat --deterministic-result-order
+  $ owi sym not_exists.wat --deterministic-result-order
   owi: no file 'not_exists.wat'
   Usage: owi sym [OPTION]… [ARG]…
   Try 'owi sym --help' or 'owi --help' for more information.

--- a/test/sym/sub.t
+++ b/test/sym/sub.t
@@ -1,5 +1,5 @@
 sub binop:
-  $ dune exec owi -- sym sub_i32.wat --no-value --deterministic-result-order
+  $ owi sym sub_i32.wat --no-value --deterministic-result-order
   Assert failure: (i32.ge symbol_0 (i32.sub symbol_0 symbol_1))
   Model:
     (model
@@ -7,7 +7,7 @@ sub binop:
       (symbol_1 i32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym sub_i64.wat --no-value --deterministic-result-order
+  $ owi sym sub_i64.wat --no-value --deterministic-result-order
   Assert failure: (i64.ge symbol_0 (i64.sub symbol_0 symbol_1))
   Model:
     (model
@@ -15,7 +15,7 @@ sub binop:
       (symbol_1 i64))
   Reached problem!
   [13]
-  $ dune exec owi -- sym sub_f32.wat --no-value --deterministic-result-order
+  $ owi sym sub_f32.wat --no-value --deterministic-result-order
   Assert failure: (f32.eq (f32.sub symbol_0 symbol_1) (f32.sub symbol_0 symbol_1))
   Model:
     (model
@@ -23,7 +23,7 @@ sub binop:
       (symbol_1 f32))
   Reached problem!
   [13]
-  $ dune exec owi -- sym sub_f64.wat --no-value --deterministic-result-order
+  $ owi sym sub_f64.wat --no-value --deterministic-result-order
   Assert failure: (f64.eq (f64.sub symbol_0 symbol_1) (f64.sub symbol_0 symbol_1))
   Model:
     (model

--- a/test/sym/syntax_error.t
+++ b/test/sym/syntax_error.t
@@ -1,4 +1,4 @@
 syntax error:
-  $ dune exec owi -- sym syntax_error.wat
+  $ owi sym syntax_error.wat
   unexpected token
   [40]

--- a/test/sym/table.t
+++ b/test/sym/table.t
@@ -1,5 +1,5 @@
 table stuff:
-  $ dune exec owi -- sym table.wat --deterministic-result-order
+  $ owi sym table.wat --deterministic-result-order
   Trap: undefined element
   Model:
     (model

--- a/test/sym/unop.t
+++ b/test/sym/unop.t
@@ -1,5 +1,5 @@
 unop i32:
-  $ dune exec owi -- sym unop_i32.wat --no-value --deterministic-result-order
+  $ owi sym unop_i32.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -73,7 +73,7 @@ unop i32:
   Reached 10 problems!
   [13]
 unop i64:
-  $ dune exec owi -- sym unop_i64.wat --no-value --deterministic-result-order
+  $ owi sym unop_i64.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -161,7 +161,7 @@ unop i64:
   Reached 12 problems!
   [13]
 unop f32:
-  $ dune exec owi -- sym unop_f32.wat --no-value --deterministic-result-order
+  $ owi sym unop_f32.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model
@@ -235,7 +235,7 @@ unop f32:
   Reached 10 problems!
   [13]
 unop f64:
-  $ dune exec owi -- sym unop_f64.wat --no-value --deterministic-result-order
+  $ owi sym unop_f64.wat --no-value --deterministic-result-order
   Trap: unreachable
   Model:
     (model

--- a/test/validate/not_exists.t
+++ b/test/validate/not_exists.t
@@ -1,5 +1,5 @@
 file doesn't exist:
-  $ dune exec -- owi validate idontexist.wat
+  $ owi validate idontexist.wat
   owi: no file 'idontexist.wat'
   Usage: owi validate [--debug] [OPTION]… [ARG]…
   Try 'owi validate --help' or 'owi --help' for more information.

--- a/test/validate/unknown_label.t
+++ b/test/validate/unknown_label.t
@@ -1,3 +1,3 @@
-  $ dune exec owi -- validate ./unknown_label.wat
+  $ owi validate ./unknown_label.wat
   unknown label
   [44]


### PR DESCRIPTION
Using `dune exec`` means that the dune-project file needs to be present in the dune sandbox, which
would sometimes not happen and lead to the very
annoying workflow of having to dune clean before
every dune runtest.

I tried adding the dune-project file as a dependency but couldn't get it to work.

A direct call to the binary seems to solve the issue.