### PR TITLE
Reduce dune rules when submodules are checked out

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,1 @@
+(dirs :standard \ klee pie results-*)

--- a/bench/testcomp/dune
+++ b/bench/testcomp/dune
@@ -1,3 +1,5 @@
+(dirs :standard \ sv-benchmarks)
+
 (executable
  (name testcomp)
  (modules testcomp whitelist)


### PR DESCRIPTION
When I have all the submodules checked out and the results of benchmarking owi on test-comp, it would considerably slow down dune's start time on my slow pc.

I ran `dune show rules` and got:

```sh
$ time dune show rules | wc -l
2547084
dune show rules  4.09s user 0.45s system 97% cpu 4.649 total
wc -l  0.01s user 0.04s system 0% cpu 4.648 total
```

With this PR, it should be better:

```sh
$ time dune show rules | wc -l
25002
dune show rules  0.17s user 0.02s system 101% cpu 0.187 total
wc -l  0.00s user 0.00s system 0% cpu 0.187 total
```

This might not be an issue on faster computers. Let me know if you find this useful.