### PR TITLE
Remove binary modul from Link.modul_to_run

### DIFF
--- a/src/concolic/concolic.ml
+++ b/src/concolic/concolic.ml
@@ -257,14 +257,14 @@ module P = struct
 
   module Module_to_run = struct
     type t =
-      { modul : Binary.modul
+      { id : string option
       ; env : Env.t
       ; to_run : Types.binary Types.expr list
       }
 
     let env (t : t) = t.env
 
-    let modul (t : t) = t.modul
+    let id (t : t) = t.id
 
     let to_run (t : t) = t.to_run
   end
@@ -273,7 +273,7 @@ end
 module P' : Interpret_intf.P = P
 
 let convert_module_to_run (m : 'f Link.module_to_run) =
-  P.Module_to_run.{ modul = m.modul; env = m.env; to_run = m.to_run }
+  P.Module_to_run.{ id = m.id; env = m.env; to_run = m.to_run }
 
 let backup (m : P.Module_to_run.t) = Link_env.backup m.env
 

--- a/src/concrete/concrete.ml
+++ b/src/concrete/concrete.ml
@@ -46,7 +46,7 @@ module Module_to_run = struct
 
   let env (t : Concrete_value.Func.extern_func Link.module_to_run) = t.env
 
-  let modul (t : Concrete_value.Func.extern_func Link.module_to_run) = t.modul
+  let id (t : Concrete_value.Func.extern_func Link.module_to_run) = t.id
 
   let to_run (t : Concrete_value.Func.extern_func Link.module_to_run) = t.to_run
 end

--- a/src/interpret/interpret.ml
+++ b/src/interpret/interpret.ml
@@ -1504,8 +1504,7 @@ module Make (P : Interpret_intf.P) :
                   None
               in
               Log.profile3 "Exec module %s@.%a@."
-                (Option.value (Module_to_run.modul modul).id
-                   ~default:"anonymous" )
+                (Option.value (Module_to_run.id modul) ~default:"anonymous")
                 State.print_count count )
             (Choice.return ())
             (Module_to_run.to_run modul)

--- a/src/intf/interpret_intf.ml
+++ b/src/intf/interpret_intf.ml
@@ -144,7 +144,7 @@ module type P = sig
 
     val to_run : t -> binary expr list
 
-    val modul : t -> Binary.modul
+    val id : t -> string option
   end
 end
 

--- a/src/link/link.ml
+++ b/src/link/link.ml
@@ -22,7 +22,7 @@ type exports =
   }
 
 type 'f module_to_run =
-  { modul : Binary.modul
+  { id : string option
   ; env : 'f Link_env.t
   ; to_run : binary expr list
   }
@@ -393,7 +393,7 @@ let modul (ls : 'f state) ~name (modul : Binary.modul) =
   in
   let start = Option.fold ~none:[] ~some:(fun s -> [ s ]) start in
   let to_run = (init_active_data @ init_active_elem) @ start in
-  let module_to_run = { modul; env; to_run } in
+  let module_to_run = { id = modul.id; env; to_run } in
   Ok
     ( module_to_run
     , { by_id

--- a/src/link/link.mli
+++ b/src/link/link.mli
@@ -11,7 +11,7 @@ open Types
 
 (** runnable module *)
 type 'f module_to_run =
-  { modul : Binary.modul
+  { id : string option
   ; env : 'f Link_env.t
   ; to_run : binary expr list
   }

--- a/src/symbolic/symbolic.ml
+++ b/src/symbolic/symbolic.ml
@@ -123,14 +123,14 @@ struct
   module Module_to_run = struct
     (** runnable module *)
     type t =
-      { modul : Binary.modul
+      { id : string option
       ; env : Env.t
       ; to_run : Types.binary Types.expr list
       }
 
     let env (t : t) = t.env
 
-    let modul (t : t) = t.modul
+    let id (t : t) = t.id
 
     let to_run (t : t) = t.to_run
   end
@@ -144,7 +144,7 @@ module M =
     (Symbolic_choice_minimalist)
 
 let convert_module_to_run (m : 'f Link.module_to_run) =
-  P.Module_to_run.{ modul = m.modul; env = m.env; to_run = m.to_run }
+  P.Module_to_run.{ id = m.id; env = m.env; to_run = m.to_run }
 
 let convert_module_to_run_minimalist (m : 'f Link.module_to_run) =
-  M.Module_to_run.{ modul = m.modul; env = m.env; to_run = m.to_run }
+  M.Module_to_run.{ id = m.id; env = m.env; to_run = m.to_run }


### PR DESCRIPTION
Only its id is needed, and it makes for a clearer and less confusing interface.