### PR TITLE
Refactor symbol creation functions

### DIFF
--- a/src/symbolic/symbolic_choice.mli
+++ b/src/symbolic/symbolic_choice.mli
@@ -13,6 +13,8 @@ include
      and type 'a run_result = ('a eval * Thread.t) Seq.t
      and module V := Symbolic_value
 
+val with_new_symbol : Smtml.Ty.t -> (Smtml.Symbol.t -> 'b) -> 'b t
+
 val run :
      workers:int
   -> Smtml.Solver_dispatcher.solver_type

--- a/src/symbolic/thread.ml
+++ b/src/symbolic/thread.ml
@@ -3,8 +3,8 @@
 (* Written by the Owi programmers *)
 
 type t =
-  { choices : int
-  ; mutable symbol_set : Smtml.Symbol.t list
+  { symbols : int
+  ; symbol_set : Smtml.Symbol.t list
   ; pc : Symbolic_value.vbool list
   ; memories : Symbolic_memory.collection
   ; tables : Symbolic_table.collection
@@ -14,7 +14,7 @@ type t =
   ; breadcrumbs : int32 list
   }
 
-let choices t = t.choices
+let symbols t = t.symbols
 
 let pc t = t.pc
 
@@ -26,18 +26,18 @@ let globals t = t.globals
 
 let breadcrumbs t = t.breadcrumbs
 
-let symbols t = t.symbol_set
+let symbols_set t = t.symbol_set
 
-let add_symbol t s = t.symbol_set <- s :: t.symbol_set
+let add_symbol t s = { t with symbol_set = s :: t.symbol_set }
 
 let add_pc t c = { t with pc = c :: t.pc }
 
 let add_breadcrumb t crumb = { t with breadcrumbs = crumb :: t.breadcrumbs }
 
-let incr_choices t = { t with choices = succ t.choices }
+let incr_symbols t = { t with symbols = succ t.symbols }
 
 let create () =
-  { choices = 0
+  { symbols = 0
   ; symbol_set = []
   ; pc = []
   ; memories = Symbolic_memory.init ()
@@ -46,8 +46,8 @@ let create () =
   ; breadcrumbs = []
   }
 
-let clone { choices; symbol_set; pc; memories; tables; globals; breadcrumbs } =
+let clone { symbols; symbol_set; pc; memories; tables; globals; breadcrumbs } =
   let memories = Symbolic_memory.clone memories in
   let tables = Symbolic_table.clone tables in
   let globals = Symbolic_global.clone globals in
-  { choices; symbol_set; pc; memories; tables; globals; breadcrumbs }
+  { symbols; symbol_set; pc; memories; tables; globals; breadcrumbs }

--- a/src/symbolic/thread.mli
+++ b/src/symbolic/thread.mli
@@ -14,9 +14,9 @@ val globals : t -> Symbolic_global.collection
 
 val breadcrumbs : t -> int32 list
 
-val symbols : t -> Smtml.Symbol.t list
+val symbols_set : t -> Smtml.Symbol.t list
 
-val choices : t -> int
+val symbols : t -> int
 
 val create : unit -> t
 
@@ -26,6 +26,6 @@ val add_pc : t -> Symbolic_value.vbool -> t
 
 val add_breadcrumb : t -> int32 -> t
 
-val add_symbol : t -> Smtml.Symbol.t -> unit
+val add_symbol : t -> Smtml.Symbol.t -> t
 
-val incr_choices : t -> t
+val incr_symbols : t -> t

--- a/test/sym/div.t
+++ b/test/sym/div.t
@@ -51,16 +51,16 @@ div binop:
   Model:
     (model
       (symbol_0 (i32 1))
-      (symbol_2 (i32 0)))
+      (symbol_1 (i32 0)))
   Trap: integer divide by zero
   Model:
     (model
       (symbol_0 (i32 2))
-      (symbol_3 (i64 0)))
+      (symbol_1 (i64 0)))
   Trap: integer divide by zero
   Model:
     (model
       (symbol_0 (i32 3))
-      (symbol_5 (i64 0)))
+      (symbol_1 (i64 0)))
   Reached 4 problems!
   [13]


### PR DESCRIPTION
- Use `Thread.symbol` for creating unique symbols, replacing the global atomic variable in `symbolic_wasm_ffi.ml`.

This makes symbol names nicer for each path since now they are sequential. (c.f. [in the promoted test](https://github.com/OCamlPro/owi/pull/333/files#diff-c59bd1833c328a05ea217570fd32fe02ef78b6b7dfab8455bbf01c849604ce9a)) 

- Add `with_new_symbol` to `symbolic_choice` to mirror the approach in `concolic_wasm_ffi`.

- Rename `Thread.incr_choices` to `incr_symbols` and make `Thread.symbol_set` immutable.