### PR TITLE
Lifts most simplification concerns to encoding

### DIFF
--- a/src/symbolic.ml
+++ b/src/symbolic.ml
@@ -62,20 +62,17 @@ struct
     let concretise (a : Encoding.Expr.t) : Encoding.Expr.t Choice.t =
       let open Choice in
       let open Encoding in
-      match a.node.e with
+      match Expr.view a with
       (* Avoid unecessary re-hashconsing and allocation when the value
          is already concrete. *)
-      | Val _ | Ptr (_, { node = { e = Val _; _ }; _ }) -> return a
+      | Val _ | Ptr (_, { node = Val _; _ }) -> return a
       | Ptr (base, offset) ->
         let+ offset = select_i32 offset in
-        Expr.(Ptr (base, Symbolic_value.const_i32 offset) @: Ty_bitv S32)
+        Expr.make (Ptr (base, Symbolic_value.const_i32 offset))
       | _ ->
         let+ v = select_i32 a in
         Symbolic_value.const_i32 v
 
-    (* TODO: *)
-    (* 1. Let pointers have symbolic offsets *)
-    (* 2. Let addresses have symbolic values *)
     let check_within_bounds m a =
       match check_within_bounds m a with
       | Error t -> Choice.trap t

--- a/src/symbolic_choice.ml
+++ b/src/symbolic_choice.ml
@@ -5,7 +5,6 @@
 open Solver
 open Encoding
 open Symbolic_value
-open Hc
 
 exception Assertion of Expr.t * Thread.t
 
@@ -41,20 +40,20 @@ module Minimalist = struct
 
   let select (vb : vbool) =
     let v = Expr.simplify vb in
-    match v.node.e with
+    match Expr.view v with
     | Val True -> return true
     | Val False -> return false
     | _ -> Format.kasprintf failwith "%a" Expr.pp v
 
   let select_i32 (i : int32) =
     let v = Expr.simplify i in
-    match v.node.e with Val (Num (I32 i)) -> return i | _ -> assert false
+    match Expr.view v with Val (Num (I32 i)) -> return i | _ -> assert false
 
   let trap t = M (fun th _sol -> (Error (Trap t), th))
 
   let assertion (vb : vbool) =
     let v = Expr.simplify vb in
-    match v.node.e with
+    match Expr.view v with
     | Val True -> return ()
     | Val False -> M (fun th _sol -> (Error Assert_fail, th))
     | _ -> assert false
@@ -450,13 +449,13 @@ module Multicore = struct
 
   (*
     We can now use CoreImpl only through its exposed signature which
-    maintains all invariants.  
+    maintains all invariants.
   *)
 
   include CoreImpl
 
   let add_pc (c : vbool) =
-    match c.node.e with
+    match Expr.view c with
     | Val True -> return ()
     | Val False -> stop
     | _ ->
@@ -504,7 +503,7 @@ module Multicore = struct
 
   let select (cond : Symbolic_value.vbool) =
     let v = Expr.simplify cond in
-    match v.node.e with
+    match Expr.view v with
     | Val True -> return true
     | Val False -> return false
     | Val (Num (I32 _)) -> failwith "unreachable (type error)"
@@ -524,19 +523,19 @@ module Multicore = struct
 
   let summary_symbol (e : Expr.t) =
     let* thread in
-    match e.node.e with
+    match Expr.view e with
     | Symbol sym -> return (None, sym)
     | _ ->
       let choices = thread.choices in
       let symbol_name = Format.sprintf "choice_i32_%i" choices in
       let+ () = modify_thread (fun t -> { t with choices = choices + 1 }) in
-      let sym = Symbol.(symbol_name @: Ty_bitv S32) in
-      let assign = Expr.(Relop (Eq, mk_symbol sym, e) @: Ty_bitv S32) in
+      let sym = Symbol.(symbol_name @: Ty_bitv 32) in
+      let assign = Expr.(make (Relop (Ty_bitv 32, Eq, mk_symbol sym, e))) in
       (Some assign, sym)
 
   let select_i32 (i : Symbolic_value.int32) =
     let sym_int = Expr.simplify i in
-    match sym_int.node.e with
+    match Expr.view sym_int with
     | Val (Num (I32 i)) -> return i
     | _ ->
       let* assign, symbol = summary_symbol sym_int in

--- a/src/symbolic_memory.ml
+++ b/src/symbolic_memory.ml
@@ -5,7 +5,6 @@ module Value = Symbolic_value
 module Expr = Encoding.Expr
 module Ty = Encoding.Ty
 open Expr
-open Hc
 
 let page_size = Symbolic_value.const_i32 65_536l
 
@@ -24,7 +23,7 @@ let create size =
   }
 
 let i32 v =
-  match v.node.e with
+  match view v with
   | Val (Num (I32 i)) -> i
   | _ -> Log.err {|Unsupported symbolic value reasoning over "%a"|} Expr.pp v
 
@@ -57,7 +56,7 @@ let blit_string m str ~src ~dst ~len =
     for i = 0 to len - 1 do
       let byte = Char.code @@ String.get str (src + i) in
       let dst = Int32.of_int (dst + i) in
-      Hashtbl.replace m.data dst (Val (Num (I8 byte)) @: Ty_bitv S8)
+      Hashtbl.replace m.data dst (make (Val (Num (I8 byte))))
     done;
     Value.Bool.const false
   end
@@ -73,19 +72,19 @@ let rec load_byte { parent; data; _ } a =
   try Hashtbl.find data a
   with Not_found -> (
     match parent with
-    | None -> Val (Num (I8 0)) @: Ty_bitv S8
+    | None -> make (Val (Num (I8 0)))
     | Some parent -> load_byte parent a )
 
 (* TODO: don't rebuild so many values it generates unecessary hc lookups *)
 let merge_extracts (e1, h, m1) (e2, m2, l) =
-  let ty = e1.node.ty in
+  let ty = Expr.ty e1 in
   if m1 = m2 && Expr.equal e1 e2 then
-    if h - l = Ty.size ty then e1 else Extract (e1, h, l) @: ty
-  else Expr.(Concat (Extract (e1, h, m1) @: ty, Extract (e2, m2, l) @: ty) @: ty)
+    if h - l = Ty.size ty then e1 else make (Extract (e1, h, l))
+  else make (Concat (make (Extract (e1, h, m1)), make (Extract (e2, m2, l))))
 
 let concat ~msb ~lsb offset =
   assert (offset > 0 && offset <= 8);
-  match (msb.node.e, lsb.node.e) with
+  match (view msb, view lsb) with
   | Val (Num (I8 i1)), Val (Num (I8 i2)) ->
     Value.const_i32 Int32.(logor (shl (of_int i1) 8l) (of_int i2))
   | Val (Num (I8 i1)), Val (Num (I32 i2)) ->
@@ -101,13 +100,9 @@ let concat ~msb ~lsb offset =
     Value.const_i64 Int64.(logor (shl (of_int i1) offset) i2)
   | Extract (e1, h, m1), Extract (e2, m2, l) ->
     merge_extracts (e1, h, m1) (e2, m2, l)
-  | ( Extract (e1, h, m1)
-    , Concat ({ node = { e = Extract (e2, m2, l); _ }; _ }, e3) ) ->
-    let ty : Ty.t = if offset >= 4 then Ty_bitv S64 else Ty_bitv S32 in
-    Concat (merge_extracts (e1, h, m1) (e2, m2, l), e3) @: ty
-  | _ ->
-    let ty : Ty.t = if offset >= 4 then Ty_bitv S64 else Ty_bitv S32 in
-    Concat (msb, lsb) @: ty
+  | Extract (e1, h, m1), Concat ({ node = Extract (e2, m2, l); _ }, e3) ->
+    make (Concat (merge_extracts (e1, h, m1) (e2, m2, l), e3))
+  | _ -> make (Concat (msb, lsb))
 
 let loadn m a n =
   let rec loop addr size i acc =
@@ -122,44 +117,45 @@ let loadn m a n =
 
 let load_8_s m a =
   let v = loadn m (i32 a) 1 in
-  match v.node.e with
+  match view v with
   | Val (Num (I8 i8)) -> Value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
-  | _ -> Cvtop (ExtS 24, v) @: Ty_bitv S32
+  | _ -> make (Cvtop (Ty_bitv 32, ExtS 24, v))
 
 let load_8_u m a =
   let v = loadn m (i32 a) 1 in
-  match v.node.e with
+  match view v with
   | Val (Num (I8 i)) -> Value.const_i32 (Int32.of_int i)
-  | _ -> Cvtop (ExtU 24, v) @: Ty_bitv S32
+  | _ -> make (Cvtop (Ty_bitv 32, ExtU 24, v))
 
 let load_16_s m a =
   let v = loadn m (i32 a) 2 in
-  match v.node.e with
+  match view v with
   | Val (Num (I32 i16)) -> Value.const_i32 (Int32.extend_s 16 i16)
-  | _ -> Cvtop (ExtS 16, v) @: Ty_bitv S32
+  | _ -> make (Cvtop (Ty_bitv 32, ExtS 16, v))
 
 let load_16_u m a =
   let v = loadn m (i32 a) 2 in
-  match v.node.e with
+  match view v with
   | Val (Num (I32 _)) -> v
-  | _ -> Cvtop (ExtU 16, v) @: Ty_bitv S32
+  | _ -> make (Cvtop (Ty_bitv 32, ExtU 16, v))
 
 let load_32 m a = loadn m (i32 a) 4
 
 let load_64 m a = loadn m (i32 a) 8
 
 let extract v pos =
-  match v.node.e with
+  match view v with
   | Val (Num (I32 i)) ->
     let i' = Int32.(to_int @@ logand 0xffl @@ shr_s i @@ of_int (pos * 8)) in
-    Val (Num (I8 i')) @: Ty_bitv S8
+    make (Val (Num (I8 i')))
   | Val (Num (I64 i)) ->
     let i' = Int64.(to_int @@ logand 0xffL @@ shr_s i @@ of_int (pos * 8)) in
-    Val (Num (I8 i')) @: Ty_bitv S8
-  | Cvtop (ExtU 24, ({ node = { e = Symbol _; ty = Ty_bitv S8 }; _ } as sym))
-  | Cvtop (ExtS 24, ({ node = { e = Symbol _; ty = Ty_bitv S8 }; _ } as sym)) ->
+    make (Val (Num (I8 i')))
+  | Cvtop (_, ExtU 24, ({ node = Symbol _; _ } as sym))
+  | Cvtop (_, ExtS 24, ({ node = Symbol _; _ } as sym))
+    when ty sym = Ty_bitv 8 ->
     sym
-  | _ -> Extract (v, pos + 1, pos) @: Ty_bitv S8
+  | _ -> make (Extract (v, pos + 1, pos))
 
 let storen m ~addr v n =
   let a0 = i32 addr in
@@ -180,7 +176,7 @@ let store_64 m ~addr v = storen m ~addr v 8
 let get_limit_max _m = None (* TODO *)
 
 let check_within_bounds m a =
-  match a.node.e with
+  match view a with
   | Val (Num (I32 _)) -> Ok (Value.Bool.const false, a)
   | Ptr (base, offset) -> (
     match Hashtbl.find m.chunks base with

--- a/src/symbolic_value.ml
+++ b/src/symbolic_value.ml
@@ -5,41 +5,6 @@
 open Encoding
 open Ty
 open Expr
-open Hc
-
-let ( let+ ) o f = Option.map f o
-
-let unop ty op e =
-  match e.node.e with
-  | Val (Num n) -> Val (Num (Eval_numeric.eval_unop ty op n)) @: e.node.ty
-  | _ -> Unop (op, e) @: ty
-
-let binop ty op e1 e2 =
-  match (e1.node.e, e2.node.e) with
-  | Val (Num n1), Val (Num n2) ->
-    Val (Num (Eval_numeric.eval_binop ty op n1 n2)) @: ty
-  | Ptr _, _ | _, Ptr _ ->
-    (* Does pointer arithmetic *)
-    Expr.simplify @@ Binop (op, e1, e2) @: Ty_bitv S32
-  | _ -> Binop (op, e1, e2) @: ty
-
-let relop ty op e1 e2 =
-  match (e1.node.e, e2.node.e) with
-  | Val (Num n1), Val (Num n2) ->
-    Val (if Eval_numeric.eval_relop ty op n1 n2 then True else False) @: ty
-  | Val (Num n), Ptr (b, { node = { e = Val (Num o); _ }; _ }) ->
-    let base = Eval_numeric.eval_binop (Ty_bitv S32) Add (I32 b) o in
-    Val (if Eval_numeric.eval_relop ty op n base then True else False) @: ty
-  | Ptr (b, { node = { e = Val (Num o); _ }; _ }), Val (Num n) ->
-    let base = Eval_numeric.eval_binop (Ty_bitv S32) Add (I32 b) o in
-    let b = Eval_numeric.eval_relop ty op base n in
-    Val (if b then True else False) @: ty
-  | _ -> Relop (op, e1, e2) @: ty
-
-let cvtop ty op e =
-  match e.node.e with
-  | Val (Num n) -> Val (Num (Eval_numeric.eval_cvtop ty op n)) @: ty
-  | _ -> Cvtop (op, e) @: ty
 
 type vbool = Expr.t
 
@@ -64,15 +29,15 @@ type t =
   | F64 of float64
   | Ref of ref_value
 
-let const_i32 (i : Int32.t) : int32 = Val (Num (I32 i)) @: Ty_bitv S32
+let const_i32 (i : Int32.t) : int32 = make (Val (Num (I32 i)))
 
-let const_i64 (i : Int64.t) : int64 = Val (Num (I64 i)) @: Ty_bitv S64
+let const_i64 (i : Int64.t) : int64 = make (Val (Num (I64 i)))
 
 let const_f32 (f : Float32.t) : float32 =
-  Val (Num (F32 (Float32.to_bits f))) @: Ty_fp S32
+  make (Val (Num (F32 (Float32.to_bits f))))
 
 let const_f64 (f : Float64.t) : float64 =
-  Val (Num (F64 (Float64.to_bits f))) @: Ty_fp S64
+  make (Val (Num (F64 (Float64.to_bits f))))
 
 let ref_null _ty = Ref (Funcref None)
 
@@ -81,8 +46,8 @@ let ref_func f : t = Ref (Funcref (Some f))
 let ref_externref t v : t = Ref (Externref (Some (E (t, v))))
 
 let ref_is_null = function
-  | Funcref (Some _) | Externref (Some _) -> Val False @: Ty_bool
-  | Funcref None | Externref None -> Val True @: Ty_bool
+  | Funcref (Some _) | Externref (Some _) -> make (Val False)
+  | Funcref None | Externref None -> make (Val True)
 
 let pp ppf v =
   let e =
@@ -113,63 +78,34 @@ module Ref = struct
 end
 
 module Bool = struct
-  let of_val = function
-    | Val True -> Some true
-    | Val False -> Some false
-    | _ -> None
+  let const b = Bool.v b
 
-  let const b = Val (if b then True else False) @: Ty_bool
+  let not e = Bool.not_ e
 
-  let not e =
-    match e.node.e with
-    | Unop (Not, cond) -> cond
-    | e' ->
-      Option.value ~default:(Unop (Not, e) @: Ty_bool)
-      @@ let+ b = of_val e' in
-         const (not b)
+  let or_ e1 e2 = Bool.or_ e1 e2
 
-  let or_ e1 e2 =
-    match (of_val e1.node.e, of_val e2.node.e) with
-    | Some b1, Some b2 -> const (b1 || b2)
-    | Some false, _ -> e2
-    | _, Some false -> e1
-    | Some true, _ | _, Some true -> const true
-    | _ -> Binop (Or, e1, e2) @: Ty_bool
-
-  let and_ e1 e2 =
-    match (of_val e1.node.e, of_val e2.node.e) with
-    | Some b1, Some b2 -> const (b1 && b2)
-    | Some true, _ -> e2
-    | _, Some true -> e1
-    | Some false, _ | _, Some false -> const false
-    | _ -> Binop (And, e1, e2) @: Ty_bool
+  let and_ e1 e2 = Bool.and_ e1 e2
 
   let int32 e =
-    match e.node.e with
+    match view e with
     | Val True -> const_i32 1l
     | Val False -> const_i32 0l
-    | Cvtop (ToBool, ({ node = { ty = Ty_bitv S32; _ }; _ } as e')) -> e'
-    | _ -> Cvtop (OfBool, e) @: Ty_bitv S32
+    | Cvtop (Ty_bitv 32, ToBool, e') -> e'
+    | _ -> make (Cvtop (Ty_bitv 32, OfBool, e))
 
-  let select_expr c ~if_true ~if_false =
-    match of_val c.node.e with
-    | Some true -> if_true
-    | Some false -> if_false
-    | None -> Triop (Ite, c, if_true, if_false) @: Ty_bool
+  let select_expr c ~if_true ~if_false = Bool.ite c if_true if_false
 
   let pp ppf (e : vbool) = Expr.pp ppf e
 end
 
 module I32 = struct
-  let ty = Ty_bitv S32
+  let ty = Ty_bitv 32
 
   let zero = const_i32 0l
 
   let clz e = unop ty Clz e
 
-  let ctz _ =
-    (* TODO *)
-    assert false
+  let ctz e = unop ty Ctz e
 
   let popcnt _ =
     (* TODO *)
@@ -190,10 +126,10 @@ module I32 = struct
   let unsigned_rem e1 e2 = binop ty RemU e1 e2
 
   let boolify e =
-    match e.node.e with
+    match view e with
     | Val (Num (I32 0l)) -> Some (Bool.const false)
     | Val (Num (I32 1l)) -> Some (Bool.const true)
-    | Cvtop (OfBool, cond) -> Some cond
+    | Cvtop (_, OfBool, cond) -> Some cond
     | _ -> None
 
   let logand e1 e2 =
@@ -219,8 +155,8 @@ module I32 = struct
   let rotr e1 e2 = binop ty Rotr e1 e2
 
   let eq_const e c =
-    match e.node.e with
-    | Cvtop (OfBool, cond) -> begin
+    match view e with
+    | Cvtop (_, OfBool, cond) -> begin
       match c with 0l -> Bool.not cond | 1l -> cond | _ -> Bool.const false
     end
     | _ -> relop ty Eq e (const_i32 c)
@@ -246,10 +182,10 @@ module I32 = struct
   let ge_u e1 e2 = if e1 == e2 then Bool.const true else relop ty GeU e1 e2
 
   let to_bool (e : vbool) =
-    match e.node.e with
+    match view e with
     | Val (Num (I32 i)) -> Bool.const @@ Int32.ne i 0l
-    | Cvtop (OfBool, cond) -> cond
-    | _ -> Cvtop (ToBool, e) @: ty
+    | Cvtop (_, OfBool, cond) -> cond
+    | _ -> make (Cvtop (ty, ToBool, e))
 
   let trunc_f32_s x = cvtop ty TruncSF32 x
 
@@ -272,20 +208,17 @@ module I32 = struct
   let wrap_i64 x = cvtop ty WrapI64 x
 
   (* FIXME: This is probably wrong? *)
-  let extend_s n x =
-    cvtop ty (ExtS (32 - n)) (Extract (x, n / 8, 0) @: Ty_bitv S32)
+  let extend_s n x = cvtop ty (ExtS (32 - n)) (make (Extract (x, n / 8, 0)))
 end
 
 module I64 = struct
-  let ty = Ty_bitv S64
+  let ty = Ty_bitv 64
 
   let zero = const_i64 0L
 
   let clz e = unop ty Clz e
 
-  let ctz _ =
-    (* TODO *)
-    assert false
+  let ctz e = unop ty Ctz e
 
   let popcnt _ =
     (* TODO *)
@@ -345,7 +278,7 @@ module I64 = struct
 
   let of_int32 e = cvtop ty (ExtS 32) e
 
-  let to_int32 e = cvtop (Ty_bitv S32) WrapI64 e
+  let to_int32 e = cvtop (Ty_bitv 32) WrapI64 e
 
   let trunc_f32_s x = cvtop ty TruncSF32 x
 
@@ -367,7 +300,7 @@ module I64 = struct
 
   (* FIXME: This is probably wrong? *)
   let extend_s n x =
-    cvtop ty (ExtS (64 - n)) (Extract (x, n / 8, 0) @: Ty_bitv S64)
+    cvtop ty (ExtS (64 - n)) (make (Extract (x, n / 8, 0)))
 
   let extend_i32_s x = cvtop ty (ExtS 32) x
 
@@ -375,7 +308,7 @@ module I64 = struct
 end
 
 module F32 = struct
-  let ty = Ty_fp S32
+  let ty = Ty_fp 32
 
   let zero = const_f32 Float32.zero
 
@@ -431,7 +364,7 @@ module F32 = struct
 
   let of_bits x = cvtop ty Reinterpret_int x
 
-  let to_bits x = cvtop (Ty_bitv S32) Reinterpret_float x
+  let to_bits x = cvtop (Ty_bitv 32) Reinterpret_float x
 
   let copy_sign x y =
     let xi = to_bits (abs x) in
@@ -440,7 +373,7 @@ module F32 = struct
 end
 
 module F64 = struct
-  let ty = Ty_fp S64
+  let ty = Ty_fp 64
 
   let zero = const_f64 Float64.zero
 
@@ -496,7 +429,7 @@ module F64 = struct
 
   let of_bits x = cvtop ty Reinterpret_int x
 
-  let to_bits x = cvtop (Ty_bitv S64) Reinterpret_float x
+  let to_bits x = cvtop (Ty_bitv 64) Reinterpret_float x
 
   let copy_sign x y =
     let xi = to_bits (abs x) in


### PR DESCRIPTION
This focuses on removing simplifications from `Symbolic_value` to encoding. Please let me know if I should also move any other code to encoding.

Since this depends on formalsec/encoding#86, CI will fail until it is merged. I haven't done it to avoid breaking any ongoing work on owi. However, I've run the tests locally, and everything is okay, including performance, which seems to be the same.