### PR TITLE
actually parse inline binary and quoted module in scripts

### DIFF
--- a/src/ast/text.ml
+++ b/src/ast/text.ml
@@ -178,13 +178,15 @@ type register = string * string option
 let pp_register fmt (s, _name) = pf fmt "(register %s)" s
 
 type cmd =
-  | Module of modul
+  | Binary_module of string option * string
+  | Text_module of modul
   | Assert of assertion
   | Register of string * string option
   | Action of action
 
 let pp_cmd fmt = function
-  | Module m -> pp_modul fmt m
+  | Binary_module (id, m) -> Fmt.pf fmt "(module %a %S)" Types.pp_id_opt id m
+  | Text_module m -> pp_modul fmt m
   | Assert a -> pp_assertion fmt a
   | Register (s, name) -> pp_register fmt (s, name)
   | Action _a -> pf fmt "<action>"

--- a/src/ast/text.ml
+++ b/src/ast/text.ml
@@ -178,6 +178,7 @@ type register = string * string option
 let pp_register fmt (s, _name) = pf fmt "(register %s)" s
 
 type cmd =
+  | Quoted_module of string
   | Binary_module of string option * string
   | Text_module of modul
   | Assert of assertion
@@ -185,6 +186,7 @@ type cmd =
   | Action of action
 
 let pp_cmd fmt = function
+  | Quoted_module m -> pf fmt "(module %S)" m
   | Binary_module (id, m) -> Fmt.pf fmt "(module %a %S)" Types.pp_id_opt id m
   | Text_module m -> pp_modul fmt m
   | Assert a -> pp_assertion fmt a

--- a/src/parser/text_parser.mly
+++ b/src/parser/text_parser.mly
@@ -1002,14 +1002,17 @@ let inline_module :=
 
 let modul :=
   | LPAR; MODULE; id = ioption(id); ~ = inline_module_inner; RPAR; {
-    (* TODO: handle fields_bin
-    let fields_bin = String.concat "" l in *)
     { inline_module_inner with id }
   }
 
 let module_binary :=
   | MODULE; id = ioption(id); BINARY; lines = list(NAME); {
     id, String.concat "" lines
+  }
+
+let module_quoted :=
+  | MODULE; QUOTE; lines = list(NAME); {
+    String.concat "" lines
   }
 
 let literal_const ==
@@ -1078,6 +1081,7 @@ let action ==
 
 let cmd ==
   | ~ = modul; <Text_module>
+  | ~ = par(module_quoted); <Quoted_module>
   | bm = par(module_binary); {
     let id, m = bm in
     Binary_module (id, m)

--- a/src/parser/text_parser.mly
+++ b/src/parser/text_parser.mly
@@ -1008,10 +1008,8 @@ let modul :=
   }
 
 let module_binary :=
-  | MODULE; id = ioption(id); BINARY; ~ = inline_module_inner; _ = list(NAME); {
-    (* TODO: handle fields_bin
-    let fields_bin = String.concat "" l in *)
-    { inline_module_inner with id }
+  | MODULE; id = ioption(id); BINARY; lines = list(NAME); {
+    id, String.concat "" lines
   }
 
 let literal_const ==
@@ -1079,8 +1077,11 @@ let action ==
   | GET; ~ = ioption(id); ~ = utf8_name; <Get>
 
 let cmd ==
-  | ~ = modul; <Module>
-  | ~ = par(module_binary); <Module>
+  | ~ = modul; <Text_module>
+  | bm = par(module_binary); {
+    let id, m = bm in
+    Binary_module (id, m)
+  }
   | ~ = par(assert_); <Assert>
   | ~ = par(register); <>
   | ~ = par(action); <Action>
@@ -1088,5 +1089,5 @@ let cmd ==
 let script :=
   | ~ = nonempty_list(cmd); EOF; <>
   | ~ = inline_module_inner; EOF; {
-    [ Module inline_module_inner ]
+    [ Text_module inline_module_inner ]
   }

--- a/src/script/script.ml
+++ b/src/script/script.ml
@@ -161,8 +161,15 @@ let run ~no_exhaustion ~optimize script =
         in
         Log.debug_on := debug_on;
         link_state
+      | Text.Quoted_module m ->
+        Log.debug0 "*** quoted module@\n";
+        incr curr_module;
+        let* m = Parse.Text.Inline_module.from_string m in
+        let+ link_state =
+          Compile.Text.until_interpret link_state ~unsafe ~optimize ~name:None m
+        in
+        link_state
       | Text.Binary_module (id, m) ->
-        if !curr_module = 0 then Log.debug_on := false;
         Log.debug0 "*** binary module@\n";
         incr curr_module;
         let* m = Parse.Binary.Module.from_string m in
@@ -171,7 +178,6 @@ let run ~no_exhaustion ~optimize script =
           Compile.Binary.until_interpret link_state ~unsafe ~optimize ~name:None
             m
         in
-        Log.debug_on := debug_on;
         link_state
       | Assert (Assert_trap_module (m, expected)) ->
         Log.debug0 "*** assert_trap@\n";

--- a/src/script/spectest.ml
+++ b/src/script/spectest.ml
@@ -49,7 +49,7 @@ let extern_m =
 
 let m =
   let open Text in
-  Text.Module
+  Text.Text_module
     { id = Some "spectest"
     ; fields =
         [ MImport

--- a/test/script/passing.t
+++ b/test/script/passing.t
@@ -43,3 +43,4 @@
   $ owi script --no-exhaustion passing/typecheck4.wast
   $ owi script --no-exhaustion passing/typecheckbis.wast
   $ owi script --no-exhaustion passing/typecheck.wast
+  $ owi script --no-exhaustion passing/quoted.wast

--- a/test/script/passing/quoted.wast
+++ b/test/script/passing/quoted.wast
@@ -1,0 +1,3 @@
+(module quote
+  "(func )"
+)

--- a/test/script/reference.t
+++ b/test/script/reference.t
@@ -30,8 +30,6 @@
   $ owi script --no-exhaustion reference/fac.wast
   $ owi script --no-exhaustion reference/float_exprs.wast
   $ owi script --no-exhaustion reference/float_literals.wast
-  unbound name 4294967249
-  [38]
   $ owi script --no-exhaustion reference/float_memory.wast
   $ owi script --no-exhaustion reference/float_misc.wast
   $ owi script --no-exhaustion reference/forward.wast

--- a/test/script/reference.t
+++ b/test/script/reference.t
@@ -12,8 +12,6 @@
   $ owi script --no-exhaustion reference/call_indirect.wast
   $ owi script --no-exhaustion reference/call.wast
   $ owi script --no-exhaustion reference/comments.wast
-  unexpected token "\"(func (export \"f1\") (result i32)\""
-  [40]
   $ owi script --no-exhaustion reference/const.wast
   $ owi script --no-exhaustion reference/conversions.wast
   $ owi script --no-exhaustion reference/custom.wast

--- a/test/script/reference_opt.t
+++ b/test/script/reference_opt.t
@@ -12,8 +12,6 @@
   $ owi script --no-exhaustion --optimize reference/call_indirect.wast
   $ owi script --no-exhaustion --optimize reference/call.wast
   $ owi script --no-exhaustion --optimize reference/comments.wast
-  unexpected token "\"(func (export \"f1\") (result i32)\""
-  [40]
   $ owi script --no-exhaustion --optimize reference/const.wast
   $ owi script --no-exhaustion --optimize reference/conversions.wast
   $ owi script --no-exhaustion --optimize reference/custom.wast

--- a/test/script/reference_opt.t
+++ b/test/script/reference_opt.t
@@ -30,8 +30,6 @@
   $ owi script --no-exhaustion --optimize reference/fac.wast
   $ owi script --no-exhaustion --optimize reference/float_exprs.wast
   $ owi script --no-exhaustion --optimize reference/float_literals.wast
-  unbound name 4294967249
-  [38]
   $ owi script --no-exhaustion --optimize reference/float_memory.wast
   $ owi script --no-exhaustion --optimize reference/float_misc.wast
   $ owi script --no-exhaustion --optimize reference/forward.wast


### PR DESCRIPTION
Fix #279. The binary parser code was actually correct. The issue was that we were not parsing inline binary module correctly...