### PR TITLE
add `--model-output-format` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 - add event logger
 - add `owi_range` primitive
 - add `owi zig` subcommand
+* add `--model-output-format` option
 
 ## 0.2 - 2024-04-24
 

--- a/example/c/README.md
+++ b/example/c/README.md
@@ -464,6 +464,9 @@ OPTIONS
        -m VAL, --arch=VAL (absent=32)
            data model
 
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
+
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure
 

--- a/example/c/README.md
+++ b/example/c/README.md
@@ -465,7 +465,7 @@ OPTIONS
            data model
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/conc/README.md
+++ b/example/conc/README.md
@@ -27,8 +27,9 @@ Let's see if owi is able to find a value for `x` that lead to an error:
 $ owi conc ./mini.wat
 Trap: unreachable
 Model:
-  (model
-    (symbol_1 (i32.const 6)))
+ model {
+  symbol symbol_1 i32 6
+}
 Reached problem!
 [13]
 ```
@@ -58,6 +59,9 @@ OPTIONS
 
        --fail-on-trap-only
            ignore assertion violations and only report traps
+
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/conc/README.md
+++ b/example/conc/README.md
@@ -61,7 +61,7 @@ OPTIONS
            ignore assertion violations and only report traps
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -157,6 +157,9 @@ OPTIONS
        -m VAL, --arch=VAL (absent=32)
            data model
 
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
+
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure
 

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -158,7 +158,7 @@ OPTIONS
            data model
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -72,6 +72,9 @@ OPTIONS
        -m VAL, --arch=VAL (absent=32)
            data model
 
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
+
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure
 

--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -73,7 +73,7 @@ OPTIONS
            data model
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/sym/README.md
+++ b/example/sym/README.md
@@ -59,6 +59,9 @@ OPTIONS
        --fail-on-trap-only
            ignore assertion violations and only report traps
 
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
+
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure
 

--- a/example/sym/README.md
+++ b/example/sym/README.md
@@ -60,7 +60,7 @@ OPTIONS
            ignore assertion violations and only report traps
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/example/zig/README.md
+++ b/example/zig/README.md
@@ -71,6 +71,9 @@ OPTIONS
        -I VAL
            headers path
 
+       --model-output-format=VAL (absent=scfg)
+           The format of the output model
+
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure
 

--- a/example/zig/README.md
+++ b/example/zig/README.md
@@ -72,7 +72,7 @@ OPTIONS
            headers path
 
        --model-output-format=VAL (absent=scfg)
-           The format of the output model
+            The format of the output model ("json" or "scfg")
 
        --no-assert-failure-expression-printing
            do not display the expression in the assert failure

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -42,7 +42,7 @@ let model_format_conv =
     match String.lowercase_ascii s with
     | "scfg" -> Ok Cmd_utils.Scfg
     | "json" -> Ok Json
-    | _ -> Error (`Msg "Expected \"json\" or \"scfg\" but got %s\n")
+    | _ -> Fmt.error_msg {|Expected "json" or "scfg" but got "%s"|} s
   in
   let pp fmt = function
     | Cmd_utils.Scfg -> Fmt.string fmt "scfg"
@@ -138,7 +138,7 @@ let solver =
     & info [ "solver"; "s" ] ~doc )
 
 let model_output_format =
-  let doc = "The format of the output model (\"json\" or \"scfg\")" in
+  let doc = {| The format of the output model ("json" or "scfg") |} in
   Arg.(value & opt model_format_conv Scfg & info [ "model-output-format" ] ~doc)
 
 let unsafe =

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -124,6 +124,10 @@ let solver =
     & opt solver_conv Smtml.Solver_type.Z3_solver
     & info [ "solver"; "s" ] ~doc )
 
+let model_output_format =
+  let doc = "The format of the output model" in
+  Arg.(value & opt string "scfg" & info [ "model-output-format" ] ~doc)
+
 let unsafe =
   let doc = "skip typechecking pass" in
   Arg.(value & flag & info [ "unsafe"; "u" ] ~doc)
@@ -177,11 +181,12 @@ let cpp_cmd =
   and+ deterministic_result_order
   and+ fail_mode
   and+ solver
-  and+ profile in
+  and+ profile
+  and+ model_output_format in
   Cmd_cpp.cmd ~debug ~arch ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
     ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
-    ~fail_mode ~concolic ~solver ~profile
+    ~fail_mode ~concolic ~solver ~profile ~model_output_format
 
 (* owi c *)
 
@@ -229,11 +234,12 @@ let c_cmd =
        Frama-C's current language feature implementations"
     in
     Arg.(value & flag & info [ "e-acsl" ] ~doc)
-  and+ solver in
+  and+ solver
+  and+ model_output_format in
   Cmd_c.cmd ~debug ~arch ~property ~testcomp ~workspace ~workers ~opt_lvl
     ~includes ~files ~profiling ~unsafe ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
-    ~fail_mode ~concolic ~eacsl ~solver ~profile
+    ~fail_mode ~concolic ~eacsl ~solver ~profile ~model_output_format
 
 (* owi fmt *)
 
@@ -334,11 +340,12 @@ let rust_cmd =
   and+ deterministic_result_order
   and+ fail_mode
   and+ solver
-  and+ profile in
+  and+ profile
+  and+ model_output_format in
   Cmd_rust.cmd ~debug ~arch ~workers ~opt_lvl ~includes ~files ~profiling
     ~unsafe ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
-    ~fail_mode ~concolic ~solver ~profile
+    ~fail_mode ~concolic ~solver ~profile ~model_output_format
 
 (* owi validate *)
 
@@ -393,10 +400,12 @@ let sym_cmd =
   and+ workspace
   and+ solver
   and+ files
-  and+ profile in
+  and+ profile
+  and+ model_output_format in
   Cmd_sym.cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
+    ~model_output_format
 
 (* owi replay *)
 
@@ -445,10 +454,12 @@ let conc_cmd =
   and+ workspace
   and+ solver
   and+ files
-  and+ profile in
+  and+ profile
+  and+ model_output_format in
   Cmd_conc.cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
+    ~model_output_format
 
 (* owi version *)
 
@@ -524,10 +535,12 @@ let zig_cmd =
   and+ deterministic_result_order
   and+ fail_mode
   and+ profile
-  and+ solver in
+  and+ solver
+  and+ model_output_format in
   Cmd_zig.cmd ~debug ~includes ~workers ~files ~profiling ~unsafe ~optimize
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
+    ~model_output_format
 
 (* owi *)
 

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -37,6 +37,19 @@ let path_conv = Arg.conv (Fpath.of_string, Fpath.pp)
 
 let solver_conv = Arg.conv (Smtml.Solver_type.of_string, Smtml.Solver_type.pp)
 
+let model_format_conv =
+  let of_string s =
+    match String.lowercase_ascii s with
+    | "scfg" -> Ok Cmd_utils.Scfg
+    | "json" -> Ok Json
+    | _ -> Error (`Msg "Expected \"json\" or \"scfg\" but got %s\n")
+  in
+  let pp fmt = function
+    | Cmd_utils.Scfg -> Fmt.string fmt "scfg"
+    | Json -> Fmt.string fmt "json"
+  in
+  Arg.conv (of_string, pp)
+
 (* Common options *)
 
 let copts_t = Term.(const [])
@@ -125,8 +138,8 @@ let solver =
     & info [ "solver"; "s" ] ~doc )
 
 let model_output_format =
-  let doc = "The format of the output model" in
-  Arg.(value & opt string "scfg" & info [ "model-output-format" ] ~doc)
+  let doc = "The format of the output model (\"json\" or \"scfg\")" in
+  Arg.(value & opt model_format_conv Scfg & info [ "model-output-format" ] ~doc)
 
 let unsafe =
   let doc = "skip typechecking pass" in

--- a/src/cmd/cmd_c.ml
+++ b/src/cmd/cmd_c.ml
@@ -181,7 +181,7 @@ let metadata ~workspace arch property files : unit Result.t =
 let cmd ~debug ~arch ~property ~testcomp:_ ~workspace ~workers ~opt_lvl
   ~includes ~files ~profiling ~unsafe ~optimize ~no_stop_at_failure ~no_value
   ~no_assert_failure_expression_printing ~deterministic_result_order ~fail_mode
-  ~concolic ~eacsl ~solver ~profile : unit Result.t =
+  ~concolic ~eacsl ~solver ~profile ~model_output_format : unit Result.t =
   let includes = c_files_location @ includes in
   let* (_exists : bool) = OS.Dir.create ~path:true workspace in
   let* files = eacsl_instrument eacsl debug ~includes files in
@@ -193,3 +193,4 @@ let cmd ~debug ~arch ~property ~testcomp:_ ~workspace ~workers ~opt_lvl
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
+    ~model_output_format

--- a/src/cmd/cmd_c.mli
+++ b/src/cmd/cmd_c.mli
@@ -24,4 +24,5 @@ val cmd :
   -> eacsl:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
+  -> model_output_format: string
   -> unit Result.t

--- a/src/cmd/cmd_c.mli
+++ b/src/cmd/cmd_c.mli
@@ -24,5 +24,5 @@ val cmd :
   -> eacsl:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format:string
+  -> model_output_format:Cmd_utils.model_output_format
   -> unit Result.t

--- a/src/cmd/cmd_c.mli
+++ b/src/cmd/cmd_c.mli
@@ -24,5 +24,5 @@ val cmd :
   -> eacsl:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format: string
+  -> model_output_format:string
   -> unit Result.t

--- a/src/cmd/cmd_conc.ml
+++ b/src/cmd/cmd_conc.ml
@@ -492,7 +492,7 @@ let cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers:_
     (* Fmt.pr "Model:@\n  @[<v>%a@]@." *)
     (*   (Concolic_choice.pp_assignments ~no_value) *)
     (*   assignments; *)
-    Fmt.pr "Model:@\n %s" (to_string assignments);
+    Fmt.pr "Model:@\n %s\n" (to_string assignments);
     let* () = testcase assignments in
     Error (`Found_bug 1)
   | Some (`Assert_fail, { assignments; _ }) ->

--- a/src/cmd/cmd_conc.ml
+++ b/src/cmd/cmd_conc.ml
@@ -449,12 +449,11 @@ let cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers:_
   if debug then Log.debug_on := true;
   (* deterministic_result_order implies no_stop_at_failure *)
   (* let no_stop_at_failure = deterministic_result_order || no_stop_at_failure in *)
-  let to_string =
+  let to_string m =
+    let model = assignments_to_model m in
     match model_output_format with
-    | Cmd_utils.Json ->
-      fun m -> assignments_to_model m |> Smtml.Model.to_json_string
-    | Scfg ->
-      fun m -> assignments_to_model m |> Smtml.Model.to_scfg_string ~no_value
+    | Cmd_utils.Json -> Smtml.Model.to_json_string model
+    | Scfg -> Smtml.Model.to_scfg_string ~no_value model
   in
   let* _created_dir = Bos.OS.Dir.create ~path:true ~mode:0o755 workspace in
   let solver = Solver.fresh solver () in

--- a/src/cmd/cmd_conc.mli
+++ b/src/cmd/cmd_conc.mli
@@ -19,5 +19,5 @@ val cmd :
   -> solver:Smtml.Solver_type.t
   -> files:Fpath.t list
   -> profile:Fpath.t option
-  -> model_output_format:string
+  -> model_output_format:Cmd_utils.model_output_format
   -> unit Result.t

--- a/src/cmd/cmd_conc.mli
+++ b/src/cmd/cmd_conc.mli
@@ -19,4 +19,5 @@ val cmd :
   -> solver:Smtml.Solver_type.t
   -> files:Fpath.t list
   -> profile:Fpath.t option
+  -> model_output_format:string
   -> unit Result.t

--- a/src/cmd/cmd_cpp.ml
+++ b/src/cmd/cmd_cpp.ml
@@ -104,7 +104,7 @@ let compile ~includes ~opt_lvl debug (files : Fpath.t list) : Fpath.t Result.t =
 
 let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile :
+  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile ~model_output_format :
   unit Result.t =
   let includes = c_files_location @ includes in
   let* modul = compile ~includes ~opt_lvl debug files in
@@ -113,4 +113,4 @@ let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace:(Fpath.v "owi-out")
-    ~solver ~files ~profile
+    ~solver ~files ~profile ~model_output_format

--- a/src/cmd/cmd_cpp.ml
+++ b/src/cmd/cmd_cpp.ml
@@ -104,8 +104,8 @@ let compile ~includes ~opt_lvl debug (files : Fpath.t list) : Fpath.t Result.t =
 
 let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile ~model_output_format :
-  unit Result.t =
+  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
+  ~model_output_format : unit Result.t =
   let includes = c_files_location @ includes in
   let* modul = compile ~includes ~opt_lvl debug files in
   let files = [ modul ] in

--- a/src/cmd/cmd_cpp.mli
+++ b/src/cmd/cmd_cpp.mli
@@ -20,5 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format: string
+  -> model_output_format:string
   -> unit Result.t

--- a/src/cmd/cmd_cpp.mli
+++ b/src/cmd/cmd_cpp.mli
@@ -20,4 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
+  -> model_output_format: string
   -> unit Result.t

--- a/src/cmd/cmd_cpp.mli
+++ b/src/cmd/cmd_cpp.mli
@@ -20,5 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format:string
+  -> model_output_format:Cmd_utils.model_output_format
   -> unit Result.t

--- a/src/cmd/cmd_rust.ml
+++ b/src/cmd/cmd_rust.ml
@@ -55,12 +55,12 @@ let compile ~includes:_ ~opt_lvl:_ debug (files : Fpath.t list) :
 
 let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile :
-  unit Result.t =
+  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
+  ~model_output_format : unit Result.t =
   let* modul = compile ~includes ~opt_lvl debug files in
   let files = [ modul ] in
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace:(Fpath.v "owi-out")
-    ~solver ~files ~profile
+    ~solver ~files ~profile ~model_output_format

--- a/src/cmd/cmd_rust.mli
+++ b/src/cmd/cmd_rust.mli
@@ -20,5 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format: string
+  -> model_output_format:string
   -> unit Result.t

--- a/src/cmd/cmd_rust.mli
+++ b/src/cmd/cmd_rust.mli
@@ -20,4 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
+  -> model_output_format: string
   -> unit Result.t

--- a/src/cmd/cmd_rust.mli
+++ b/src/cmd/cmd_rust.mli
@@ -20,5 +20,5 @@ val cmd :
   -> concolic:bool
   -> solver:Smtml.Solver_type.t
   -> profile:Fpath.t option
-  -> model_output_format:string
+  -> model_output_format:Cmd_utils.model_output_format
   -> unit Result.t

--- a/src/cmd/cmd_sym.ml
+++ b/src/cmd/cmd_sym.ml
@@ -64,12 +64,9 @@ let cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers
   let res_queue = Wq.make () in
   let path_count = ref 0 in
   let to_string =
-    match String.lowercase_ascii model_output_format with
-    | "json" -> Smtml.Model.to_json_string
-    | "scfg" -> Smtml.Model.to_scfg_string ~no_value
-    | _ ->
-      Fmt.epr "Expected \"json\" or \"scfg\" but got %s\n" model_output_format;
-      assert false
+    match model_output_format with
+    | Cmd_utils.Json -> Smtml.Model.to_json_string
+    | Scfg -> Smtml.Model.to_scfg_string ~no_value
   in
   let callback v =
     let open Symbolic_choice_intf in

--- a/src/cmd/cmd_sym.mli
+++ b/src/cmd/cmd_sym.mli
@@ -25,4 +25,5 @@ val cmd :
   -> solver:Smtml.Solver_type.t
   -> files:Fpath.t list
   -> profile:Fpath.t option
+  -> model_output_format:string
   -> unit Result.t

--- a/src/cmd/cmd_sym.mli
+++ b/src/cmd/cmd_sym.mli
@@ -25,5 +25,5 @@ val cmd :
   -> solver:Smtml.Solver_type.t
   -> files:Fpath.t list
   -> profile:Fpath.t option
-  -> model_output_format:string
+  -> model_output_format:Cmd_utils.model_output_format
   -> unit Result.t

--- a/src/cmd/cmd_utils.ml
+++ b/src/cmd/cmd_utils.ml
@@ -4,6 +4,8 @@
 
 open Syntax
 
+type model_output_format = Scfg | Json
+
 let out_testcase ~dst testcase =
   let o = Xmlm.make_output ~nl:true ~indent:(Some 2) dst in
   let tag atts name = (("", name), atts) in

--- a/src/cmd/cmd_utils.ml
+++ b/src/cmd/cmd_utils.ml
@@ -4,7 +4,9 @@
 
 open Syntax
 
-type model_output_format = Scfg | Json
+type model_output_format =
+  | Scfg
+  | Json
 
 let out_testcase ~dst testcase =
   let o = Xmlm.make_output ~nl:true ~indent:(Some 2) dst in

--- a/src/cmd/cmd_utils.mli
+++ b/src/cmd/cmd_utils.mli
@@ -4,7 +4,9 @@
 
 val write_testcase : dir:Fpath.t -> Smtml.Value.t list -> unit Result.t
 
-type model_output_format = Scfg | Json
+type model_output_format =
+  | Scfg
+  | Json
 
 val add_main_as_start :
   Binary.modul -> (Binary.modul, [> `Msg of string ]) result

--- a/src/cmd/cmd_utils.mli
+++ b/src/cmd/cmd_utils.mli
@@ -4,5 +4,7 @@
 
 val write_testcase : dir:Fpath.t -> Smtml.Value.t list -> unit Result.t
 
+type model_output_format = Scfg | Json
+
 val add_main_as_start :
   Binary.modul -> (Binary.modul, [> `Msg of string ]) result

--- a/src/cmd/cmd_zig.ml
+++ b/src/cmd/cmd_zig.ml
@@ -63,8 +63,8 @@ let compile ~includes debug (files : Fpath.t list) : Fpath.t Result.t =
 
 let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile ~model_output_format :
-  unit Result.t =
+  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
+  ~model_output_format : unit Result.t =
   let includes = zig_files_location @ includes in
   let* modul = compile ~includes debug files in
   let workspace = Fpath.v "owi-out" in
@@ -72,4 +72,5 @@ let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-    ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile ~model_output_format
+    ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
+    ~model_output_format

--- a/src/cmd/cmd_zig.ml
+++ b/src/cmd/cmd_zig.ml
@@ -63,7 +63,7 @@ let compile ~includes debug (files : Fpath.t list) : Fpath.t Result.t =
 
 let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile :
+  ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile ~model_output_format :
   unit Result.t =
   let includes = zig_files_location @ includes in
   let* modul = compile ~includes debug files in
@@ -72,4 +72,4 @@ let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
-    ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
+    ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile ~model_output_format

--- a/test/c/collections-c/tests_array.t
+++ b/test/c/collections-c/tests_array.t
@@ -79,12 +79,12 @@ Array tests:
   Using owi conc:
   Assert failure
   Model:
-    (model
-      (symbol_1 (i32.const 1048068351))
-      (symbol_2 (i32.const 12775386))
-      (symbol_3 (i32.const 0))
-      (symbol_4 (i32.const 0)))
-  Reached problem!
+   model {
+    symbol symbol_1 i32 1048068351
+    symbol symbol_2 i32 12775386
+    symbol symbol_3 i32 0
+    symbol symbol_4 i32 0
+  }Reached problem!
   [13]
   Testing "files/normal/testsuite/array/array_test_reverse.c":
   Using owi sym:

--- a/test/c/collections-c/tests_array.t
+++ b/test/c/collections-c/tests_array.t
@@ -84,7 +84,8 @@ Array tests:
     symbol symbol_2 i32 12775386
     symbol symbol_3 i32 0
     symbol symbol_4 i32 0
-  }Reached problem!
+  }
+  Reached problem!
   [13]
   Testing "files/normal/testsuite/array/array_test_reverse.c":
   Using owi sym:

--- a/test/c/concolic.t
+++ b/test/c/concolic.t
@@ -8,5 +8,6 @@
     symbol symbol_4 i32
     symbol symbol_5 i32
     symbol symbol_6 i32
-  }Reached problem!
+  }
+  Reached problem!
   [13]

--- a/test/c/concolic.t
+++ b/test/c/concolic.t
@@ -1,12 +1,12 @@
   $ owi c --concolic ./main.c --no-value
   Assert failure
   Model:
-    (model
-      (symbol_1 i32)
-      (symbol_2 i32)
-      (symbol_3 i32)
-      (symbol_4 i32)
-      (symbol_5 i32)
-      (symbol_6 i32))
-  Reached problem!
+   model {
+    symbol symbol_1 i32
+    symbol symbol_2 i32
+    symbol symbol_3 i32
+    symbol symbol_4 i32
+    symbol symbol_5 i32
+    symbol symbol_6 i32
+  }Reached problem!
   [13]

--- a/test/conc/immediately_fail.t
+++ b/test/conc/immediately_fail.t
@@ -1,5 +1,6 @@
   $ owi conc immediately_fail.wat
   Assert failure
   Model:
-   modelReached problem!
+   model
+  Reached problem!
   [13]

--- a/test/conc/immediately_fail.t
+++ b/test/conc/immediately_fail.t
@@ -1,7 +1,5 @@
   $ owi conc immediately_fail.wat
   Assert failure
   Model:
-    (model
-      )
-  Reached problem!
+   modelReached problem!
   [13]

--- a/test/conc/range.t
+++ b/test/conc/range.t
@@ -4,5 +4,6 @@
    model {
     symbol symbol_1 i32 16
     symbol symbol_2 i32 299
-  }Reached problem!
+  }
+  Reached problem!
   [13]

--- a/test/conc/range.t
+++ b/test/conc/range.t
@@ -1,8 +1,8 @@
   $ owi conc ./range.wat
   Assert failure
   Model:
-    (model
-      (symbol_1 (i32.const 16))
-      (symbol_2 (i32.const 299)))
-  Reached problem!
+   model {
+    symbol symbol_1 i32 16
+    symbol symbol_2 i32 299
+  }Reached problem!
   [13]

--- a/test/wat2wasm/cmd_conc.t
+++ b/test/wat2wasm/cmd_conc.t
@@ -2,8 +2,9 @@
   $ owi conc symbolic.wasm
   Trap: unreachable
   Model:
-    (model
-      (symbol_1 (i32.const 6)))
+   model {
+    symbol symbol_1 i32 6
+  }
   Reached problem!
   [13]
   $ owi wasm2wat symbolic.wasm


### PR DESCRIPTION
Adds `--model-output-format` option with `json` and `scfg` as possible values, defaulting to `scfg`.

This also changes the output of concolic mode which wasn't `scfg` previously. I don't know if we're supposed to keep the old output format, but now the output format of concolic and symbolic modes are the same.