### PR TITLE
Add breadcrumbs to Thread.t

### DIFF
--- a/src/cmd_sym.ml
+++ b/src/cmd_sym.ml
@@ -250,7 +250,13 @@ let cmd profiling debug unsafe optimize workers no_stop_at_failure no_values
   in
   let results =
     if deterministic_result_order then
-      List.to_seq @@ List.sort compare @@ List.of_seq results
+      results
+      |> Seq.map (function (_, th) as x ->
+           (x, List.rev @@ Thread.breadcrumbs th) )
+      |> List.of_seq
+      |> List.sort (fun (_, bc1) (_, bc2) ->
+             List.compare Stdlib.Int32.compare bc1 bc2 )
+      |> List.to_seq |> Seq.map fst
     else results
   in
   let* count = print_and_count_failures 0 results in

--- a/src/thread.ml
+++ b/src/thread.ml
@@ -9,6 +9,9 @@ type t =
   ; memories : Symbolic_memory.collection
   ; tables : Symbolic_table.collection
   ; globals : Symbolic_global.collection
+      (** Breadcrumbs represent the list of choices that were made so far. They
+          identify one given symbolic execution trace. *)
+  ; breadcrumbs : int32 list
   }
 
 let pc t = t.pc
@@ -19,6 +22,8 @@ let tables t = t.tables
 
 let globals t = t.globals
 
+let breadcrumbs t = t.breadcrumbs
+
 let create () =
   { choices = 0
   ; symbol_set = []
@@ -26,10 +31,11 @@ let create () =
   ; memories = Symbolic_memory.init ()
   ; tables = Symbolic_table.init ()
   ; globals = Symbolic_global.init ()
+  ; breadcrumbs = []
   }
 
-let clone { choices; symbol_set; pc; memories; tables; globals } =
+let clone { choices; symbol_set; pc; memories; tables; globals; breadcrumbs } =
   let memories = Symbolic_memory.clone memories in
   let tables = Symbolic_table.clone tables in
   let globals = Symbolic_global.clone globals in
-  { choices; symbol_set; pc; memories; tables; globals }
+  { choices; symbol_set; pc; memories; tables; globals; breadcrumbs }

--- a/test/sym/table.t
+++ b/test/sym/table.t
@@ -1,14 +1,14 @@
 table stuff:
   $ owi sym table.wat --deterministic-result-order
-  Trap: undefined element
-  Model:
-    (model
-      (symbol_0 (i32 0))
-      (symbol_1 (i32 -2147483648)))
   Trap: unreachable
   Model:
     (model
       (symbol_0 (i32 0))
       (symbol_1 (i32 0)))
+  Trap: undefined element
+  Model:
+    (model
+      (symbol_0 (i32 0))
+      (symbol_1 (i32 -2147483648)))
   Reached 2 problems!
   [13]


### PR DESCRIPTION
As identified in https://github.com/OCamlPro/owi/issues/208, the
deterministic order option is not deterministic across architectures.

A likely culprit is the use of the polymorphic compare function which
may not give the same result in different environments or on different
targets.

This commit resolves this by keeping track of each choice made ('select')
through "breadcrumbs" and sorting results on these breadcrumbs.

Closes: https://github.com/OCamlPro/owi/issues/208
