### PR TITLE
Test-comp makes my tree dirty 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 _coverage
 owi-out
 results-*
+a.out.wasm


### PR DESCRIPTION
Test-comp creates wasm binaries named `a.out.wasm`, making my working git tree dirty. This cleans it up :sweat_smile: 