### PR TITLE
Bump smtml to 0.3.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,7 @@
   ocaml_intrinsics
   (prelude (>= 0.3))
   sedlex
-  (smtml (>= 0.2.3))
+  (smtml (>= 0.3.1))
   uutf
   xmlm
   (processor (>= 0.2))

--- a/owi.opam
+++ b/owi.opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml_intrinsics"
   "prelude" {>= "0.3"}
   "sedlex"
-  "smtml" {>= "0.2.3"}
+  "smtml" {>= "0.3.1"}
   "uutf"
   "xmlm"
   "processor" {>= "0.2"}

--- a/src/concolic/concolic_wasm_ffi.ml
+++ b/src/concolic/concolic_wasm_ffi.ml
@@ -26,7 +26,7 @@ module M :
           | Some (Num (I32 n)) -> n
           | _ -> assert false
         in
-        (I32 n, Value.pair n (Expr.mk_symbol sym)) )
+        (I32 n, Value.pair n (Expr.symbol sym)) )
 
   let symbol_i8 () : Value.int32 Choice.t =
     Choice.with_new_symbol (Ty_bitv 32) (fun sym forced_value ->
@@ -37,7 +37,7 @@ module M :
           | _ -> assert false
         in
         let sym_expr =
-          Expr.make (Cvtop (Ty_bitv 32, Zero_extend 24, Expr.mk_symbol sym))
+          Expr.make (Cvtop (Ty_bitv 32, Zero_extend 24, Expr.symbol sym))
         in
         (I32 n, Value.pair n sym_expr) )
 
@@ -50,7 +50,7 @@ module M :
           | _ -> assert false
         in
         let sym_expr =
-          Expr.make (Cvtop (Ty_bitv 32, Zero_extend 24, Expr.mk_symbol sym))
+          Expr.make (Cvtop (Ty_bitv 32, Zero_extend 24, Expr.symbol sym))
         in
         (I32 n, Value.pair n sym_expr) )
 
@@ -62,7 +62,7 @@ module M :
           | Some (Num (I64 n)) -> n
           | _ -> assert false
         in
-        (I64 n, Value.pair n (Expr.mk_symbol sym)) )
+        (I64 n, Value.pair n (Expr.symbol sym)) )
 
   let symbol_f32 () : Value.float32 Choice.t =
     Choice.with_new_symbol (Ty_fp 32) (fun sym forced_value ->
@@ -73,7 +73,7 @@ module M :
           | _ -> assert false
         in
         let n = Float32.of_bits n in
-        (F32 n, Value.pair n (Expr.mk_symbol sym)) )
+        (F32 n, Value.pair n (Expr.symbol sym)) )
 
   let symbol_f64 () : Value.float64 Choice.t =
     Choice.with_new_symbol (Ty_fp 64) (fun sym forced_value ->
@@ -84,7 +84,7 @@ module M :
           | _ -> assert false
         in
         let n = Float64.of_bits n in
-        (F64 n, Value.pair n (Expr.mk_symbol sym)) )
+        (F64 n, Value.pair n (Expr.symbol sym)) )
 
   let assume_i32 (i : Value.int32) : unit Choice.t =
     let c = Value.I32.to_bool i in

--- a/src/symbolic/symbolic_choice.ml
+++ b/src/symbolic/symbolic_choice.ml
@@ -420,7 +420,7 @@ module Make (Thread : Thread.S) = struct
       let sym_name = Fmt.str "choice_i32_%i" num_symbols in
       let sym_type = Smtml.Ty.Ty_bitv 32 in
       let sym = Smtml.Symbol.make sym_type sym_name in
-      let assign = Smtml.Expr.(relop Ty_bool Eq (mk_symbol sym) e) in
+      let assign = Smtml.Expr.(relop Ty_bool Eq (symbol sym) e) in
       (Some assign, sym)
 
   let select_i32 (i : Symbolic_value.int32) =
@@ -440,7 +440,7 @@ module Make (Thread : Thread.S) = struct
           | Smtml.Value.Num (I32 i) -> i
           | _ -> Fmt.failwith "Unreachable: found symbol must be a value"
         in
-        let s = Smtml.Expr.mk_symbol symbol in
+        let s = Smtml.Expr.symbol symbol in
         let this_value_cond =
           let open Smtml.Expr in
           Bitv.I32.(s = v i)


### PR DESCRIPTION
Bumps smtml version to 0.3.1 (latest) which now supports Alt-Ergo and includes the fix for Bitwuzla.

I ran Owi on testcomp with Z3, 4 workers, and 5s timeout and compared the latest (0.3.1) version of smtml to the previous (0.2.5). Results appear the same, only a slight variation in two benchmarks which is expected with a low timeout. Results are summarized below:

### w4_O3_sZ3 smtml.0.3.1 (latest)

Results:

| Nothing | Reached | Timeout | Other | Killed | Total |
|:-------:|:-------:|:-------:|:-----:|:------:|:-----:|
|      0 |    578 |    637 |      0 |      0 |   1215 |

Time stats (in seconds):

| Total | Mean | Median | Min | Max |
|:-----:|:----:|:------:|:---:|:---:|
| 3504.09 | 2.88 | 5.00 | 0.09 | 5.00 |


### w4_O3_sZ3 smtml.0.2.5 (previous)

Results:

| Nothing | Reached | Timeout | Other | Killed | Total |
|:-------:|:-------:|:-------:|:-----:|:------:|:-----:|
|      0 |    580 |    635 |      0 |      0 |   1215 |

Time stats (in seconds):

| Total | Mean | Median | Min | Max |
|:-----:|:----:|:------:|:---:|:---:|
| 3496.49 | 2.88 | 5.00 | 0.09 | 5.00 |

I also ran bitwuzla with the latest version. Results are better and there are no segfaults. There are 6 benchmarks which crash due to a missing operator in Bitwuzla, but this is expected. There are also 15 which are killed but I'm not quite sure why. I'll try to investigate when I get some time. 

### w4_O3_sBitwuzla smtml.0.3.1 (latest)

Results:                                                                                                                                                                      
                                                                                                                                                                              
| Nothing | Reached | Timeout | Other | Killed | Total |                                                                                                                      
|:-------:|:-------:|:-------:|:-----:|:------:|:-----:|                                                                                                                      
|      0 |    522 |    672 |      6 |     15 |   1215 |                                                                                                                       
                                                                                                                                                                              
Time stats (in seconds):                                                                                                                                                      
                                                                                                                                                                              
| Total | Mean | Median | Min | Max |                                                                                                                                         
|:-----:|:----:|:------:|:---:|:---:|                                                  
| 3658.69 | 3.01 | 5.00 | 0.08 | 5.00 |      
