### PR TITLE
Make symbolic memory parametric and concretise every symbolic address 

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -67,6 +67,9 @@
   symbolic_choice_without_memory
   symbolic_global
   symbolic_memory
+  symbolic_memory_concretizing
+  symbolic_memory_intf
+  symbolic_memory_make
   symbolic_table
   symbolic_value
   symbolic_wasm_ffi

--- a/src/intf/symbolic_memory_intf.ml
+++ b/src/intf/symbolic_memory_intf.ml
@@ -1,0 +1,138 @@
+module type M = sig
+  type t
+
+  type address
+
+  val address : Smtml.Expr.t -> address Symbolic_choice_without_memory.t
+
+  val address_i32 : Int32.t -> address
+
+  val make : unit -> t
+
+  val clone : t -> t
+
+  val loadn : t -> address -> int -> Smtml.Expr.t
+
+  val storen : t -> address -> Smtml.Expr.t -> int -> unit
+
+  val validate_address :
+       t
+    -> Smtml.Expr.t
+    -> (Smtml.Expr.t, Trap.t) result Symbolic_choice_without_memory.t
+
+  val realloc :
+       t
+    -> ptr:Smtml.Expr.t
+    -> size:Smtml.Expr.t
+    -> Smtml.Expr.t Symbolic_choice_without_memory.t
+
+  val free : t -> Smtml.Expr.t -> unit Symbolic_choice_without_memory.t
+end
+
+module type S = sig
+  type t
+
+  type collection
+
+  val init : unit -> collection
+
+  val clone : collection -> collection
+
+  val get_memory : Env_id.t -> Concrete_memory.t -> collection -> int -> t
+
+  (* val check_within_bounds : *)
+  (*   t -> Smtml.Expr.t -> (Smtml.Expr.t * Symbolic_value.int32, Trap.t) result *)
+
+  val realloc :
+       t
+    -> ptr:Smtml.Expr.t
+    -> size:Smtml.Expr.t
+    -> Smtml.Expr.t Symbolic_choice_without_memory.t
+
+  val free : t -> Smtml.Expr.t -> unit Symbolic_choice_without_memory.t
+
+  val load_8_s :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val load_8_u :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val load_16_s :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val load_16_u :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val load_32 :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val load_64 :
+    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+
+  val store_8 :
+       t
+    -> addr:Smtml.Expr.t
+    -> Smtml.Expr.t
+    -> unit Symbolic_choice_without_memory.t
+
+  val store_16 :
+       t
+    -> addr:Smtml.Expr.t
+    -> Smtml.Expr.t
+    -> unit Symbolic_choice_without_memory.t
+
+  val store_32 :
+       t
+    -> addr:Smtml.Expr.t
+    -> Smtml.Expr.t
+    -> unit Symbolic_choice_without_memory.t
+
+  val store_64 :
+       t
+    -> addr:Smtml.Expr.t
+    -> Smtml.Expr.t
+    -> unit Symbolic_choice_without_memory.t
+
+  val grow : t -> Smtml.Expr.t -> unit
+
+  val fill : t -> pos:Smtml.Expr.t -> len:Smtml.Expr.t -> char -> Smtml.Expr.t
+
+  val blit :
+       t
+    -> src:Smtml.Expr.t
+    -> dst:Smtml.Expr.t
+    -> len:Smtml.Expr.t
+    -> Smtml.Expr.t
+
+  val blit_string :
+       t
+    -> string
+    -> src:Smtml.Expr.t
+    -> dst:Smtml.Expr.t
+    -> len:Smtml.Expr.t
+    -> Smtml.Expr.t
+
+  val size : t -> Smtml.Expr.t
+
+  val size_in_pages : t -> Smtml.Expr.t
+
+  val get_limit_max : t -> Smtml.Expr.t option
+
+  module ITbl : sig
+    type 'a t
+
+    type key
+
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
+  end
+
+  val iter : (t ITbl.t -> unit) -> collection -> unit
+end
+
+module type Intf = sig
+  module type M = M
+
+  module type S = S
+
+  module Make (_ : M) : S
+end

--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -197,7 +197,7 @@ let free m base =
     Fmt.failwith "Memory leak double free";
   Hashtbl.remove m.chunks base
 
-let replace_size m base size = Hashtbl.replace m.chunks base size
+let realloc m base size = Hashtbl.replace m.chunks base size
 
 module ITbl = Hashtbl.Make (struct
   include Int

--- a/src/symbolic/symbolic_memory.mli
+++ b/src/symbolic/symbolic_memory.mli
@@ -15,7 +15,7 @@ val get_memory : Env_id.t -> Concrete_memory.t -> collection -> int -> t
 val check_within_bounds :
   t -> Smtml.Expr.t -> (Smtml.Expr.t * Symbolic_value.int32, Trap.t) result
 
-val replace_size : t -> Int32.t -> Smtml.Expr.t -> unit
+val realloc : t -> Int32.t -> Smtml.Expr.t -> unit
 
 val free : t -> Int32.t -> unit
 

--- a/src/symbolic/symbolic_memory_concretizing.ml
+++ b/src/symbolic/symbolic_memory_concretizing.ml
@@ -1,0 +1,150 @@
+module Backend = struct
+  open Smtml
+
+  type address = Int32.t
+
+  type t =
+    { data : (address, Symbolic_value.int32) Hashtbl.t
+    ; parent : t option
+    ; chunks : (address, Symbolic_value.int32) Hashtbl.t
+    }
+
+  let make () =
+    { data = Hashtbl.create 16; parent = None; chunks = Hashtbl.create 16 }
+
+  let clone m =
+    (* TODO: Make chunk copying lazy *)
+    { data = Hashtbl.create 16
+    ; parent = Some m
+    ; chunks = Hashtbl.copy m.chunks
+    }
+
+  let address a =
+    let open Symbolic_choice_without_memory in
+    match Expr.view a with
+    | Val (Num (I32 i)) -> return i
+    | Ptr { base; offset } ->
+      select_i32 Symbolic_value.(I32.add (const_i32 base) offset)
+    | _ -> select_i32 a
+
+  let address_i32 a = a
+
+  let rec load_byte { parent; data; _ } a =
+    try Hashtbl.find data a
+    with Not_found -> (
+      match parent with
+      | None -> Expr.value (Num (I8 0))
+      | Some parent -> load_byte parent a )
+
+  (* TODO: don't rebuild so many values it generates unecessary hc lookups *)
+  let merge_extracts (e1, h, m1) (e2, m2, l) =
+    let ty = Expr.ty e1 in
+    if m1 = m2 && Expr.equal e1 e2 then
+      if h - l = Ty.size ty then e1 else Expr.make (Extract (e1, h, l))
+    else
+      Expr.(
+        make (Concat (make (Extract (e1, h, m1)), make (Extract (e2, m2, l)))) )
+
+  let concat ~msb ~lsb offset =
+    assert (offset > 0 && offset <= 8);
+    match (Expr.view msb, Expr.view lsb) with
+    | Val (Num (I8 i1)), Val (Num (I8 i2)) ->
+      Symbolic_value.const_i32 Int32.(logor (shl (of_int i1) 8l) (of_int i2))
+    | Val (Num (I8 i1)), Val (Num (I32 i2)) ->
+      let offset = offset * 8 in
+      if offset < 32 then
+        Symbolic_value.const_i32
+          Int32.(logor (shl (of_int i1) (of_int offset)) i2)
+      else
+        let i1' = Int64.of_int i1 in
+        let i2' = Int64.of_int32 i2 in
+        Symbolic_value.const_i64 Int64.(logor (shl i1' (of_int offset)) i2')
+    | Val (Num (I8 i1)), Val (Num (I64 i2)) ->
+      let offset = Int64.of_int (offset * 8) in
+      Symbolic_value.const_i64 Int64.(logor (shl (of_int i1) offset) i2)
+    | Extract (e1, h, m1), Extract (e2, m2, l) ->
+      merge_extracts (e1, h, m1) (e2, m2, l)
+    | Extract (e1, h, m1), Concat ({ node = Extract (e2, m2, l); _ }, e3) ->
+      Expr.(make (Concat (merge_extracts (e1, h, m1) (e2, m2, l), e3)))
+    | _ -> Expr.make (Concat (msb, lsb))
+
+  let loadn m a n =
+    let rec loop addr size i acc =
+      if i = size then acc
+      else
+        let addr' = Int32.(add addr (of_int i)) in
+        let byte = load_byte m addr' in
+        loop addr size (i + 1) (concat i ~msb:byte ~lsb:acc)
+    in
+    let v0 = load_byte m a in
+    loop a n 1 v0
+
+  let extract v pos =
+    match Expr.view v with
+    | Val (Num (I8 _)) -> v
+    | Val (Num (I32 i)) ->
+      let i' = Int32.(to_int @@ logand 0xffl @@ shr_s i @@ of_int (pos * 8)) in
+      Expr.value (Num (I8 i'))
+    | Val (Num (I64 i)) ->
+      let i' = Int64.(to_int @@ logand 0xffL @@ shr_s i @@ of_int (pos * 8)) in
+      Expr.value (Num (I8 i'))
+    | Cvtop
+        (_, Zero_extend 24, ({ node = Symbol { ty = Ty_bitv 8; _ }; _ } as sym))
+    | Cvtop
+        (_, Sign_extend 24, ({ node = Symbol { ty = Ty_bitv 8; _ }; _ } as sym))
+      ->
+      sym
+    | _ -> Expr.make (Extract (v, pos + 1, pos))
+
+  let storen m a v n =
+    for i = 0 to n - 1 do
+      let a' = Int32.add a (Int32.of_int i) in
+      let v' = extract v i in
+      Hashtbl.replace m.data a' v'
+    done
+
+  let validate_address m a =
+    let open Symbolic_choice_without_memory in
+    match Smtml.Expr.view a with
+    | Val (Num (I32 _)) -> return (Ok a) (* An i32 is a valid address *)
+    | Ptr { base; offset } -> (
+      let (* A pointer is valid if it's within bounds. *)
+      open Symbolic_value in
+      match Hashtbl.find m.chunks base with
+      | exception Not_found -> return (Error Trap.Memory_leak_use_after_free)
+      | size ->
+        let base = const_i32 base in
+        let ptr = I32.add base offset in
+        let+ is_out_of_bounds =
+          select (Bool.or_ (I32.lt ptr base) (I32.ge ptr (I32.add base size)))
+        in
+        if is_out_of_bounds then Error Trap.Memory_heap_buffer_overflow
+        else Ok a )
+    | _ ->
+      (* A symbolic expression should be a valid address *)
+      return (Ok a)
+
+  let ptr v =
+    let open Symbolic_choice_without_memory in
+    match Expr.view v with
+    | Ptr { base; _ } -> return base
+    | _ ->
+      Log.debug2 {|free: cannot fetch pointer base of "%a"|} Expr.pp v;
+      let* () = add_pc @@ Expr.value False in
+      assert false
+
+  let free m p =
+    let open Symbolic_choice_without_memory in
+    let+ base = ptr p in
+    if not @@ Hashtbl.mem m.chunks base then
+      Fmt.failwith "Memory leak double free";
+    Hashtbl.remove m.chunks base
+
+  let realloc m ~ptr ~size =
+    let open Symbolic_choice_without_memory in
+    let+ base = address ptr in
+    Hashtbl.replace m.chunks base size;
+    Expr.ptr base (Symbolic_value.const_i32 0l)
+end
+
+include Symbolic_memory_make.Make (Backend)

--- a/src/symbolic/symbolic_memory_concretizing.mli
+++ b/src/symbolic/symbolic_memory_concretizing.mli
@@ -1,0 +1,6 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2024 OCamlPro *)
+(* Written by the Owi programmers *)
+
+(** @inline *)
+include Symbolic_memory_intf.S

--- a/src/symbolic/symbolic_memory_make.ml
+++ b/src/symbolic/symbolic_memory_make.ml
@@ -1,0 +1,180 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2024 OCamlPro *)
+(* Written by the Owi programmers *)
+
+include Symbolic_memory_intf
+
+let page_size = Symbolic_value.const_i32 65_536l
+
+module Make (Backend : M) = struct
+  type t =
+    { data : Backend.t
+    ; mutable size : Symbolic_value.int32
+    }
+
+  let create size =
+    { data = Backend.make (); size = Symbolic_value.const_i32 size }
+
+  let i32 v =
+    match Smtml.Expr.view v with
+    | Val (Num (I32 i)) -> i
+    | _ ->
+      Log.err {|Unsupported symbolic value reasoning over "%a"|} Smtml.Expr.pp v
+
+  let grow m delta =
+    let old_size = Symbolic_value.I32.mul m.size page_size in
+    let new_size = Symbolic_value.I32.(div (add old_size delta) page_size) in
+    m.size <-
+      Symbolic_value.Bool.select_expr
+        (Symbolic_value.I32.gt new_size m.size)
+        ~if_true:new_size ~if_false:m.size
+
+  let size { size; _ } = Symbolic_value.I32.mul size page_size
+
+  let size_in_pages { size; _ } = size
+
+  let fill _ = assert false
+
+  let blit _ = assert false
+
+  let blit_string m str ~src ~dst ~len =
+    (* This function is only used in memory init so everything will be concrete *)
+    let str_len = String.length str in
+    let mem_len = Int32.(to_int (i32 m.size) * to_int (i32 page_size)) in
+    let src = Int32.to_int @@ i32 src in
+    let dst = Int32.to_int @@ i32 dst in
+    let len = Int32.to_int @@ i32 len in
+    if
+      src < 0 || dst < 0 || len < 0
+      || src + len > str_len
+      || dst + len > mem_len
+    then Symbolic_value.Bool.const true
+    else begin
+      for i = 0 to len - 1 do
+        let byte = Char.code @@ String.get str (src + i) in
+        let a = Backend.address_i32 (Int32.of_int (dst + i)) in
+        Backend.storen m.data a (Smtml.Expr.value (Num (I8 byte))) 1
+      done;
+      Symbolic_value.Bool.const false
+    end
+
+  let clone m = { data = Backend.clone m.data; size = m.size }
+
+  let must_be_valid_address m a =
+    let open Symbolic_choice_without_memory in
+    let* addr = Backend.validate_address m a in
+    match addr with Error t -> trap t | Ok ptr -> Backend.address ptr
+
+  let load_8_s m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    let v = Backend.loadn m.data a 1 in
+    match Smtml.Expr.view v with
+    | Val (Num (I8 i8)) ->
+      Symbolic_value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
+    | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Sign_extend 24) v
+
+  let load_8_u m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    let v = Backend.loadn m.data a 1 in
+    match Smtml.Expr.view v with
+    | Val (Num (I8 i)) -> Symbolic_value.const_i32 (Int32.of_int i)
+    | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Zero_extend 24) v
+
+  let load_16_s m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    let v = Backend.loadn m.data a 2 in
+    match Smtml.Expr.view v with
+    | Val (Num (I32 i16)) -> Symbolic_value.const_i32 (Int32.extend_s 16 i16)
+    | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Sign_extend 16) v
+
+  let load_16_u m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    let v = Backend.loadn m.data a 2 in
+    match Smtml.Expr.view v with
+    | Val (Num (I32 _)) -> v
+    | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Zero_extend 16) v
+
+  let load_32 m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    Backend.loadn m.data a 4
+
+  let load_64 m a =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data a in
+    Backend.loadn m.data a 8
+
+  let store_8 m ~addr v =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data addr in
+    Backend.storen m.data a v 1
+
+  let store_16 m ~addr v =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data addr in
+    Backend.storen m.data a v 2
+
+  let store_32 m ~addr v =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data addr in
+    Backend.storen m.data a v 4
+
+  let store_64 m ~addr v =
+    let open Symbolic_choice_without_memory in
+    let+ a = must_be_valid_address m.data addr in
+    Backend.storen m.data a v 8
+
+  let get_limit_max _m = None (* TODO *)
+
+  let free m base = Backend.free m.data base
+
+  let realloc m ~ptr ~size = Backend.realloc m.data ~ptr ~size
+
+  (* TODO: Move this into a separate module? *)
+  module ITbl = Hashtbl.Make (struct
+    include Int
+
+    let hash x = x
+  end)
+
+  type collection = t ITbl.t Env_id.Tbl.t
+
+  let init () = Env_id.Tbl.create 0
+
+  let iter f collection = Env_id.Tbl.iter (fun _ tbl -> f tbl) collection
+
+  let clone collection =
+    (* TODO: this is ugly and should be rewritten *)
+    let s = Env_id.Tbl.to_seq collection in
+    Env_id.Tbl.of_seq
+    @@ Seq.map
+         (fun (i, t) ->
+           let s = ITbl.to_seq t in
+           (i, ITbl.of_seq @@ Seq.map (fun (i, a) -> (i, clone a)) s) )
+         s
+
+  let convert (orig_mem : Concrete_memory.t) : t =
+    let s = Concrete_memory.size_in_pages orig_mem in
+    create s
+
+  let get_env env_id memories =
+    match Env_id.Tbl.find_opt memories env_id with
+    | Some env -> env
+    | None ->
+      let t = ITbl.create 0 in
+      Env_id.Tbl.add memories env_id t;
+      t
+
+  let get_memory env_id (orig_memory : Concrete_memory.t) collection g_id =
+    let env = get_env env_id collection in
+    match ITbl.find_opt env g_id with
+    | Some t -> t
+    | None ->
+      let t = convert orig_memory in
+      ITbl.add env g_id t;
+      t
+end

--- a/src/symbolic/symbolic_memory_make.mli
+++ b/src/symbolic/symbolic_memory_make.mli
@@ -1,0 +1,6 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2024 OCamlPro *)
+(* Written by the Owi programmers *)
+
+(** @inline *)
+include Symbolic_memory_intf.Intf

--- a/src/symbolic/thread_with_memory.ml
+++ b/src/symbolic/thread_with_memory.ml
@@ -2,7 +2,7 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-include Thread.Make (Symbolic_memory)
+include Thread.Make (Symbolic_memory_concretizing)
 
 let project (th : t) : Thread_without_memory.t * _ =
   let projected =
@@ -24,7 +24,8 @@ let restore backup th =
   let symbols_set = Thread_without_memory.symbols_set th in
   let pc = Thread_without_memory.pc th in
   let memories =
-    if Thread_without_memory.memories th then Symbolic_memory.clone backup
+    if Thread_without_memory.memories th then
+      Symbolic_memory_concretizing.clone backup
     else backup
   in
   let tables = Thread_without_memory.tables th in

--- a/src/symbolic/thread_with_memory.mli
+++ b/src/symbolic/thread_with_memory.mli
@@ -3,7 +3,8 @@
 (* Written by the Owi programmers *)
 
 (** @inline *)
-include Thread.S with type Memory.collection = Symbolic_memory.collection
+include
+  Thread.S with type Memory.collection = Symbolic_memory_concretizing.collection
 
 val project : t -> Thread_without_memory.t * Memory.collection
 


### PR DESCRIPTION
Since this depends on #367, the relevant changes are in https://github.com/OCamlPro/owi/pull/371/commits/6c8a21e6dcb58e9378eda62b03827247725c156c.

### Summary

1. Parameterizes symbolic memory on an abstract backend which allows handling  addresses in an isolated way (`symbolic_memory_make.ml`).

2. Implements a concrete backend that always concretizes symbolic expressions to concrete addresses (`symbolic_memory_conrcetizing.ml`).

**Last remark**: I left the original `symbolic_memory.ml` in order to not break concolic execution. It's unclear to me that we will be able to perform concolic execution with the same symbolic execution memory backend that we use for `owi sym`.  

### Benchmarking

- TestComp with 5 second timeout:

```sh
# results-testcomp-owi_w8_O3_sZ3-2024-07-29_14h49m24s
Run 1216/1216: testcomp/sv-benchmarks/c/xcsp/aim-200-6-0-sat-4.c
  Timeout in 5.01258 12.243 0.433289
  Nothing:      0    Reached:    591    Timeout:    624    Other:      1    Killed:      0
```