### PR TITLE
Allow passing the memory to external functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- adds a `Mem` argument to external function to allow direct manipulation of the memory.
 - support other solvers through the `--solver` option (Z3, Colibri2, Bitwuzla and CVC5)
 - support the extended constant expressions proposal
 - `owi opt` and `owi sym` can run on `.wasm` files directly

--- a/example/define_host_function/dune
+++ b/example/define_host_function/dune
@@ -2,11 +2,18 @@
  (name extern)
  (libraries owi))
 
+(executable
+ (name extern_mem)
+ (libraries owi))
+
 (mdx
  (libraries owi fpath)
  (deps
   %{bin:owi}
   (file extern.exe)
   (file extern.ml)
-  (file extern.wat))
+  (file extern.wat)
+  (file extern_mem.exe)
+  (file extern_mem.ml)
+  (file extern_mem.wat))
  (files README.md))

--- a/example/define_host_function/extern_mem.ml
+++ b/example/define_host_function/extern_mem.ml
@@ -1,0 +1,51 @@
+open Owi
+
+(* an extern module that will be linked with a wasm module *)
+let extern_module : Concrete_value.Func.extern_func Link.extern_module =
+  (* some custom functions *)
+  let memset m start byte length =
+    let rec loop offset =
+      if Int32.le offset length then begin
+        Concrete_memory.store_8 m ~addr:(Int32.add start offset) byte;
+        loop (Int32.add offset 1l)
+      end
+    in
+    loop 0l
+  in
+  let print_x64 (i : int64) = Printf.printf "0x%LX\n%!" i in
+  (* we need to describe their types *)
+  let functions =
+    [ ( "print_x64"
+      , Concrete_value.Func.Extern_func (Func (Arg (I64, Res), R0), print_x64)
+      )
+    ; ( "memset"
+      , Concrete_value.Func.Extern_func
+          (Func (Mem (Arg (I32, Arg (I32, Arg (I32, Res)))), R0), memset) )
+    ]
+  in
+  { functions }
+
+(* a link state that contains our custom module, available under the name `chorizo` *)
+let link_state =
+  Link.extern_module Link.empty_state ~name:"chorizo" extern_module
+
+(* a pure wasm module refering to `$extern_mem` *)
+let pure_wasm_module =
+  match Parse.Text.Module.from_file (Fpath.v "extern_mem.wat") with
+  | Error e -> Result.failwith e
+  | Ok modul -> modul
+
+(* our pure wasm module, linked with `chorizo` *)
+let module_to_run, link_state =
+  match
+    Compile.Text.until_link link_state ~unsafe:false ~optimize:true ~name:None
+      pure_wasm_module
+  with
+  | Error e -> Result.failwith e
+  | Ok v -> v
+
+(* let's run it ! it will print the values as defined in the print_i64 function *)
+let () =
+  match Interpret.Concrete.modul link_state.envs module_to_run with
+  | Error e -> Result.failwith e
+  | Ok () -> ()

--- a/example/define_host_function/extern_mem.wat
+++ b/example/define_host_function/extern_mem.wat
@@ -1,0 +1,19 @@
+(module $extern_mem
+
+  (import "chorizo" "memset" (func $memset (param i32 i32 i32)))
+
+  (import "chorizo" "print_x64" (func $print_x64 (param i64)))
+
+  (memory 1)
+
+  (func $start
+
+    ;; memset 0 0xAA 8
+    (call $memset (i32.const 0) (i32.const 0xAA) (i32.const 8))
+
+    ;; print_x64 (load 0)
+    (call $print_x64 (i64.load (i32.const 0)))
+  )
+
+  (start $start)
+)

--- a/src/concolic/concolic.ml
+++ b/src/concolic/concolic.ml
@@ -56,8 +56,6 @@ module P = struct
       failwith "TODO"
     | _, _ -> assert false
 
-  module Extern_func = Concrete_value.Make_extern_func (Value) (Choice)
-
   module Global = struct
     open Concolic_value
 
@@ -182,6 +180,8 @@ module P = struct
 
     let get_limit_max _ = failwith "TODO"
   end
+
+  module Extern_func = Concrete_value.Make_extern_func (Value) (Choice) (Memory)
 
   module Data = struct
     type t = Link_env.data

--- a/src/concolic/concolic_wasm_ffi.ml
+++ b/src/concolic/concolic_wasm_ffi.ml
@@ -4,13 +4,17 @@
 
 module Expr = Smtml.Expr
 module Choice = Concolic.P.Choice
+module Memory = Concolic.P.Memory
 
 (* The constraint is used here to make sure we don't forget to define one of the expected FFI functions, this whole file is further constrained such that if one function of M is unused in the FFI module below, an error will be displayed *)
 module M :
   Wasm_ffi_intf.S0
     with type 'a t = 'a Choice.t
+     and type memory = Memory.t
      and module Value = Concolic_value.V = struct
   type 'a t = 'a Choice.t
+
+  type memory = Memory.t
 
   module Value = Concolic_value.V
 
@@ -107,35 +111,17 @@ module M :
     ignore p;
     abort ()
 
-  let alloc (base : Value.int32) (_size : Value.int32) : Value.int32 Choice.t =
+  let alloc _ (base : Value.int32) (_size : Value.int32) : Value.int32 Choice.t
+      =
     Choice.bind (i32 base) (fun (base : int32) ->
         Choice.return
           { Concolic_value.concrete = base
           ; symbolic = Expr.ptr base (Symbolic_value.const_i32 0l)
           } )
-  (* WHAT ???? *)
-  (* Choice.with_thread (fun t : Value.int32 -> *)
-  (*     let memories = t.shared.memories in *)
-  (*     Symbolic_memory.iter *)
-  (*       (fun tbl -> *)
-  (*         Symbolic_memory.ITbl.iter *)
-  (*           (fun _ (m : Symbolic_memory.t) -> *)
-  (*             Symbolic_memory.replace_size m base size.s ) *)
-  (*           tbl ) *)
-  (*       memories; *)
-  (*     { c = base; s = Expr.make (Ptr (base, Symbolic_value.const_i32 0l)) }) *)
 
-  let free (p : Value.int32) : unit Choice.t =
+  let free _ (p : Value.int32) : unit Choice.t =
     (* WHAT ???? *)
     let _base = ptr p in
-    (* Choice.with_thread (fun t -> *)
-    (*     let memories = t.shared.memories in *)
-    (*     Symbolic_memory.iter *)
-    (*       (fun tbl -> *)
-    (*         Symbolic_memory.ITbl.iter *)
-    (*           (fun _ (m : Symbolic_memory.t) -> Symbolic_memory.free m base) *)
-    (*           tbl ) *)
-    (*       memories ) *)
     Choice.return ()
 end
 
@@ -177,9 +163,10 @@ let summaries_extern_module =
   let functions =
     [ ( "alloc"
       , Concolic.P.Extern_func.Extern_func
-          (Func (Arg (I32, Arg (I32, Res)), R1 I32), alloc) )
+          (Func (Mem (Arg (I32, Arg (I32, Res))), R1 I32), alloc) )
     ; ( "dealloc"
-      , Concolic.P.Extern_func.Extern_func (Func (Arg (I32, Res), R0), free) )
+      , Concolic.P.Extern_func.Extern_func
+          (Func (Mem (Arg (I32, Res)), R0), free) )
     ; ("abort", Concolic.P.Extern_func.Extern_func (Func (UArg Res, R0), abort))
     ]
   in

--- a/src/concrete/concrete_value.mli
+++ b/src/concrete/concrete_value.mli
@@ -9,13 +9,17 @@ open Types
 
 type externref = E : 'a Type.Id.t * 'a -> externref
 
-module Make_extern_func (V : Func_intf.Value_types) (M : Func_intf.Monad_type) :
+module Make_extern_func
+    (V : Func_intf.Value_types)
+    (M : Func_intf.Monad_type)
+    (Memory : Func_intf.Memory_type) :
   Func_intf.T_Extern_func
     with type int32 := V.int32
      and type int64 := V.int64
      and type float32 := V.float32
      and type float64 := V.float64
      and type 'a m := 'a M.t
+     and type memory := Memory.t
 
 module Func :
   Func_intf.T
@@ -24,6 +28,7 @@ module Func :
      and type float32 := Float32.t
      and type float64 := Float64.t
      and type 'a m := 'a
+     and type memory := Concrete_memory.t
 
 type ref_value =
   | Externref of externref option

--- a/src/intf/func_intf.ml
+++ b/src/intf/func_intf.ml
@@ -20,6 +20,10 @@ module type Monad_type = sig
   type 'a t
 end
 
+module type Memory_type = sig
+  type t
+end
+
 module type T_Extern_func = sig
   type int32
 
@@ -30,6 +34,8 @@ module type T_Extern_func = sig
   type float64
 
   type 'a m
+
+  type memory
 
   type _ telt =
     | I32 : int32 telt
@@ -46,6 +52,7 @@ module type T_Extern_func = sig
     | R4 : 'a telt * 'b telt * 'c telt * 'd telt -> ('a * 'b * 'c * 'd) rtype
 
   type (_, _) atype =
+    | Mem : ('b, 'r) atype -> (memory -> 'b, 'r) atype
     | UArg : ('b, 'r) atype -> (unit -> 'b, 'r) atype
     | Arg : 'a telt * ('b, 'r) atype -> ('a -> 'b, 'r) atype
     | NArg : string * 'a telt * ('b, 'r) atype -> ('a -> 'b, 'r) atype

--- a/src/intf/interpret_intf.ml
+++ b/src/intf/interpret_intf.ml
@@ -4,42 +4,6 @@
 
 open Types
 
-module type Memory_data = sig
-  type int32
-
-  type int64
-
-  type t
-
-  val load_8_s : t -> int32 -> int32
-
-  val load_8_u : t -> int32 -> int32
-
-  val load_16_s : t -> int32 -> int32
-
-  val load_16_u : t -> int32 -> int32
-
-  val load_32 : t -> int32 -> int32
-
-  val load_64 : t -> int32 -> int64
-
-  val store_8 : t -> addr:int32 -> int32 -> unit
-
-  val store_16 : t -> addr:int32 -> int32 -> unit
-
-  val store_32 : t -> addr:int32 -> int32 -> unit
-
-  val store_64 : t -> addr:int32 -> int64 -> unit
-
-  val create : Int32.t -> t
-
-  val grow : t -> int32 -> unit
-
-  val size : t -> int32
-
-  val size_in_pages : t -> int32
-end
-
 module type P = sig
   type thread
 
@@ -49,14 +13,6 @@ module type P = sig
 
   val select :
     Value.vbool -> if_true:Value.t -> if_false:Value.t -> Value.t Choice.t
-
-  module Extern_func :
-    Func_intf.T_Extern_func
-      with type int32 := Value.int32
-       and type int64 := Value.int64
-       and type float32 := Value.float32
-       and type float64 := Value.float64
-       and type 'a m := 'a Choice.t
 
   module Global : sig
     type t
@@ -134,6 +90,15 @@ module type P = sig
 
     val get_limit_max : t -> Value.int64 option
   end
+
+  module Extern_func :
+    Func_intf.T_Extern_func
+      with type int32 := Value.int32
+       and type int64 := Value.int64
+       and type float32 := Value.float32
+       and type float64 := Value.float64
+       and type 'a m := 'a Choice.t
+       and type memory := Memory.t
 
   module Data : sig
     type t

--- a/src/intf/wasm_ffi_intf.ml
+++ b/src/intf/wasm_ffi_intf.ml
@@ -5,6 +5,8 @@
 module type S0 = sig
   type 'a t
 
+  type memory
+
   module Value : sig
     type int32
 
@@ -33,9 +35,9 @@ module type S0 = sig
 
   val abort : unit -> unit t
 
-  val alloc : Value.int32 -> Value.int32 -> Value.int32 t
+  val alloc : memory -> Value.int32 -> Value.int32 -> Value.int32 t
 
-  val free : Value.int32 -> unit t
+  val free : memory -> Value.int32 -> unit t
 
   val exit : Value.int32 -> unit t
 end

--- a/src/symbolic/symbolic.ml
+++ b/src/symbolic/symbolic.ml
@@ -22,7 +22,8 @@ module MakeP
 struct
   module Value = Symbolic_value
   module Choice = Choice
-  module Extern_func = Concrete_value.Make_extern_func (Value) (Choice)
+  module Extern_func =
+    Concrete_value.Make_extern_func (Value) (Choice) (Symbolic_memory)
   module Global = Symbolic_global
   module Table = Symbolic_table
 


### PR DESCRIPTION
Adds a `Mem` argument to external function to allow direct manipulation of the memory. 
