### PR TITLE
Feature: Enable OWI fuzzer.ml to save generated WASM modules to local dir

### DIFF
--- a/test/fuzz/fuzzer.ml
+++ b/test/fuzz/fuzzer.ml
@@ -4,6 +4,11 @@ let timeout_count = ref 0
 
 let global_count = ref 0
 
+let write_module filename m = 
+  let oc = open_out filename in
+  Fmt.pf (Format.formatter_of_out_channel oc) "%a@." Owi.Text.pp_modul m;
+  close_out oc
+
 let compare (module I1 : Interprets.INTERPRET)
   (module I2 : Interprets.INTERPRET) m =
   if Param.debug then begin
@@ -69,6 +74,20 @@ let compare (module I1 : Interprets.INTERPRET)
 
 let check (module I1 : Interprets.INTERPRET) (module I2 : Interprets.INTERPRET)
   m =
+  (* Save the generated module *)
+  if Param.save_modules then (
+    (* Create output directory if it doesn't exist *)
+    if not (Sys.file_exists Param.output_dir) then
+      Unix.mkdir Param.output_dir 0o755;
+
+    let filename = Printf.sprintf "%s/gen_do_module_%d.wat" 
+      Param.output_dir !global_count in
+    write_module filename m;
+
+    if Param.debug then 
+      Fmt.epr "Saved module to %s@\n" filename;
+  );
+
   compare (module I1) (module I2) m
 
 let add_test name gen (module I1 : Interprets.INTERPRET)

--- a/test/fuzz/param.ml
+++ b/test/fuzz/param.ml
@@ -15,6 +15,6 @@ let allow_partial_timeout = true
 
 let max_time_execution = 0.01 (* seconds *)
 
-let save_modules = true (* Set to false to disable saving modules *)
+let save_modules = false (* Set to 'true' enable saving modules *)
 
-let output_dir = "generated_modules" (* Directory to save modules *)
+let output_dir = Fpath.v "generated_modules" (* Directory to save modules *)

--- a/test/fuzz/param.ml
+++ b/test/fuzz/param.ml
@@ -14,3 +14,7 @@ let initial_fuel = 100
 let allow_partial_timeout = true
 
 let max_time_execution = 0.01 (* seconds *)
+
+let save_modules = true (* Set to false to disable saving modules *)
+
+let output_dir = "generated_modules" (* Directory to save modules *)


### PR DESCRIPTION
Generated modules will be saved in WebAssembly text format (.wat) in the output directory `generated_modules`.

- fuzz/param.ml contains a flag `save_modules` that is set to 'false' by default  ('true to enable)
- Each module will be named gen_do_module_N.wat where N is the incremental counter from global_count.
- Generated modules are valid WebAssembly modules since they're generated using the type-aware generators in gen.ml
- Modules can be converted to binary format using wat2wasm and run directly using `owi run`

Modules contain random, but valid :

- Functions
- Instructions
- Memory operations
- Global variables
- Type definitions

The generated modules are random but valid WebAssembly programs, so their behavior will vary. We can add additional parameters in param.ml to control aspects of generation like module complexity, instruction types, etc.