### PR TITLE
Testcomp script zulip webhook integration

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -26,6 +26,17 @@ $ dune exec -- testcomp/testcomp.exe 5 # timeout of 5 seconds
 
 A folder `testcomp-results-YYYY-MM-DD_HHhMMhSSs` has been created with a lot of output. It contains `results-report/index.html` which is the recommended way to visualize the results.
 
+### Zulip notification:
+
+You can set up the script to notify you or a stream on Zulip using the Zulip Slack incoming webhook integration.
+For information on creating webhooks, see [this](https://zulip.com/integrations/doc/slack_incoming#zulip-slack-incoming-webhook-integration).
+Next, just set the `ZULIP_WEBHOOK` environment variable with the generated webhook and launch the script:
+
+```shell-session
+export ZULIP_WEBHOOK="https://saussice.zulipchat.com/api/v1/external/slack_incoming?api_key=...&stream=germany&topic=bratwurst"
+dune exec ./testcomp/testcomp.exe
+```
+
 ## Generate the report by hand
 
 ```shell-session

--- a/bench/testcomp/dune
+++ b/bench/testcomp/dune
@@ -3,7 +3,7 @@
 (executable
  (name testcomp)
  (modules testcomp whitelist)
- (libraries bos fpath report tool yaml unix smtml))
+ (libraries bos fpath report tool yaml unix smtml cohttp cohttp-lwt-unix lwt))
 
 (rule
  (deps whitelist.txt)


### PR DESCRIPTION
Adds an environment variable `ZULIP_WEBHOOK` that allows specifying a webhook to send a notification upon the termination of the `testcomp` script.

Example usage on my dummy zulip:

```sh
ZULIP_WEBHOOK="https://formalsec.zulipchat.com/api/v1/external/slack_incoming?api_key=dG28edLNmRyaf7BATr5WiPUenJrpf6zo&stream=448636&topic=webhook" dune exec ./testcomp/testcomp.exe
```

Preview:

![image](https://github.com/user-attachments/assets/066987d9-1928-493a-bd0a-12b0c69e5f87)

TODO:

- [x] Report current commit

~~Is there a good library to just fetch the git HEAD? Or, should I just simply get the output of: `git rev-parse --short HEAD`?~~
