### PR TITLE
libdisplay-info fixes

### DIFF
--- a/src/libc/include/assert.h
+++ b/src/libc/include/assert.h
@@ -1,6 +1,8 @@
 #ifndef ASSERT_H
 #define ASSERT_H
 
+#define static_assert(...)
+
 extern void __assert_fail(const char *__assertion, const char *__file,
                           unsigned int __line, const char *__function);
 #define assert(expr)                                                           \

--- a/src/libc/include/math.h
+++ b/src/libc/include/math.h
@@ -3,5 +3,14 @@
 
 double sin(double);
 double cos(double);
+double floor(double);
+double round(double);
+float powf(float x, float y);
+float floorf(float x);
+double ceil(double x);
+double sqrt(double x);
+float roundf(float x);
+float log2f(float x);
+float sqrtf(float x);
 
 #endif

--- a/src/libc/include/stdio.h
+++ b/src/libc/include/stdio.h
@@ -52,11 +52,15 @@ int scanf(const char *format, ...);
 int fscanf(FILE *stream, const char *format, ...);
 int sscanf(const char *str, const char *format, ...);
 
+int vfprintf(FILE *restrict stream, const char *restrict format, va_list ap);
 int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 
 char getchar(void);
 
 int fflush(FILE *stream);
+int ferror(FILE *stream);
+size_t fread(void *ptr, size_t size, size_t nmemb, FILE *restrict stream);
+
 /*
 int vprintf(const char *format, va_list ap);
 int vfprintf(FILE *stream, const char *format, va_list ap);
@@ -74,12 +78,17 @@ __attribute__((__format__(__scanf__,2,0)));
 
 */
 
+void perror(const char *s);
+
 int fclose(FILE *stream);
 FILE *fopen(const char *path, const char *mode);
 int feof(FILE *stream);
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 char *fgets(char *s, int size, FILE *stream);
+long ftell(FILE *stream);
 
 FILE *popen(const char *command, const char *type);
 int pclose(FILE *stream);
+
+FILE *open_memstream(char **ptr, size_t *sizeloc);
 #endif

--- a/src/libc/include/unistd.h
+++ b/src/libc/include/unistd.h
@@ -10,5 +10,6 @@ extern char *optarg;
 /* int open(const char* pathname,int flags, ...); */
 int close(int fd);
 ssize_t read(int fd, void *buf, size_t len) __attribute__ ((weak));;
+int getopt(int argc, char *argv[], const char *optstring);
 
 #endif

--- a/src/libc/src/math.c
+++ b/src/libc/src/math.c
@@ -3,3 +3,12 @@
 // TODO: External to OWI
 double sin(double x) { return x; }
 double cos(double x) { return x; }
+double floor(double x) { return x; }
+double round(double x) { return x; }
+float powf(float x, float y) { return x; }
+float floorf(float x) { return x; }
+double ceil(double x) { return x; }
+double sqrt(double x) { return x; }
+float roundf(float x) { return x; }
+float log2f(float x) { return x; }
+float sqrtf(float x) { return x; }

--- a/src/libc/src/stdio.c
+++ b/src/libc/src/stdio.c
@@ -25,6 +25,12 @@ int fscanf(FILE *stream, const char *format, ...) { return 0; }
 int sscanf(const char *str, const char *format, ...) { return 0; }
 
 int fflush(FILE *stream) { return 0; }
+int ferror(FILE *stream) { return 0; }
+size_t fread(void *ptr, size_t size, size_t nmemb, FILE *restrict stream) {
+  return 0;
+}
+
+void perror(const char *s) {}
 
 int fclose(FILE *stream) { return 0; }
 FILE *fopen(const char *path, const char *mode) { return 0; }
@@ -33,10 +39,19 @@ size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream) {
   return 0;
 }
 char *fgets(char *s, int size, FILE *stream) { return 0; }
+long ftell(FILE *stream) { return 0; }
 
 FILE *popen(const char *command, const char *type) { return 0; }
 int pclose(FILE *stream) { return 0; }
 
+int vfprintf(FILE *restrict stream, const char *restrict format, va_list ap) {
+  return 0;
+}
 int vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return 0;
+}
+
+FILE memstream = {0};
+FILE *open_memstream(char **ptr, size_t *sizeloc) {
+  return &memstream;
 }

--- a/src/libc/src/stdio.c
+++ b/src/libc/src/stdio.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+FILE *stdin = &(FILE){0};
+
 int puts(const char *str) { return 0; }
 
 int fputs(const char *s, FILE *stream) { return 0; }

--- a/src/libc/src/unistd.c
+++ b/src/libc/src/unistd.c
@@ -8,3 +8,5 @@ char *optarg = NULL;
 int close(int fd) { return 0; }
 ssize_t read(int fd, void *buf, size_t len) { return 0; }
 int getpid(void) { return 0; }
+
+int getopt(int argc, char *argv[], const char *optstring) { return -1; }


### PR DESCRIPTION
A bunch of fixes to make owi work with [libdisplay-info](https://gitlab.freedesktop.org/emersion/libdisplay-info).

Test with:

    owi c -I include/ *.c di-edid-decode/*.c

It reached the `owi_assert(0)` in the patch below after 27 minutes of execution time.

<details>

<summary>libdisplay-info patch</summary>

```diff
diff --git a/di-edid-decode/main.c b/di-edid-decode/main.c
index bb3d9e7e0999..78d3265548a4 100644
--- a/di-edid-decode/main.c
+++ b/di-edid-decode/main.c
@@ -3,20 +3,22 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
+//#include <getopt.h>
 
 #include <libdisplay-info/displayid.h>
 #include <libdisplay-info/edid.h>
 #include <libdisplay-info/info.h>
 
+#include <owi.h>
+
 #include "di-edid-decode.h"
 
 struct uncommon_features uncommon_features = {0};
 
-static const struct option long_options[] = {
+/*static const struct option long_options[] = {
 	{ "help", no_argument, 0, 'h' },
 	{ 0, 0, 0, 0 }
-};
+};*/
 
 static void usage(void)
 {
@@ -95,7 +97,8 @@ main(int argc, char *argv[])
 	in = stdin;
 	while (1) {
 		int option_index = 0;
-		opt = getopt_long(argc, argv, "h", long_options, &option_index);
+		//opt = getopt_long(argc, argv, "h", long_options, &option_index);
+		opt = getopt(argc, argv, "h");
 		if (opt == -1)
 			break;
 
@@ -117,7 +120,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	while (!feof(in)) {
+	/*while (!feof(in)) {
 		size += fread(&raw[size], 1, sizeof(raw) - size, in);
 		if (ferror(in)) {
 			perror("fread failed");
@@ -128,7 +131,12 @@ main(int argc, char *argv[])
 		}
 	}
 
-	fclose(in);
+	fclose(in);*/
+
+	size = 128;
+	for (size_t i = 0; i < size; i++) {
+		raw[i] = owi_char();
+	}
 
 	info = di_info_parse_edid(raw, size);
 	if (!info) {
diff --git a/edid.c b/edid.c
index 2383fa91e9f2..716d46f1ff41 100644
--- a/edid.c
+++ b/edid.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <owi.h>
+
 #include "bits.h"
 #include "dmt.h"
 #include "edid.h"
@@ -337,9 +339,9 @@ parse_standard_timing(struct di_edid *edid,
 		return true;
 	}
 	if (data[0] == 0x00) {
-		add_failure_until(edid, 4,
+		/*add_failure_until(edid, 4,
 				  "Use 0x0101 as the invalid Standard Timings code, not 0x%02x%02x.",
-				  data[0], data[1]);
+				  data[0], data[1]);*/
 		return true;
 	}
 
@@ -1275,6 +1277,8 @@ _di_edid_parse(const void *data, size_t size, FILE *failure_msg_file)
 		}
 	}
 
+	owi_assert(0);
+
 	for (i = 0; i < EDID_BYTE_DESCRIPTOR_COUNT; i++) {
 		byte_desc_data = (const uint8_t *) data
 			       + 0x36 + i * EDID_BYTE_DESCRIPTOR_SIZE;
```

</details>

I also had to add `#define __ASSERT_FUNCTION NULL` otherwise it would fail compilation because it's undefined.