### PR TITLE
Use `wait4` and measure memory usage of children in the runner

### DIFF
--- a/bench/report/run.ml
+++ b/bench/report/run.ml
@@ -20,6 +20,8 @@ let utime run = (rusage run).utime
 
 let stime run = (rusage run).stime
 
+let maxrss run = (rusage run).maxrss
+
 let is_reached { res; _ } = Run_result.is_reached res
 
 let is_timeout { res; _ } = Run_result.is_timeout res

--- a/bench/report/run.mli
+++ b/bench/report/run.mli
@@ -10,6 +10,8 @@ val utime : t -> float
 
 val stime : t -> float
 
+val maxrss : t -> int64
+
 val is_nothing : t -> bool
 
 val is_killed : t -> bool

--- a/bench/report/run_result.ml
+++ b/bench/report/run_result.ml
@@ -17,15 +17,10 @@ let is_timeout = function Timeout _ -> true | _ -> false
 let is_other = function Other _ -> true | _ -> false
 
 let pp fmt = function
-  | Timeout t ->
-    Format.fprintf fmt "Timeout in %g %g %g" t.clock t.utime t.stime
-  | Nothing t ->
-    Format.fprintf fmt "Nothing in %g %g %g" t.clock t.utime t.stime
-  | Reached t ->
-    Format.fprintf fmt "Reached in %g %g %g" t.clock t.utime t.stime
-  | Other (t, code) ->
-    Format.fprintf fmt "Other %i in %g %g %g" code t.clock t.utime t.stime
+  | Timeout t -> Format.fprintf fmt "Timeout in %a" Rusage.pp t
+  | Nothing t -> Format.fprintf fmt "Nothing in %a" Rusage.pp t
+  | Reached t -> Format.fprintf fmt "Reached in %a" Rusage.pp t
+  | Other (t, code) -> Format.fprintf fmt "Other %i in %a" code Rusage.pp t
   | Signaled (t, code) ->
-    Format.fprintf fmt "Signaled %i in %g %g %g" code t.clock t.utime t.stime
-  | Stopped (t, code) ->
-    Format.fprintf fmt "Stopped %i in %g %g %g" code t.clock t.utime t.stime
+    Format.fprintf fmt "Signaled %i in %a" code Rusage.pp t
+  | Stopped (t, code) -> Format.fprintf fmt "Stopped %i in %a" code Rusage.pp t

--- a/bench/report/runs.mli
+++ b/bench/report/runs.mli
@@ -46,13 +46,19 @@ val sum_stime : t -> float
 
 val mean_stime : t -> float
 
+val sum_maxrss : t -> int64
+
+val mean_maxrss : t -> float
+
 val to_distribution : max_time:int -> t -> float list
 
-val pp_quick_results : Format.formatter -> t -> unit
+val pp_quick_results : t Fmt.t
 
-val pp_table_results : Format.formatter -> t -> unit
+val pp_table_results : t Fmt.t
 
-val pp_table_statistics : Format.formatter -> t -> unit
+val pp_table_statistics : t Fmt.t
+
+val pp_table_memory : t Fmt.t
 
 val map : (Run.t -> 'a) -> t -> 'a list
 

--- a/bench/report/rusage.ml
+++ b/bench/report/rusage.ml
@@ -2,4 +2,8 @@ type t =
   { clock : float
   ; utime : float
   ; stime : float
+  ; maxrss : int64
   }
+
+let pp fmt { clock; utime; stime; maxrss } =
+  Fmt.pf fmt "%4.2f %4.2f %4.2f %Ld" clock utime stime maxrss

--- a/bench/report/rusage.mli
+++ b/bench/report/rusage.mli
@@ -2,4 +2,7 @@ type t =
   { clock : float
   ; utime : float
   ; stime : float
+  ; maxrss : int64
   }
+
+val pp : t Fmt.t

--- a/bench/report/rusage.mli
+++ b/bench/report/rusage.mli
@@ -1,8 +1,8 @@
 type t =
   { clock : float
-  ; utime : float
-  ; stime : float
-  ; maxrss : int64
+  ; utime : float  (** user CPU time used *)
+  ; stime : float  (** system CPU time used *)
+  ; maxrss : int64  (** Maximum resident size (in kilobytes) *)
   }
 
 val pp : t Fmt.t

--- a/bench/testcomp/testcomp.ml
+++ b/bench/testcomp/testcomp.ml
@@ -184,9 +184,13 @@ let notify_finished runs =
        @\n\
        Time stats (in seconds):@\n\
        @\n\
+       %a@\n\
+       @\n\
+       Memory stats (in kilobytes):@\n\
+       @\n\
        %a@."
       reference_name timeout Fpath.pp output_dir Report.Runs.pp_table_results
-      runs Report.Runs.pp_table_statistics runs
+      runs Report.Runs.pp_table_statistics runs Report.Runs.pp_table_memory runs
   in
   (* Notify on `ZULIP_WEBHOOK` *)
   match Bos.OS.Env.var "ZULIP_WEBHOOK" with

--- a/bench/tool/tool.ml
+++ b/bench/tool/tool.ml
@@ -32,95 +32,80 @@ let mk_symbiotic () = Symbiotic
 
 exception Sigchld
 
-let kill_klee_descendants () =
-  let _ = Format.ksprintf Sys.command "pkill klee" in
-  ()
+let wait_pid ~pid ~timeout ~tool ~dst_stderr =
+  let did_timeout = ref false in
+  let start_time = Unix.gettimeofday () in
+  begin
+    try
+      Sys.set_signal Sys.sigchld (Signal_handle (fun (_ : int) -> raise Sigchld));
+      Unix.sleepf timeout;
+      did_timeout := true;
+      (* we kill the process group id (pgid) which should be equal to pid *)
+      Unix.kill (-pid) 9;
+      Sys.set_signal Sys.sigchld Signal_default
+    with Sigchld -> ()
+  end;
+  Sys.set_signal Sys.sigchld Signal_default;
+  let ( waited_pid
+      , status
+      , { ExtUnix.Specific.ru_utime = utime; ru_stime = stime; ru_maxrss = _ } )
+      =
+    ExtUnix.Specific.wait4 [] ~-pid
+  in
+  let end_time = Unix.gettimeofday () in
+  assert (waited_pid = pid);
 
-let wait_pid =
-  let last_utime = ref 0. in
-  let last_stime = ref 0. in
-  fun ~pid ~timeout ~tool ~dst_stderr ->
-    let did_timeout = ref false in
-    let start_time = Unix.gettimeofday () in
-    begin
-      try
-        Sys.set_signal Sys.sigchld
-          (Signal_handle (fun (_ : int) -> raise Sigchld));
-        Unix.sleepf timeout;
-        did_timeout := true;
-        (* we kill the process group id (pgid) which should be equal to pid *)
-        Unix.kill (-pid) 9;
-        Sys.set_signal Sys.sigchld Signal_default
-      with Sigchld -> ()
-    end;
-    Sys.set_signal Sys.sigchld Signal_default;
-    let waited_pid, status = Unix.waitpid [] (-pid) in
-    (* Because symbiotic is leaking klee processes *)
-    kill_klee_descendants ();
-    let end_time = Unix.gettimeofday () in
-    let { Rusage.utime; stime; _ } = Rusage.get Rusage.Children in
-    assert (waited_pid = pid);
+  let clock = end_time -. start_time in
 
-    let utime_diff = utime -. !last_utime in
-    let stime_diff = stime -. !last_stime in
-    last_utime := utime;
-    last_stime := stime;
-    let utime = utime_diff in
-    let stime = stime_diff in
-    let clock = end_time -. start_time in
+  (* Sometimes the clock goes a little bit above the allowed timeout... *)
+  let clock = min clock timeout in
+  let rusage = { Report.Rusage.clock; utime; stime } in
 
-    (* Sometimes the clock goes a little bit above the allowed timeout... *)
-    let clock = min clock timeout in
-    let rusage = { Report.Rusage.clock; utime; stime } in
-
-    if !did_timeout || Float.equal clock timeout then
-      Report.Run_result.Timeout rusage
-    else
-      match status with
-      | WEXITED code -> begin
-        match tool with
-        | Owi _ ->
-          if code = 0 then Nothing rusage
-          else if code = 13 then Reached rusage
-          else Other (rusage, code)
-        | Klee ->
-          if code = 0 then begin
-            let chan = open_in (Fpath.to_string dst_stderr) in
-            let has_found_error = ref false in
-            begin
-              try
-                while true do
-                  let line = input_line chan in
-                  match
-                    String.split_on_char ' ' line
-                    |> List.filter (fun s -> s <> "")
-                  with
-                  | [ "KLEE:"; "ERROR:"; _location; "ASSERTION"; "FAIL:"; "0" ]
-                    ->
-                    has_found_error := true;
-                    raise Exit
-                  | _line -> ()
-                done
-              with End_of_file | Exit -> ()
-            end;
-            close_in chan;
-            if !has_found_error then Reached rusage else Nothing rusage
-          end
-          else Other (rusage, code)
-        | Symbiotic ->
-          if code = 0 then begin
-            match Bos.OS.File.read dst_stderr with
-            | Error (`Msg err) -> failwith err
-            | Ok data -> (
-              let error = Astring.String.find_sub ~sub:"Found ERROR!" data in
-              match error with
-              | Some _ -> Reached rusage
-              | None -> Nothing rusage )
-          end
-          else Other (rusage, code)
-      end
-      | WSIGNALED n -> Signaled (rusage, n)
-      | WSTOPPED n -> Stopped (rusage, n)
+  if !did_timeout || Float.equal clock timeout then
+    Report.Run_result.Timeout rusage
+  else
+    match status with
+    | WEXITED code -> begin
+      match tool with
+      | Owi _ ->
+        if code = 0 then Nothing rusage
+        else if code = 13 then Reached rusage
+        else Other (rusage, code)
+      | Klee ->
+        if code = 0 then begin
+          let chan = open_in (Fpath.to_string dst_stderr) in
+          let has_found_error = ref false in
+          begin
+            try
+              while true do
+                let line = input_line chan in
+                match
+                  String.split_on_char ' ' line
+                  |> List.filter (fun s -> s <> "")
+                with
+                | [ "KLEE:"; "ERROR:"; _location; "ASSERTION"; "FAIL:"; "0" ] ->
+                  has_found_error := true;
+                  raise Exit
+                | _line -> ()
+              done
+            with End_of_file | Exit -> ()
+          end;
+          close_in chan;
+          if !has_found_error then Reached rusage else Nothing rusage
+        end
+        else Other (rusage, code)
+      | Symbiotic ->
+        if code = 0 then begin
+          match Bos.OS.File.read dst_stderr with
+          | Error (`Msg err) -> failwith err
+          | Ok data -> (
+            let error = Astring.String.find_sub ~sub:"Found ERROR!" data in
+            match error with Some _ -> Reached rusage | None -> Nothing rusage )
+        end
+        else Other (rusage, code)
+    end
+    | WSIGNALED n -> Signaled (rusage, n)
+    | WSTOPPED n -> Stopped (rusage, n)
 
 let execvp ~output_dir tool file timeout =
   let output_dir = Fpath.(output_dir / to_short_name tool) |> Fpath.to_string in

--- a/bench/tool/tool.ml
+++ b/bench/tool/tool.ml
@@ -48,8 +48,10 @@ let wait_pid ~pid ~timeout ~tool ~dst_stderr =
   Sys.set_signal Sys.sigchld Signal_default;
   let ( waited_pid
       , status
-      , { ExtUnix.Specific.ru_utime = utime; ru_stime = stime; ru_maxrss = _ } )
-      =
+      , { ExtUnix.Specific.ru_utime = utime
+        ; ru_stime = stime
+        ; ru_maxrss = maxrss
+        } ) =
     ExtUnix.Specific.wait4 [] ~-pid
   in
   let end_time = Unix.gettimeofday () in
@@ -59,7 +61,7 @@ let wait_pid ~pid ~timeout ~tool ~dst_stderr =
 
   (* Sometimes the clock goes a little bit above the allowed timeout... *)
   let clock = min clock timeout in
-  let rusage = { Report.Rusage.clock; utime; stime } in
+  let rusage = { Report.Rusage.clock; utime; stime; maxrss } in
 
   if !did_timeout || Float.equal clock timeout then
     Report.Run_result.Timeout rusage

--- a/dune-project
+++ b/dune-project
@@ -99,7 +99,10 @@ An OCaml library is available to embed WebAssembly modules and import OCaml func
   (cohttp :with-dev-setup)
   (cohttp-lwt-unix :with-dev-setup)
   (crowbar :with-dev-setup)
-  (extunix :with-dev-setup)
+  (extunix
+   (and
+    (>= 0.4.4)
+    :with-dev-setup))
   (gnuplot :with-dev-setup)
   (graphics :with-dev-setup)
   (landmarks-ppx :with-dev-setup)

--- a/owi.opam
+++ b/owi.opam
@@ -49,7 +49,7 @@ depends: [
   "cohttp" {with-dev-setup}
   "cohttp-lwt-unix" {with-dev-setup}
   "crowbar" {with-dev-setup}
-  "extunix" {with-dev-setup}
+  "extunix" {>= "0.4.4" & with-dev-setup}
   "gnuplot" {with-dev-setup}
   "graphics" {with-dev-setup}
   "landmarks-ppx" {with-dev-setup}


### PR DESCRIPTION
Should Close #478 

The PR is not ready yet, I still have to format the code, remove some comments, and I'm going to split this into two commits: one which focuses on introducing `wait4` and replacing the usage of `waitpid` and another which counts and displays `maxrss`. 

Also, I'm benchmarking this locally to see if the results are consistent with main.

But feel free to comment already :) 