### PR TITLE
instruction-level block types declaration

### DIFF
--- a/example/opt/README.md
+++ b/example/opt/README.md
@@ -339,7 +339,6 @@ Owi is able to get rid of most of the code:
 ```sh
 $ owi opt useless.wat
 (module
-
   (type (sub final  (func)))
   (func $i32binop
 

--- a/example/wasm2wat/README.md
+++ b/example/wasm2wat/README.md
@@ -7,7 +7,6 @@ Given a file `42.wasm`:
 ```sh
 $ owi wasm2wat ./42.wasm
 (module
-
   (type (sub final  (func)))
   (func
     i32.const 20

--- a/src/ast/binary_encoder.ml
+++ b/src/ast/binary_encoder.ml
@@ -117,7 +117,7 @@ let write_block_type buf (typ : binary block_type option) =
   match typ with
   | None | Some (Bt_raw (None, ([], []))) -> Buffer.add_char buf '\x40'
   | Some (Bt_raw (None, ([], [ vt ]))) -> write_valtype buf vt
-  | Some (Bt_raw (None, (pt, _))) -> write_paramtype buf pt
+  | Some (Bt_raw (Some idx, _)) -> write_indice buf idx
   (* TODO: memo
      will this pattern matching be enough with the use of the new modul.types field?
   *)

--- a/src/ast/types.ml
+++ b/src/ast/types.ml
@@ -939,7 +939,7 @@ type 'a rec_type = 'a type_def list
 let pp_rec_type fmt l =
   match l with
   | [] -> ()
-  | [ t ] -> pf fmt "@\n%a" pp_type_def_no_indent t
+  | [ t ] -> pf fmt "%a" pp_type_def_no_indent t
   | l -> pf fmt "(rec %a)" (list ~sep:sp pp_type_def) l
 
 let pp_start fmt start = pf fmt "(start %a)" pp_indice start

--- a/src/text_to_binary/grouped.ml
+++ b/src/text_to_binary/grouped.ml
@@ -106,15 +106,13 @@ let add_mem value (fields : t) (curr : curr) =
 let rec extract_block_types expr =
   let aux instr =
     match instr with
-    | Block (_str_opt, bt, expr1) ->
-      Option.to_list bt @ extract_block_types expr1
-    | Loop (_str_opt, bt, expr1) ->
+    | Block (_str_opt, bt, expr1) | Loop (_str_opt, bt, expr1) ->
       Option.to_list bt @ extract_block_types expr1
     | If_else (_str_opt, bt, expr1, expr2) ->
       Option.to_list bt @ extract_block_types expr1 @ extract_block_types expr2
-    | Return_call_indirect (_ind, bt) -> [ bt ]
-    | Return_call_ref bt -> [ bt ]
-    | Call_indirect (_ind, bt) -> [ bt ]
+    | Return_call_indirect (_, bt) | Return_call_ref bt | Call_indirect (_, bt)
+      ->
+      [ bt ]
     | _ -> []
   in
   List.concat_map aux expr
@@ -124,8 +122,7 @@ let add_func value (fields : t) (curr : curr) =
     match value with
     | Runtime.Local func ->
       let fields = declare_func_type fields func.type_f in
-      let temp = extract_block_types func.body in
-      List.fold_left declare_func_type fields temp
+      List.fold_left declare_func_type fields (extract_block_types func.body)
     | Imported func -> declare_func_type fields func.desc
   in
   let index = !(curr.func) in

--- a/test/fmt/print.t
+++ b/test/fmt/print.t
@@ -17,9 +17,7 @@ print symbolic:
 print simplified:
   $ dune exec -- ./print_simplified.exe m.wat
   (module
-    
     (type (sub final  (func (param $x i32) (param $y i32) (result i32))))
-    
     (type (sub final  (func)))
     (func $f (param $x i32) (param $y i32) (result i32)
       local.get 0

--- a/test/fmt/script.t
+++ b/test/fmt/script.t
@@ -697,7 +697,6 @@ print script:
       (func $f (param i32) (result i32)
         local.get 0
       )
-      
       (type $sig (sub final  (func (param i32) (result i32))))
       (table 1 1 (ref null func))
       (elem (offset i32.const 0) (ref null func) (item ref.func $f))
@@ -1075,7 +1074,6 @@ print script:
       (func $f (param i32) (result i32)
         local.get 0
       )
-      
       (type $sig (sub final  (func (param i32) (result i32))))
       (table 1 1 (ref null func))
       (elem (offset i32.const 0) (ref null func) (item ref.func $f))
@@ -1094,7 +1092,6 @@ print script:
       (func $f (param i32) (result i32)
         local.get 0
       )
-      
       (type $sig (sub final  (func (param i32) (result i32))))
       (table 1 1 (ref null func))
       (elem (offset i32.const 0) (ref null func) (item ref.func $f))

--- a/test/opt/binop.t
+++ b/test/opt/binop.t
@@ -2,7 +2,6 @@ binary operations instructions:
   $ owi opt binop.wat > binop.opt.wat
   $ cat binop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $i32binop
       

--- a/test/opt/block_loop.t
+++ b/test/opt/block_loop.t
@@ -2,7 +2,6 @@ block loop instructions:
   $ owi opt block_loop.wat > block_loop.opt.wat
   $ cat block_loop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/br.t
+++ b/test/opt/br.t
@@ -2,7 +2,6 @@ br instructions:
   $ owi opt br.wat > br.opt.wat
   $ cat br.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $br
       i32.const 42

--- a/test/opt/convert.t
+++ b/test/opt/convert.t
@@ -2,7 +2,6 @@ f**.convert_i** instructions:
   $ owi opt convert.wat > convert.opt.wat
   $ cat convert.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/debug.t
+++ b/test/opt/debug.t
@@ -8,7 +8,6 @@ test debug printing:
   typechecking ...
   optimizing   ...
   (module
-    
     (type (sub final  (func)))
     (global $g i32 i32.const 0)
     (func $start

--- a/test/opt/demote_promote.t
+++ b/test/opt/demote_promote.t
@@ -2,7 +2,6 @@ f32.demote_f64 f64.promote_f32 instructions:
   $ owi opt demote_promote.wat > demote_promote.opt.wat
   $ cat demote_promote.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/drop.t
+++ b/test/opt/drop.t
@@ -2,7 +2,6 @@ drop instruction:
   $ owi opt drop.wat > drop.opt.wat
   $ cat drop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (global $g i32 i32.const 0)
     (func $start

--- a/test/opt/extend_wrap.t
+++ b/test/opt/extend_wrap.t
@@ -2,7 +2,6 @@ i**.extend_** i32.wrap_i64 instructions:
   $ owi opt extend_wrap.wat > extend_wrap.opt.wat
   $ cat extend_wrap.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $extend
       

--- a/test/opt/fbinop.t
+++ b/test/opt/fbinop.t
@@ -2,7 +2,6 @@ f32 / f64 binary operations:
   $ owi opt fbinop.wat > fbinop.opt.wat
   $ cat fbinop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/ibinop.t
+++ b/test/opt/ibinop.t
@@ -2,7 +2,6 @@ i32 / i64 binary operations:
   $ owi opt ibinop.wat > ibinop.opt.wat
   $ cat ibinop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/if.t
+++ b/test/opt/if.t
@@ -2,9 +2,7 @@ if then else instruction:
   $ owi opt if.wat > if.opt.wat
   $ cat if.opt.wat
   (module
-    
     (type (sub final  (func)))
-    
     (type (sub final  (func (result i32))))
     (func $start
       (block (result i32)

--- a/test/opt/if.t
+++ b/test/opt/if.t
@@ -4,6 +4,8 @@ if then else instruction:
   (module
     
     (type (sub final  (func)))
+    
+    (type (sub final  (func (result i32))))
     (func $start
       (block (result i32)
         i32.const 42)

--- a/test/opt/local.t
+++ b/test/opt/local.t
@@ -2,7 +2,6 @@ unused local variables:
   $ owi opt local.wat > local.opt.wat
   $ cat local.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $f0 (local i32)
       i32.const 0

--- a/test/opt/ref_nop.t
+++ b/test/opt/ref_nop.t
@@ -2,7 +2,6 @@ ref.null ref.is_null nop instructions:
   $ owi opt ref_nop.wat > ref_nop.opt.wat
   $ cat ref_nop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/reinterpret.t
+++ b/test/opt/reinterpret.t
@@ -2,7 +2,6 @@ f**.reinterpret_i** i**.reinterpret_f** instructions:
   $ owi opt reinterpret.wat > reinterpret.opt.wat
   $ cat reinterpret.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/relop_testop.t
+++ b/test/opt/relop_testop.t
@@ -2,7 +2,6 @@
   $ owi opt relop_testop.wat > relop_testop.opt.wat
   $ cat relop_testop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $i32relop
       

--- a/test/opt/return.t
+++ b/test/opt/return.t
@@ -2,9 +2,7 @@ return instructions:
   $ owi opt return.wat > return.opt.wat
   $ cat return.opt.wat
   (module
-    
     (type (sub final  (func (result i32))))
-    
     (type (sub final  (func)))
     (table $tab 1 1 (ref null func))
     (func $return (result i32)

--- a/test/opt/select.t
+++ b/test/opt/select.t
@@ -2,7 +2,6 @@ select instruction:
   $ owi opt select.wat > select.opt.wat
   $ cat select.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start
       

--- a/test/opt/tee.t
+++ b/test/opt/tee.t
@@ -2,7 +2,6 @@ set get tee simplification:
   $ owi opt tee.wat > tee.opt.wat
   $ cat tee.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $start (local $x i32)
       i32.const 41

--- a/test/opt/trunc.t
+++ b/test/opt/trunc.t
@@ -2,7 +2,6 @@
   $ owi opt trunc.wat > trunc.opt.wat
   $ cat trunc.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $trunc
       

--- a/test/opt/unop.t
+++ b/test/opt/unop.t
@@ -2,7 +2,6 @@ unop () instructions:
   $ owi opt unop.wat > unop.opt.wat
   $ cat unop.opt.wat
   (module
-    
     (type (sub final  (func)))
     (func $iunop
       

--- a/test/wasm2wat/done.t
+++ b/test/wasm2wat/done.t
@@ -1,8 +1,6 @@
   $ owi wasm2wat done.wasm
   (module
-    
     (type (sub final  (func (param i32) (param i32) (result i32))))
-    
     (type (sub final  (func)))
     (func (param i32) (param i32) (result i32)
       local.get 0

--- a/test/wasm2wat/emit.t
+++ b/test/wasm2wat/emit.t
@@ -2,9 +2,7 @@ test that we can emit to a file:
   $ owi wasm2wat m.wasm --emit-file
   $ cat m.wat
   (module
-    
     (type (sub final  (func (param i32) (param i32) (result i32))))
-    
     (type (sub final  (func)))
     (func (param i32) (param i32) (result i32)
       local.get 0

--- a/test/wasm2wat/locals.t
+++ b/test/wasm2wat/locals.t
@@ -1,8 +1,6 @@
   $ owi wasm2wat locals.wasm
   (module
-    
     (type (sub final  (func (param i32) (param i32) (param i32))))
-    
     (type (sub final  (func)))
     (func (param i32) (param i32) (param i32) (local i32) (local i32)
       local.get 3

--- a/test/wasm2wat/locals_drop.t
+++ b/test/wasm2wat/locals_drop.t
@@ -1,8 +1,6 @@
   $ owi wasm2wat locals_drop.wasm
   (module
-    
     (type (sub final  (func (param i32) (param i32) (param i32))))
-    
     (type (sub final  (func)))
     (func (param i32) (param i32) (param i32) (local i32) (local i32)
       local.get 3

--- a/test/wasm2wat/print.t
+++ b/test/wasm2wat/print.t
@@ -1,9 +1,7 @@
 print symbolic:
   $ owi wasm2wat m.wasm
   (module
-    
     (type (sub final  (func (param i32) (param i32) (result i32))))
-    
     (type (sub final  (func)))
     (func (param i32) (param i32) (result i32)
       local.get 0

--- a/test/wat2wasm/block_type1.t
+++ b/test/wat2wasm/block_type1.t
@@ -1,0 +1,16 @@
+  $ owi wat2wasm block_type1.wat
+  $ owi wasm2wat block_type1.wasm
+  (module
+    (type (sub final  (func)))
+    (type (sub final  (func (param i32) (result i32))))
+    (func
+      i32.const 1
+      (block (param i32) (result i32)
+        i32.const 1
+        i32.add)
+      drop
+    )
+    (start 0)
+  )
+  $ owi sym block_type1.wasm
+  All OK

--- a/test/wat2wasm/block_type1.wat
+++ b/test/wat2wasm/block_type1.wat
@@ -1,0 +1,11 @@
+(module
+  (func
+    i32.const 1
+    (block (param i32) (result i32)
+      i32.const 1
+      i32.add
+    )
+    drop
+  )
+  (start 0)
+)

--- a/test/wat2wasm/block_type2.t
+++ b/test/wat2wasm/block_type2.t
@@ -1,0 +1,26 @@
+  $ owi wat2wasm block_type2.wat
+  $ owi wasm2wat block_type2.wasm
+  (module
+    (type (sub final  (func (result i32))))
+    (type (sub final  (func (param i32) (result i32))))
+    (type (sub final  (func)))
+    (func (result i32) (local i32)
+      i32.const 0
+      local.tee 0
+      (loop (param i32) (result i32)
+        i32.const 1
+        i32.add
+        local.tee 0
+        local.get 0
+        i32.const 10
+        i32.le_s
+        br_if 0)
+    )
+    (func
+      call 0
+      drop
+    )
+    (start 1)
+  )
+  $ owi sym block_type2.wasm
+  All OK

--- a/test/wat2wasm/block_type2.wat
+++ b/test/wat2wasm/block_type2.wat
@@ -1,0 +1,21 @@
+(module
+  (func (result i32)
+    (local i32)
+    i32.const 0
+    local.tee 0
+    (loop (param i32) (result i32)
+      i32.const 1
+      i32.add
+      local.tee 0
+      local.get 0
+      i32.const 10
+      i32.le_s
+      br_if 0
+    )
+  )
+  (func
+    call 0
+    drop
+  )
+  (start 1)
+)

--- a/test/wat2wasm/call_indirect.t
+++ b/test/wat2wasm/call_indirect.t
@@ -37,9 +37,7 @@
   stack        : [  ]
   $ owi wasm2wat call_indirect.wasm
   (module
-    
     (type (sub final  (func (param i64) (result i64))))
-    
     (type (sub final  (func)))
     (table 1 10 (ref null func))
     (func (param i64) (result i64)

--- a/test/wat2wasm/cmd_conc.t
+++ b/test/wat2wasm/cmd_conc.t
@@ -9,9 +9,7 @@
   $ owi wasm2wat symbolic.wasm
   (module
     (import "symbolic" "i32_symbol" (func  (result i32)))
-    
     (type (sub final  (func (result i32))))
-    
     (type (sub final  (func)))
     (func (local i32)
       call 0

--- a/test/wat2wasm/cmd_sym.t
+++ b/test/wat2wasm/cmd_sym.t
@@ -9,9 +9,7 @@
   $ owi wasm2wat symbolic.wasm
   (module
     (import "symbolic" "i32_symbol" (func  (result i32)))
-    
     (type (sub final  (func (result i32))))
-    
     (type (sub final  (func)))
     (func (local i32)
       call 0

--- a/test/wat2wasm/dune
+++ b/test/wat2wasm/dune
@@ -2,6 +2,8 @@
  (deps
   %{bin:owi}
   bad.ext
+  block_type1.wat
+  block_type2.wat
   call_indirect.wat
   func.wat
   globals.wat

--- a/test/wat2wasm/func.t
+++ b/test/wat2wasm/func.t
@@ -26,9 +26,7 @@
   stack        : [  ]
   $ owi wasm2wat func.wasm
   (module
-    
     (type (sub final  (func (param f32) (result f32))))
-    
     (type (sub final  (func)))
     (func (param f32) (result f32) (local f32)
       f32.const 2.019_999_980_926_513_7

--- a/test/wat2wasm/globals.t
+++ b/test/wat2wasm/globals.t
@@ -22,7 +22,6 @@
   stack        : [  ]
   $ owi wasm2wat globals.wasm
   (module
-    
     (type (sub final  (func)))
     (global i32 i32.const 42)
     (global (mut i64) i64.const 2)

--- a/test/wat2wasm/loop.t
+++ b/test/wat2wasm/loop.t
@@ -112,11 +112,8 @@
   stack        : [  ]
   $ owi wasm2wat loop.wasm
   (module
-    
     (type (sub final  (func (param i32) (result i64))))
-    
     (type (sub final  (func (result i64))))
-    
     (type (sub final  (func)))
     (func (param i32) (result i64) (local i32)
       i32.const 0

--- a/test/wat2wasm/loop.t
+++ b/test/wat2wasm/loop.t
@@ -115,6 +115,8 @@
     
     (type (sub final  (func (param i32) (result i64))))
     
+    (type (sub final  (func (result i64))))
+    
     (type (sub final  (func)))
     (func (param i32) (result i64) (local i32)
       i32.const 0

--- a/test/wat2wasm/mem.t
+++ b/test/wat2wasm/mem.t
@@ -2,15 +2,10 @@
   $ owi run mem.wasm
   $ owi wasm2wat mem.wasm
   (module
-    
     (type (sub final  (func)))
-    
     (type (sub final  (func (param i32) (param i32))))
-    
     (type (sub final  (func (param i32) (param i64))))
-    
     (type (sub final  (func (param i32) (param f32))))
-    
     (type (sub final  (func (param i32) (param f64))))
     (memory 1)
     (func

--- a/test/wat2wasm/rec.t
+++ b/test/wat2wasm/rec.t
@@ -2,9 +2,7 @@
   $ owi run rec.wasm
   $ owi wasm2wat rec.wasm
   (module
-    
     (type (sub final  (func (param i32) (result i32))))
-    
     (type (sub final  (func)))
     (memory 1)
     (func (param i32) (result i32)


### PR DESCRIPTION
In `binary_encoder.ml`, we acquiesce block types should not have index. These indices are removed by function `bt_some_to_raw` in the rewriting phase, which checks inline types' correspondence with the type section.

```ocaml
let write_block_type buf (typ : binary block_type option) =
  match typ with
  | None | Some (Bt_raw (None, ([], []))) -> Buffer.add_char buf '\x40'
  | Some (Bt_raw (None, ([], [ vt ]))) -> write_valtype buf vt
  | Some (Bt_raw (None, (pt, _))) -> write_paramtype buf pt
  (* TODO: memo
     will this pattern matching be enough with the use of the new modul.types field?
  *)
  | _ -> assert false (* TODO: same, new pattern matching cases ? *)
```

```ocaml
 let bt_some_to_raw : text block_type -> binary block_type Result.t = function
    | Bt_ind ind -> begin
      let+ v = get (`Unknown_type ind) modul.typ ind in
      match Indexed.get v with
      | Def_func_t t' ->
        let idx = Indexed.get_index v in
        Bt_raw (Some (Raw idx), t')
      | _ -> assert false
    end
    | Bt_raw (type_use, t) -> (
      let* t = Binary_types.convert_func_type None t in
      match type_use with
      | None -> Ok (Bt_raw (None, t))
      | Some ind ->
        (* we check that the explicit type match the type_use, we have to remove parameters names to do so *)
        let* t' =
          let+ v = get (`Unknown_type ind) modul.typ ind in
          match Indexed.get v with Def_func_t t' -> t' | _ -> assert false
        in
        let ok = Types.func_type_eq t t' in
        if not ok then Error `Inline_function_type else Ok (Bt_raw (None, t)) )
```

This would make the encoding of inline function-like block types invalid. For example :

```shell-session
$ cat block_type.wat
(module
  (func
    i32.const 1
    (block (param i32) (result i32)
      i32.const 1
      i32.add
    )
    drop
  )
  (start 0)
)
$ owi wat2wasm block_type.wat
$ owi wasm2wat block_type.wasm
owi: internal error, uncaught exception:
     Invalid_argument("index out of bounds")
```

Here, `block (param i32) (result i32)` is encoded as `0x02` (for `block`) `0x01 0x7F` (for `param i32`, but I think it should be `0x7F` for representing the inline value type `i32`). And in reality, the first `0x01` would be parsed as type index, and the second `0x7F` parsed as the instruction `i64.div_s`, making arraying indexing out of bounds.

In contrast, function types are added in the grouping phase by `declare_func_type`, and rewrited in the rewriting phase by `rewrite_block_type`, to assign them a type index. I think we should do the same thing to inline block types.

(In the reference interpreter, block types are also added to the types section :

```shell-session
$ cat block_type.wat
(module
  (func
    i32.const 1
    (loop (param i32) (result i32)
      i32.const 1
      i32.add
    )
    drop
  )
  (start 0)
)
$ ./wasm block_type.wat -o block_type.wasm
$ ./wasm block_type.wasm -o block_type.ref.wat
$ cat block_type.ref.wat 
(module
  (type $0 (func))
  (type $1 (func (param i32) (result i32)))
  (func $0
    (type 0)
    (i32.const 1)
    (loop (type 1) (i32.const 1) (i32.add))
    (drop)
  )
  (start 0)
)
```
)
