### PR TITLE
Add btree dataset submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = test/c/collections-c/files
 	url = https://github.com/zapashcanon/Collections-C.git
 	shallow = true
+[submodule "bench/btree"]
+	path = bench/btree
+	url = https://github.com/filipeom/wasm-dataset.git


### PR DESCRIPTION
From the discussion in https://github.com/OCamlPro/owi/pull/433#issuecomment-2331215405

I just randomly dropped the submodule in the `bench` directory. Let me know if you'd prefer it in a specific subdirectory or if you’d like it renamed to something else.