### PR TITLE
fix default value for global floats in spectest

### DIFF
--- a/src/script/spectest.ml
+++ b/src/script/spectest.ml
@@ -154,12 +154,12 @@ let m =
             }
         ; MGlobal
             { typ = (Const, Num_type F32)
-            ; init = [ F32_const Float32.zero ]
+            ; init = [ F32_const (Float32.of_float 666.6) ]
             ; id = Some "global_f32"
             }
         ; MGlobal
             { typ = (Const, Num_type F64)
-            ; init = [ F64_const Float64.zero ]
+            ; init = [ F64_const (Float64.of_float 666.6) ]
             ; id = Some "global_f64"
             }
         ; MExport { name = "func"; desc = Export_func (Some (Text "func")) }

--- a/test/script/reference.t
+++ b/test/script/reference.t
@@ -54,10 +54,6 @@
   24
   24
   13
-  got:      f32.const 0
-  expected: (f32.const 666.599_975_585_937_5)
-  bad result
-  [3]
   $ owi script --no-exhaustion reference/inline-module.wast
   $ owi script --no-exhaustion reference/int_exprs.wast
   $ owi script --no-exhaustion reference/int_literals.wast

--- a/test/script/reference_opt.t
+++ b/test/script/reference_opt.t
@@ -54,10 +54,6 @@
   24
   24
   13
-  got:      f32.const 0
-  expected: (f32.const 666.599_975_585_937_5)
-  bad result
-  [3]
   $ owi script --no-exhaustion --optimize reference/inline-module.wast
   $ owi script --no-exhaustion --optimize reference/int_exprs.wast
   $ owi script --no-exhaustion --optimize reference/int_literals.wast


### PR DESCRIPTION
Fix #280.