### PR TITLE
enable macOS CI again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # Deactivated, see: https://github.com/OCamlPro/owi/issues/346
-          #- macos-latest
+          - macos-latest # macOS ARM64
+            # - macos-latest-large # macOS x86_64 # disabled because we're poor
           - ubuntu-latest
           # - windows-latest see #5
         ocaml-compiler:

--- a/dune-project
+++ b/dune-project
@@ -55,7 +55,7 @@
   (smtml (>= 0.2.0))
   uutf
   xmlm
-  (processor (>= 0.1))
+  (processor (>= 0.2))
   ;; doc
   (odoc :with-doc)
   ;; test

--- a/owi.opam
+++ b/owi.opam
@@ -32,7 +32,7 @@ depends: [
   "smtml" {>= "0.2.0"}
   "uutf"
   "xmlm"
-  "processor" {>= "0.1"}
+  "processor" {>= "0.2"}
   "odoc" {with-doc}
   "mdx" {with-test & >= "2.1"}
   "bisect_ppx" {>= "2.5" & with-dev-setup}


### PR DESCRIPTION
Fix #346 (once `processor.0.2` has been accepted into opam).