### PR TITLE
ssl

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -87,5 +87,6 @@
   (lwt :with-dev-setup)
   (cohttp :with-dev-setup)
   (cohttp-lwt-unix :with-dev-setup)
+  (lwt_ssl :with-dev-setup)
   )
  (sites (share c_files) (share rust_files)))

--- a/owi.opam
+++ b/owi.opam
@@ -52,6 +52,7 @@ depends: [
   "lwt" {with-dev-setup}
   "cohttp" {with-dev-setup}
   "cohttp-lwt-unix" {with-dev-setup}
+  "lwt_ssl" {with-dev-setup}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
needed for the zulip notification at the end of benchmarks