### PR TITLE
use pin stanza in dune-project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _coverage
 owi-out
 results-*
 a.out.wasm
+owi.install

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,16 @@
 (source
  (github ocamlpro/owi))
 
+(pin
+  (package (name crowbar))
+  (url "git+https://github.com/stedolan/crowbar#1ab53fb088d56578b48301bc4cfb859331a10d78"))
+(pin
+  (package (name alt-ergo-lib))
+  (url "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"))
+(pin
+  (package (name alt-ergo))
+  (url "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"))
+
 (package
  (name owi)
  (synopsis

--- a/owi.opam
+++ b/owi.opam
@@ -74,8 +74,3 @@ depexts: [
   ["llvm" "lld"]  {os-family = "debian"}
   ["llvm"]  {os-family = "homebrew"}
 ]
-pin-depends: [
-  [ "crowbar.dev" "git+https://github.com/stedolan/crowbar#1ab53fb088d56578b48301bc4cfb859331a10d78"]
-  ["alt-ergo-lib.2.6.0" "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"]
-  ["alt-ergo.2.6.0" "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"]
-]

--- a/owi.opam.template
+++ b/owi.opam.template
@@ -3,8 +3,3 @@ depexts: [
   ["llvm" "lld"]  {os-family = "debian"}
   ["llvm"]  {os-family = "homebrew"}
 ]
-pin-depends: [
-  [ "crowbar.dev" "git+https://github.com/stedolan/crowbar#1ab53fb088d56578b48301bc4cfb859331a10d78"]
-  ["alt-ergo-lib.2.6.0" "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"]
-  ["alt-ergo.2.6.0" "git+https://github.com/OCamlPro/alt-ergo.git#7ee96296a5de9588a4d585b3b8abec35f4755425"]
-]


### PR DESCRIPTION
We can now pin packages with dune, hopefully this reduce the need for *.opam.template files for many packages.

I also added the owi.install file to .gitignore (generated by `dune build -p owi @install`)