### PR TITLE
small optimisation of the lazy memory model

### DIFF
--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -2,38 +2,39 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-module Value = Symbolic_value
-module Expr = Smtml.Expr
-module Ty = Smtml.Ty
-open Expr
-
 let page_size = Symbolic_value.const_i32 65_536l
 
+module Map = Map.Make (struct
+  include Int32
+
+  (* TODO: define this in Int32 directly? *)
+  let compare i1 i2 = compare (Int32.to_int i1) (Int32.to_int i2)
+end)
+
 type t =
-  { mutable data : (Int32.t, Value.int32) Hashtbl.t option
-  ; parent : t option
-  ; mutable size : Value.int32
-  ; chunks : (Int32.t, Value.int32) Hashtbl.t
+  { mutable data : Symbolic_value.int32 Map.t
+  ; mutable size : Symbolic_value.int32
+  ; chunks : (Int32.t, Symbolic_value.int32) Hashtbl.t
   }
 
 let create size =
-  { data = None
-  ; parent = None
-  ; size = Value.const_i32 size
+  { data = Map.empty
+  ; size = Symbolic_value.const_i32 size
   ; chunks = Hashtbl.create 16
   }
 
-let i32 v = match view v with Val (Num (I32 i)) -> i | _ -> assert false
+let i32 v =
+  match Smtml.Expr.view v with Val (Num (I32 i)) -> i | _ -> assert false
 
 let grow m delta =
-  let old_size = Value.I32.mul m.size page_size in
-  let new_size = Value.I32.(div (add old_size delta) page_size) in
+  let old_size = Symbolic_value.I32.mul m.size page_size in
+  let new_size = Symbolic_value.I32.(div (add old_size delta) page_size) in
   m.size <-
-    Value.Bool.select_expr
-      (Value.I32.gt new_size m.size)
+    Symbolic_value.Bool.select_expr
+      (Symbolic_value.I32.gt new_size m.size)
       ~if_true:new_size ~if_false:m.size
 
-let size { size; _ } = Value.I32.mul size page_size
+let size { size; _ } = Symbolic_value.I32.mul size page_size
 
 let size_in_pages { size; _ } = size
 
@@ -41,13 +42,7 @@ let fill _ = assert false
 
 let blit _ = assert false
 
-let replace m k v =
-  match m.data with
-  | None ->
-    let tbl = Hashtbl.create 16 in
-    Hashtbl.add tbl k v;
-    m.data <- Some tbl
-  | Some tbl -> Hashtbl.replace tbl k v
+let replace m k v = m.data <- Map.add k v m.data
 
 let blit_string m str ~src ~dst ~len =
   (* This function is only used in memory init so everything will be concrete *)
@@ -57,63 +52,60 @@ let blit_string m str ~src ~dst ~len =
   let dst = Int32.to_int @@ i32 dst in
   let len = Int32.to_int @@ i32 len in
   if src < 0 || dst < 0 || len < 0 || src + len > str_len || dst + len > mem_len
-  then Value.Bool.const true
+  then Symbolic_value.Bool.const true
   else begin
     for i = 0 to len - 1 do
       let byte = Char.code @@ String.get str (src + i) in
       let dst = Int32.of_int (dst + i) in
-      replace m dst (make (Val (Num (I8 byte))))
+      replace m dst (Smtml.Expr.make (Val (Num (I8 byte))))
     done;
-    Value.Bool.const false
+    Symbolic_value.Bool.const false
   end
 
-let clone m =
-  let parent = if Option.is_none m.data then m.parent else Some m in
-  { data = None
-  ; parent
-  ; size = m.size
-  ; chunks = Hashtbl.copy m.chunks (* TODO: we can make this lazy as well *)
-  }
+let clone { data; chunks; size } =
+  (* Caution, it is tempting not to rebuild the record here, but...
+       it must be! otherwise the mutable data points to the same location *)
+  (* TODO: we can make this lazy as well *)
+  let chunks = Hashtbl.copy chunks in
+  { data; chunks; size }
 
-let rec load_byte { parent; data; _ } a =
-  let v =
-    match data with None -> None | Some data -> Hashtbl.find_opt data a
-  in
-  match v with
+let load_byte { data; _ } a =
+  match Map.find_opt a data with
+  | None -> Smtml.Expr.make (Val (Num (I8 0)))
   | Some v -> v
-  | None -> (
-    match parent with
-    | None -> make (Val (Num (I8 0)))
-    | Some parent -> load_byte parent a )
 
 (* TODO: don't rebuild so many values it generates unecessary hc lookups *)
 let merge_extracts (e1, h, m1) (e2, m2, l) =
-  let ty = Expr.ty e1 in
-  if m1 = m2 && Expr.equal e1 e2 then
-    if h - l = Ty.size ty then e1 else make (Extract (e1, h, l))
-  else make (Concat (make (Extract (e1, h, m1)), make (Extract (e2, m2, l))))
+  let ty = Smtml.Expr.ty e1 in
+  if m1 = m2 && Smtml.Expr.equal e1 e2 then
+    if h - l = Smtml.Ty.size ty then e1 else Smtml.Expr.make (Extract (e1, h, l))
+  else
+    Smtml.Expr.make
+      (Concat
+         ( Smtml.Expr.make (Extract (e1, h, m1))
+         , Smtml.Expr.make (Extract (e2, m2, l)) ) )
 
 let concat ~msb ~lsb offset =
   assert (offset > 0 && offset <= 8);
-  match (view msb, view lsb) with
+  match (Smtml.Expr.view msb, Smtml.Expr.view lsb) with
   | Val (Num (I8 i1)), Val (Num (I8 i2)) ->
-    Value.const_i32 Int32.(logor (shl (of_int i1) 8l) (of_int i2))
+    Symbolic_value.const_i32 Int32.(logor (shl (of_int i1) 8l) (of_int i2))
   | Val (Num (I8 i1)), Val (Num (I32 i2)) ->
     let offset = offset * 8 in
     if offset < 32 then
-      Value.const_i32 Int32.(logor (shl (of_int i1) (of_int offset)) i2)
+      Symbolic_value.const_i32 Int32.(logor (shl (of_int i1) (of_int offset)) i2)
     else
       let i1' = Int64.of_int i1 in
       let i2' = Int64.of_int32 i2 in
-      Value.const_i64 Int64.(logor (shl i1' (of_int offset)) i2')
+      Symbolic_value.const_i64 Int64.(logor (shl i1' (of_int offset)) i2')
   | Val (Num (I8 i1)), Val (Num (I64 i2)) ->
     let offset = Int64.of_int (offset * 8) in
-    Value.const_i64 Int64.(logor (shl (of_int i1) offset) i2)
+    Symbolic_value.const_i64 Int64.(logor (shl (of_int i1) offset) i2)
   | Extract (e1, h, m1), Extract (e2, m2, l) ->
     merge_extracts (e1, h, m1) (e2, m2, l)
   | Extract (e1, h, m1), Concat ({ node = Extract (e2, m2, l); _ }, e3) ->
-    make (Concat (merge_extracts (e1, h, m1) (e2, m2, l), e3))
-  | _ -> make (Concat (msb, lsb))
+    Smtml.Expr.make (Concat (merge_extracts (e1, h, m1) (e2, m2, l), e3))
+  | _ -> Smtml.Expr.make (Concat (msb, lsb))
 
 let loadn m a n =
   let rec loop addr size i acc =
@@ -128,46 +120,47 @@ let loadn m a n =
 
 let load_8_s m a =
   let v = loadn m (i32 a) 1 in
-  match view v with
-  | Val (Num (I8 i8)) -> Value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
-  | _ -> cvtop (Ty_bitv 32) (Sign_extend 24) v
+  match Smtml.Expr.view v with
+  | Val (Num (I8 i8)) ->
+    Symbolic_value.const_i32 (Int32.extend_s 8 (Int32.of_int i8))
+  | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Sign_extend 24) v
 
 let load_8_u m a =
   let v = loadn m (i32 a) 1 in
-  match view v with
-  | Val (Num (I8 i)) -> Value.const_i32 (Int32.of_int i)
-  | _ -> cvtop (Ty_bitv 32) (Zero_extend 24) v
+  match Smtml.Expr.view v with
+  | Val (Num (I8 i)) -> Symbolic_value.const_i32 (Int32.of_int i)
+  | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Zero_extend 24) v
 
 let load_16_s m a =
   let v = loadn m (i32 a) 2 in
-  match view v with
-  | Val (Num (I32 i16)) -> Value.const_i32 (Int32.extend_s 16 i16)
-  | _ -> cvtop (Ty_bitv 32) (Sign_extend 16) v
+  match Smtml.Expr.view v with
+  | Val (Num (I32 i16)) -> Symbolic_value.const_i32 (Int32.extend_s 16 i16)
+  | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Sign_extend 16) v
 
 let load_16_u m a =
   let v = loadn m (i32 a) 2 in
-  match view v with
+  match Smtml.Expr.view v with
   | Val (Num (I32 _)) -> v
-  | _ -> cvtop (Ty_bitv 32) (Zero_extend 16) v
+  | _ -> Smtml.Expr.cvtop (Ty_bitv 32) (Zero_extend 16) v
 
 let load_32 m a = loadn m (i32 a) 4
 
 let load_64 m a = loadn m (i32 a) 8
 
 let extract v pos =
-  match view v with
+  match Smtml.Expr.view v with
   | Val (Num (I32 i)) ->
     let i' = Int32.(to_int @@ logand 0xffl @@ shr_s i @@ of_int (pos * 8)) in
-    value (Num (I8 i'))
+    Smtml.Expr.value (Num (I8 i'))
   | Val (Num (I64 i)) ->
     let i' = Int64.(to_int @@ logand 0xffL @@ shr_s i @@ of_int (pos * 8)) in
-    value (Num (I8 i'))
+    Smtml.Expr.value (Num (I8 i'))
   | Cvtop
       ( _
       , (Zero_extend 24 | Sign_extend 24)
       , ({ node = Symbol { ty = Ty_bitv 8; _ }; _ } as sym) ) ->
     sym
-  | _ -> make (Extract (v, pos + 1, pos))
+  | _ -> Smtml.Expr.make (Extract (v, pos + 1, pos))
 
 let storen m ~addr v n =
   let a0 = i32 addr in
@@ -188,19 +181,19 @@ let store_64 m ~addr v = storen m ~addr v 8
 let get_limit_max _m = None (* TODO *)
 
 let check_within_bounds m a =
-  match view a with
-  | Val (Num (I32 _)) -> Ok (Value.Bool.const false, a)
+  match Smtml.Expr.view a with
+  | Val (Num (I32 _)) -> Ok (Symbolic_value.Bool.const false, a)
   | Ptr { base; offset } -> (
     match Hashtbl.find_opt m.chunks base with
     | None -> Error Trap.Memory_leak_use_after_free
     | Some size ->
       let ptr = Int32.add base (i32 offset) in
       let upper_bound =
-        Value.(I32.ge (const_i32 ptr) (I32.add (const_i32 base) size))
+        Symbolic_value.(I32.ge (const_i32 ptr) (I32.add (const_i32 base) size))
       in
       Ok
-        ( Value.Bool.(or_ (const (Int32.lt ptr base)) upper_bound)
-        , Value.const_i32 ptr ) )
+        ( Symbolic_value.Bool.(or_ (const (Int32.lt ptr base)) upper_bound)
+        , Symbolic_value.const_i32 ptr ) )
   | _ -> assert false
 
 let free m base =

--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -10,14 +10,14 @@ open Expr
 let page_size = Symbolic_value.const_i32 65_536l
 
 type t =
-  { data : (Int32.t, Value.int32) Hashtbl.t option ref
+  { mutable data : (Int32.t, Value.int32) Hashtbl.t option
   ; parent : t option
   ; mutable size : Value.int32
   ; chunks : (Int32.t, Value.int32) Hashtbl.t
   }
 
 let create size =
-  { data = ref None
+  { data = None
   ; parent = None
   ; size = Value.const_i32 size
   ; chunks = Hashtbl.create 16
@@ -42,11 +42,11 @@ let fill _ = assert false
 let blit _ = assert false
 
 let replace m k v =
-  match !(m.data) with
+  match m.data with
   | None ->
     let tbl = Hashtbl.create 16 in
     Hashtbl.add tbl k v;
-    m.data := Some tbl
+    m.data <- Some tbl
   | Some tbl -> Hashtbl.replace tbl k v
 
 let blit_string m str ~src ~dst ~len =
@@ -68,8 +68,8 @@ let blit_string m str ~src ~dst ~len =
   end
 
 let clone m =
-  let parent = if Option.is_none !(m.data) then m.parent else Some m in
-  { data = ref None
+  let parent = if Option.is_none m.data then m.parent else Some m in
+  { data = None
   ; parent
   ; size = m.size
   ; chunks = Hashtbl.copy m.chunks (* TODO: we can make this lazy as well *)
@@ -77,7 +77,7 @@ let clone m =
 
 let rec load_byte { parent; data; _ } a =
   let v =
-    match !data with None -> None | Some data -> Hashtbl.find_opt data a
+    match data with None -> None | Some data -> Hashtbl.find_opt data a
   in
   match v with
   | Some v -> v

--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -64,7 +64,7 @@ let clone { data; chunks; size } =
        it must be! otherwise the mutable data points to the same location *)
   { data; chunks; size }
 
-let load_byte { data; _ } a =
+let load_byte a { data; _ } =
   match Map.find_opt a data with
   | None -> Smtml.Expr.make (Val (Num (I8 0)))
   | Some v -> v
@@ -107,10 +107,10 @@ let loadn m a n =
     if i = size then acc
     else
       let addr' = Int32.(add addr (of_int i)) in
-      let byte = load_byte m addr' in
+      let byte = load_byte addr' m in
       loop addr size (i + 1) (concat i ~msb:byte ~lsb:acc)
   in
-  let v0 = load_byte m a in
+  let v0 = load_byte a m in
   loop a n 1 v0
 
 let load_8_s m a =

--- a/src/symbolic/symbolic_memory.ml
+++ b/src/symbolic/symbolic_memory.ml
@@ -199,8 +199,7 @@ let free m base =
   end
 
 let realloc m base size =
-  let chunks = Map.remove base m.chunks in
-  let chunks = Map.add base size chunks in
+  let chunks = Map.add base size m.chunks in
   m.chunks <- chunks
 
 module ITbl = Hashtbl.Make (struct

--- a/src/symbolic/symbolic_memory_concretizing.ml
+++ b/src/symbolic/symbolic_memory_concretizing.ml
@@ -2,17 +2,17 @@ module Backend = struct
   type address = Int32.t
 
   type t =
-    { data : (address, Symbolic_value.int32) Hashtbl.t option ref
+    { mutable data : (address, Symbolic_value.int32) Hashtbl.t option
     ; parent : t option
     ; chunks : (address, Symbolic_value.int32) Hashtbl.t
     }
 
-  let make () = { data = ref None; parent = None; chunks = Hashtbl.create 16 }
+  let make () = { data = None; parent = None; chunks = Hashtbl.create 16 }
 
   let clone m =
-    let parent = if Option.is_none !(m.data) then m.parent else Some m in
+    let parent = if Option.is_none m.data then m.parent else Some m in
     (* TODO: Make chunk copying lazy *)
-    { data = ref None; parent; chunks = Hashtbl.copy m.chunks }
+    { data = None; parent; chunks = Hashtbl.copy m.chunks }
 
   let address a =
     let open Symbolic_choice_without_memory in
@@ -26,7 +26,7 @@ module Backend = struct
 
   let rec load_byte { parent; data; _ } a =
     let v =
-      match !data with None -> None | Some data -> Hashtbl.find_opt data a
+      match data with None -> None | Some data -> Hashtbl.find_opt data a
     in
     match v with
     | Some v -> v
@@ -97,11 +97,11 @@ module Backend = struct
     | _ -> Smtml.Expr.make (Extract (v, pos + 1, pos))
 
   let replace m k v =
-    match !(m.data) with
+    match m.data with
     | None ->
       let tbl = Hashtbl.create 16 in
       Hashtbl.add tbl k v;
-      m.data := Some tbl
+      m.data <- Some tbl
     | Some tbl -> Hashtbl.replace tbl k v
 
   let storen m a v n =

--- a/src/symbolic/symbolic_memory_concretizing.ml
+++ b/src/symbolic/symbolic_memory_concretizing.ml
@@ -30,7 +30,7 @@ module Backend = struct
 
   let address_i32 a = a
 
-  let load_byte { data; _ } a =
+  let load_byte a { data; _ } =
     match Map.find_opt a data with
     | None -> Smtml.Expr.value (Num (I8 0))
     | Some v -> v
@@ -73,10 +73,10 @@ module Backend = struct
       if i = size then acc
       else
         let addr' = Int32.(add addr (of_int i)) in
-        let byte = load_byte m addr' in
+        let byte = load_byte addr' m in
         loop addr size (i + 1) (concat i ~msb:byte ~lsb:acc)
     in
-    let v0 = load_byte m a in
+    let v0 = load_byte a m in
     loop a n 1 v0
 
   let extract v pos =

--- a/src/symbolic/symbolic_memory_concretizing.ml
+++ b/src/symbolic/symbolic_memory_concretizing.ml
@@ -154,8 +154,7 @@ module Backend = struct
   let realloc m ~ptr ~size =
     let open Symbolic_choice_without_memory in
     let+ base = address ptr in
-    let chunks = Map.remove base m.chunks in
-    let chunks = Map.add base size chunks in
+    let chunks = Map.add base size m.chunks in
     m.chunks <- chunks;
     Smtml.Expr.ptr base (Symbolic_value.const_i32 0l)
 end


### PR DESCRIPTION
This should be an optimization.

I'm not sure if the compiler will properly optimize `{ data : (Int32.t, Value.int32) Hashtbl.t option ref`. It could remove one layer of indirection by "merging" the `option ref` part but I'm not sure about it (we should ask @chambart and @lthls).

The idea is the following:

- instead of creating an empty Hashtbl, we use an option;
- we create the table the first time we actually write something;
- then, when cloning, if the option is None, our children will never read our data, so we use our parent as the parent of the new children (instead of ourself, that is, the grand-parent of the children will actually be its parent)

When traversing the list of parents, this allows to switch from:

Empty -> NonEmptyA -> NonEmptyB -> Empty -> Empty -> NonEmptyC -> Empty -> NonEmptyD

To:

Empty -> NonEmptyA -> NonEmptyB -> NonEmptyC -> NonEmptyD

The invariant is that only the youngest and the oldest element of the list can be empty. Said otherwise, when looking at the whole tree, only the root node and the leaves may be empty. This should reduce allocation and allow to have less element to traverse and try in the list.

cc @filipeom 

(I would like to benchmark this on Test-Comp but also running it in B-Tree would be probably more interesting, but Idk how to run this one..)