### PR TITLE
Make C stdlib read weak

### DIFF
--- a/src/libc/include/unistd.h
+++ b/src/libc/include/unistd.h
@@ -9,6 +9,6 @@ extern char *optarg;
 
 /* int open(const char* pathname,int flags, ...); */
 int close(int fd);
-ssize_t read(int fd, void *buf, size_t len);
+ssize_t read(int fd, void *buf, size_t len) __attribute__ ((weak));;
 
 #endif


### PR DESCRIPTION
TestComp's c/busybox-1.22.0/ test files redefine C stdlib's read which lead to wasm-ld failling with a "duplicate symbol" error. Making the symbol weak resolves the issue.

Closes https://github.com/OCamlPro/owi/issues/258