### PR TITLE
- provide exit function in summaries module

### DIFF
--- a/test/c/dune
+++ b/test/c/dune
@@ -2,4 +2,5 @@
  (deps
   %{bin:owi}
   (package owi)
-  malloc_aligned.c))
+  malloc_aligned.c
+  exit.c))

--- a/test/c/exit.c
+++ b/test/c/exit.c
@@ -1,0 +1,11 @@
+#include <owi.h>
+
+extern void exit(int);
+
+int main(void) {
+    int s = owi_i32();
+    if (s) {
+      exit(0);
+    }
+    owi_assert(s);
+}

--- a/test/c/exit.t
+++ b/test/c/exit.t
@@ -1,0 +1,7 @@
+  $ owi c ./exit.c --no-value
+  Assert failure: (i32.to_bool symbol_0)
+  Model:
+    (model
+      (symbol_0 i32))
+  Reached problem!
+  [13]

--- a/test/c/not_exists.t
+++ b/test/c/not_exists.t
@@ -1,6 +1,6 @@
 file doesn't exist:
-  $ owi c idontexist.wat
-  owi: no file 'idontexist.wat'
+  $ owi c idontexist.c
+  owi: no file 'idontexist.c'
   Usage: owi c [OPTION]… [ARG]…
   Try 'owi c --help' or 'owi --help' for more information.
   [124]


### PR DESCRIPTION
- do not fail when the memory model can not handle some cases but abort instead, so that we keep exploring other paths

fix #256 