### PR TITLE
Accommodate `encoding` library name change

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   (odoc :with-doc)
   (crunch :dev)
   bos
-  encoding
+  smtml
   (mdx
    (and
     :with-test

--- a/owi.opam
+++ b/owi.opam
@@ -31,7 +31,7 @@ depends: [
   "odoc" {with-doc}
   "crunch" {dev}
   "bos"
-  "encoding"
+  "smtml"
   "mdx" {with-test & >= "2.1"}
   "crowbar" {with-test}
   "graphics" {dev}
@@ -67,6 +67,6 @@ depexts: [
   ["llvm" "wabt"]  {os-family = "homebrew"}
 ]
 pin-depends: [
-  [ "encoding.dev" "git+https://github.com/formalsec/encoding#f5ed5da47acfb89d8af70899149ad147a2e5fdf0"]
+  [ "smtml.dev" "git+https://github.com/formalsec/smtml#6536983c6c778f66bb3b57e7467760831e3efd4a"]
   [ "crowbar.dev" "git+https://github.com/stedolan/crowbar#1ab53fb088d56578b48301bc4cfb859331a10d78"]
 ]

--- a/owi.opam.template
+++ b/owi.opam.template
@@ -4,6 +4,6 @@ depexts: [
   ["llvm" "wabt"]  {os-family = "homebrew"}
 ]
 pin-depends: [
-  [ "encoding.dev" "git+https://github.com/formalsec/encoding#f5ed5da47acfb89d8af70899149ad147a2e5fdf0"]
+  [ "smtml.dev" "git+https://github.com/formalsec/smtml#6536983c6c778f66bb3b57e7467760831e3efd4a"]
   [ "crowbar.dev" "git+https://github.com/stedolan/crowbar#1ab53fb088d56578b48301bc4cfb859331a10d78"]
 ]

--- a/src/cmd/cmd_sym.ml
+++ b/src/cmd/cmd_sym.ml
@@ -1,5 +1,5 @@
 open Syntax
-module Expr = Encoding.Expr
+module Expr = Smtml.Expr
 module Value = Symbolic_value
 module Choice = Symbolic.P.Choice
 
@@ -8,12 +8,12 @@ let symbolic_extern_module :
   let sym_cnt = Atomic.make 0 in
   let symbol ty () : Value.int32 Choice.t =
     let id = Atomic.fetch_and_add sym_cnt 1 in
-    let sym = Format.kasprintf (Encoding.Symbol.mk_symbol ty) "symbol_%d" id in
+    let sym = Format.kasprintf (Smtml.Symbol.make ty) "symbol_%d" id in
     let sym_expr = Expr.mk_symbol sym in
     Choice.with_thread (fun thread ->
         thread.symbol_set <- sym :: thread.symbol_set;
         match ty with
-        | Ty_bitv 8 -> Expr.make (Cvtop (Ty_bitv 32, ExtU 24, sym_expr))
+        | Ty_bitv 8 -> Expr.make (Cvtop (Ty_bitv 32, Zero_extend 24, sym_expr))
         | _ -> sym_expr )
   in
   let assume_i32 (i : Value.int32) : unit Choice.t =
@@ -151,7 +151,7 @@ let run_file ~unsafe ~optimize pc filename =
   simplify_then_link_then_run ~unsafe ~optimize pc m0dule
 
 let get_model ~symbols solver pc =
-  assert (Solver.Z3Batch.check solver pc);
+  assert (`Sat = Solver.Z3Batch.check solver pc);
   match Solver.Z3Batch.model ~symbols solver with
   | None -> assert false
   | Some model -> model
@@ -160,7 +160,7 @@ let out_testcase ~dst ~err testcase =
   let o = Xmlm.make_output ~nl:true ~indent:(Some 2) dst in
   let tag ?(atts = []) name = (("", name), atts) in
   let atts = if err then Some [ (("", "coversError"), "true") ] else None in
-  let to_string v = Format.asprintf "%a" Encoding.Value.pp_num v in
+  let to_string v = Format.asprintf "%a" Smtml.Value.pp_num v in
   let input v = `El (tag "input", [ `Data (to_string v) ]) in
   let testcase = `El (tag ?atts "testcase", List.map input testcase) in
   let dtd =
@@ -205,14 +205,10 @@ let cmd profiling debug unsafe optimize workers no_stop_at_failure no_values
   let print_bug = function
     | `ETrap (tr, model) ->
       Format.pp_std "Trap: %s@\n" (Trap.to_string tr);
-      Format.pp_std "Model:@\n  @[<v>%a@]@."
-        (Encoding.Model.pp ~no_values)
-        model
+      Format.pp_std "Model:@\n  @[<v>%a@]@." (Smtml.Model.pp ~no_values) model
     | `EAssert (assertion, model) ->
       Format.pp_std "Assert failure: %a@\n" Expr.pp assertion;
-      Format.pp_std "Model:@\n  @[<v>%a@]@."
-        (Encoding.Model.pp ~no_values)
-        model
+      Format.pp_std "Model:@\n  @[<v>%a@]@." (Smtml.Model.pp ~no_values) model
   in
   let rec print_and_count_failures count_acc results =
     match results () with
@@ -237,8 +233,7 @@ let cmd profiling debug unsafe optimize workers no_stop_at_failure no_values
       let* () =
         if not no_values then
           let testcase =
-            List.sort compare (Encoding.Model.get_bindings model)
-            |> List.map snd
+            List.sort compare (Smtml.Model.get_bindings model) |> List.map snd
           in
           write_testcase ~dir:workspace ~err:is_err testcase
         else Ok ()

--- a/src/concrete/thread.ml
+++ b/src/concrete/thread.ml
@@ -4,7 +4,7 @@
 
 type t =
   { choices : int
-  ; mutable symbol_set : Encoding.Symbol.t list
+  ; mutable symbol_set : Smtml.Symbol.t list
   ; pc : Symbolic_value.vbool list
   ; memories : Symbolic_memory.collection
   ; tables : Symbolic_table.collection

--- a/src/dune
+++ b/src/dune
@@ -76,7 +76,7 @@
   bos
   digestif
   dune-site
-  encoding
+  smtml
   hc
   integers
   menhirLib

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -1,13 +1,13 @@
-type 'a solver_module = (module Encoding.Solver_intf.S with type t = 'a)
+type 'a solver_module = (module Smtml.Solver_intf.S with type t = 'a)
 
 type solver = S : ('a solver_module * 'a) -> solver [@@unboxed]
 
-module Z3Batch = Encoding.Solver.Batch (Encoding.Z3_mappings)
+module Z3Batch = Smtml.Solver.Batch (Smtml.Z3_mappings)
 
 let solver_mod : Z3Batch.t solver_module = (module Z3Batch)
 
 let fresh_solver () =
-  let module Mapping = Encoding.Z3_mappings.Fresh.Make () in
-  let module Batch = Encoding.Solver.Batch (Mapping) in
+  let module Mapping = Smtml.Z3_mappings.Fresh.Make () in
+  let module Batch = Smtml.Solver.Batch (Mapping) in
   let solver = Batch.create ~logic:QF_BVFP () in
   S ((module Batch), solver)

--- a/src/symbolic/symbolic.ml
+++ b/src/symbolic/symbolic.ml
@@ -59,9 +59,9 @@ struct
   module Memory = struct
     include Symbolic_memory
 
-    let concretise (a : Encoding.Expr.t) : Encoding.Expr.t Choice.t =
+    let concretise (a : Smtml.Expr.t) : Smtml.Expr.t Choice.t =
       let open Choice in
-      let open Encoding in
+      let open Smtml in
       match Expr.view a with
       (* Avoid unecessary re-hashconsing and allocation when the value
          is already concrete. *)

--- a/src/symbolic/symbolic_choice.mli
+++ b/src/symbolic/symbolic_choice.mli
@@ -1,4 +1,4 @@
-exception Assertion of Encoding.Expr.t * Thread.t
+exception Assertion of Smtml.Expr.t * Thread.t
 
 module Minimalist : sig
   type err = private
@@ -16,7 +16,7 @@ module Multicore : sig
   type 'a eval =
     | EVal of 'a
     | ETrap of Trap.t
-    | EAssert of Encoding.Expr.t
+    | EAssert of Smtml.Expr.t
 
   include
     Choice_intf.Complete

--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -2,8 +2,8 @@
 (* Copyright © 2021 Léo Andrès *)
 (* Copyright © 2021 Pierre Chambart *)
 module Value = Symbolic_value
-module Expr = Encoding.Expr
-module Ty = Encoding.Ty
+module Expr = Smtml.Expr
+module Ty = Smtml.Ty
 open Expr
 
 let page_size = Symbolic_value.const_i32 65_536l
@@ -119,25 +119,25 @@ let load_8_s m a =
   let v = loadn m (i32 a) 1 in
   match view v with
   | Val (Num (I8 i8)) -> Value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
-  | _ -> make (Cvtop (Ty_bitv 32, ExtS 24, v))
+  | _ -> cvtop (Ty_bitv 32) (Sign_extend 24) v
 
 let load_8_u m a =
   let v = loadn m (i32 a) 1 in
   match view v with
   | Val (Num (I8 i)) -> Value.const_i32 (Int32.of_int i)
-  | _ -> make (Cvtop (Ty_bitv 32, ExtU 24, v))
+  | _ -> cvtop (Ty_bitv 32) (Zero_extend 24) v
 
 let load_16_s m a =
   let v = loadn m (i32 a) 2 in
   match view v with
   | Val (Num (I32 i16)) -> Value.const_i32 (Int32.extend_s 16 i16)
-  | _ -> make (Cvtop (Ty_bitv 32, ExtS 16, v))
+  | _ -> cvtop (Ty_bitv 32) (Sign_extend 16) v
 
 let load_16_u m a =
   let v = loadn m (i32 a) 2 in
   match view v with
   | Val (Num (I32 _)) -> v
-  | _ -> make (Cvtop (Ty_bitv 32, ExtU 16, v))
+  | _ -> cvtop (Ty_bitv 32) (Zero_extend 16) v
 
 let load_32 m a = loadn m (i32 a) 4
 
@@ -147,12 +147,12 @@ let extract v pos =
   match view v with
   | Val (Num (I32 i)) ->
     let i' = Int32.(to_int @@ logand 0xffl @@ shr_s i @@ of_int (pos * 8)) in
-    make (Val (Num (I8 i')))
+    value (Num (I8 i'))
   | Val (Num (I64 i)) ->
     let i' = Int64.(to_int @@ logand 0xffL @@ shr_s i @@ of_int (pos * 8)) in
-    make (Val (Num (I8 i')))
-  | Cvtop (_, ExtU 24, ({ node = Symbol _; _ } as sym))
-  | Cvtop (_, ExtS 24, ({ node = Symbol _; _ } as sym))
+    value (Num (I8 i'))
+  | Cvtop (_, Zero_extend 24, ({ node = Symbol _; _ } as sym))
+  | Cvtop (_, Sign_extend 24, ({ node = Symbol _; _ } as sym))
     when ty sym = Ty_bitv 8 ->
     sym
   | _ -> make (Extract (v, pos + 1, pos))

--- a/src/symbolic/symbolic_memory.mli
+++ b/src/symbolic/symbolic_memory.mli
@@ -9,59 +9,52 @@ val clone : collection -> collection
 val get_memory : Env_id.t -> Concrete_memory.t -> collection -> int -> t
 
 val check_within_bounds :
-     t
-  -> Encoding.Expr.t
-  -> (Encoding.Expr.t * Symbolic_value.int32, Trap.t) result
+  t -> Smtml.Expr.t -> (Smtml.Expr.t * Symbolic_value.int32, Trap.t) result
 
-val replace_size : t -> Int32.t -> Encoding.Expr.t -> unit
+val replace_size : t -> Int32.t -> Smtml.Expr.t -> unit
 
 val free : t -> Int32.t -> unit
 
-val load_8_s : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_8_s : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val load_8_u : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_8_u : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val load_16_s : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_16_s : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val load_16_u : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_16_u : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val load_32 : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_32 : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val load_64 : t -> Encoding.Expr.t -> Symbolic_value.int32
+val load_64 : t -> Smtml.Expr.t -> Symbolic_value.int32
 
-val store_8 : t -> addr:Encoding.Expr.t -> Encoding.Expr.t -> unit
+val store_8 : t -> addr:Smtml.Expr.t -> Smtml.Expr.t -> unit
 
-val store_16 : t -> addr:Encoding.Expr.t -> Encoding.Expr.t -> unit
+val store_16 : t -> addr:Smtml.Expr.t -> Smtml.Expr.t -> unit
 
-val store_32 : t -> addr:Encoding.Expr.t -> Encoding.Expr.t -> unit
+val store_32 : t -> addr:Smtml.Expr.t -> Smtml.Expr.t -> unit
 
-val store_64 : t -> addr:Encoding.Expr.t -> Encoding.Expr.t -> unit
+val store_64 : t -> addr:Smtml.Expr.t -> Smtml.Expr.t -> unit
 
-val grow : t -> Encoding.Expr.t -> unit
+val grow : t -> Smtml.Expr.t -> unit
 
-val fill :
-  t -> pos:Encoding.Expr.t -> len:Encoding.Expr.t -> char -> Encoding.Expr.t
+val fill : t -> pos:Smtml.Expr.t -> len:Smtml.Expr.t -> char -> Smtml.Expr.t
 
 val blit :
-     t
-  -> src:Encoding.Expr.t
-  -> dst:Encoding.Expr.t
-  -> len:Encoding.Expr.t
-  -> Encoding.Expr.t
+  t -> src:Smtml.Expr.t -> dst:Smtml.Expr.t -> len:Smtml.Expr.t -> Smtml.Expr.t
 
 val blit_string :
      t
   -> string
-  -> src:Encoding.Expr.t
-  -> dst:Encoding.Expr.t
-  -> len:Encoding.Expr.t
-  -> Encoding.Expr.t
+  -> src:Smtml.Expr.t
+  -> dst:Smtml.Expr.t
+  -> len:Smtml.Expr.t
+  -> Smtml.Expr.t
 
-val size : t -> Encoding.Expr.t
+val size : t -> Smtml.Expr.t
 
-val size_in_pages : t -> Encoding.Expr.t
+val size_in_pages : t -> Smtml.Expr.t
 
-val get_limit_max : t -> Encoding.Expr.t option
+val get_limit_max : t -> Smtml.Expr.t option
 
 module ITbl : sig
   type 'a t

--- a/src/symbolic/symbolic_value.mli
+++ b/src/symbolic/symbolic_value.mli
@@ -7,18 +7,18 @@ type ref_value =
 include
   Value_intf.T
     with type ref_value := ref_value
-    with type vbool = Encoding.Expr.t
-     and type int32 = Encoding.Expr.t
-     and type int64 = Encoding.Expr.t
-     and type float32 = Encoding.Expr.t
-     and type float64 = Encoding.Expr.t
+    with type vbool = Smtml.Expr.t
+     and type int32 = Smtml.Expr.t
+     and type int64 = Smtml.Expr.t
+     and type float32 = Smtml.Expr.t
+     and type float64 = Smtml.Expr.t
 
 module Bool : sig
   include module type of Bool
 
   val select_expr :
-       Encoding.Expr.t
-    -> if_true:Encoding.Expr.t
-    -> if_false:Encoding.Expr.t
-    -> Encoding.Expr.t
+       Smtml.Expr.t
+    -> if_true:Smtml.Expr.t
+    -> if_false:Smtml.Expr.t
+    -> Smtml.Expr.t
 end

--- a/test/c/collections-c/normal/array_tests.t
+++ b/test/c/collections-c/normal/array_tests.t
@@ -26,7 +26,7 @@ Array tests:
   $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_removeAt.c
   All OK
   $ owi c -I include src/array.c src/common.c src/utils.c testsuite/array/array_test_replaceAt.c
-  Assert failure: (i32.ne symbol_3 symbol_2)
+  Assert failure: (bool.ne symbol_3 symbol_2)
   Model:
     (model
       (symbol_0 (i32 0))

--- a/test/c/test-comp/simple.t
+++ b/test/c/test-comp/simple.t
@@ -1,5 +1,5 @@
   $ owi c --testcomp ./simple.c
-  Assert failure: (i32.ne (i32.mul symbol_0 symbol_0) (i32 0))
+  Assert failure: (bool.ne (i32.mul symbol_0 symbol_0) (i32 0))
   Model:
     (model
       (symbol_0 (i32 0)))


### PR DESCRIPTION
It was decided that the `encoding` library would now be named `smtml`. Therefore, in this PR, I make the necessary adjustments to accommodate this change.

Additionally, I took advantage of this opportunity to use more smart constructors during symbolic expression creation, rather than building these expressions manually. This allows for greater expression optimization, due to the simplification applied at construction time.
