### PR TITLE
add `--invoke-with-symbols` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - add `owi zig` subcommand
 - add `--model-output-format` option
 - add `--entry-point` option
+- add `--invoke-with-symbols` option
 
 ## 0.2 - 2024-04-24
 

--- a/example/c/README.md
+++ b/example/c/README.md
@@ -464,6 +464,10 @@ OPTIONS
        -I VAL
            headers path
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        -m VAL, --arch=VAL (absent=32)
            data model
 
@@ -479,11 +483,11 @@ OPTIONS
        --no-value
            do not display a value for each symbol
 
-       -O VAL (absent=3)
-           specify which optimization level to use
-
        -o VAL, --outpt=VAL (absent=owi-out)
            write results to dir
+
+       -O VAL (absent=3)
+           specify which optimization level to use
 
        --optimize
            optimize mode

--- a/example/conc/README.md
+++ b/example/conc/README.md
@@ -63,6 +63,10 @@ OPTIONS
        --fail-on-trap-only
            ignore assertion violations and only report traps
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        --model-output-format=VAL (absent=scfg)
             The format of the output model ("json" or "scfg")
 

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -157,6 +157,10 @@ OPTIONS
        -I VAL
            headers path
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        -m VAL, --arch=VAL (absent=32)
            data model
 

--- a/example/replay/README.md
+++ b/example/replay/README.md
@@ -53,6 +53,10 @@ OPTIONS
        --entry-point=VAL
            entry point of the executable
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        --optimize
            optimize mode
 

--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -72,6 +72,10 @@ OPTIONS
        -I VAL
            headers path
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        -m VAL, --arch=VAL (absent=32)
            data model
 

--- a/example/sym/README.md
+++ b/example/sym/README.md
@@ -62,6 +62,10 @@ OPTIONS
        --fail-on-trap-only
            ignore assertion violations and only report traps
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        --model-output-format=VAL (absent=scfg)
             The format of the output model ("json" or "scfg")
 

--- a/example/validate/README.md
+++ b/example/validate/README.md
@@ -22,7 +22,8 @@ Running the validator is as simple as:
 
 ```sh
 $ owi validate ./type_error.wat
-type mismatch (pop)
+type mismatch (expected [i32
+i32] but stack is [i32])
 [35]
 ```
 
@@ -36,7 +37,8 @@ grouping     ...
 assigning    ...
 rewriting    ...
 typechecking ...
-type mismatch (pop)
+type mismatch (expected [i32
+i32] but stack is [i32])
 [35]
 ```
 

--- a/example/validate/README.md
+++ b/example/validate/README.md
@@ -22,8 +22,7 @@ Running the validator is as simple as:
 
 ```sh
 $ owi validate ./type_error.wat
-type mismatch (expected [i32
-i32] but stack is [i32])
+type mismatch (expected [i32 i32] but stack is [i32])
 [35]
 ```
 
@@ -37,8 +36,7 @@ grouping     ...
 assigning    ...
 rewriting    ...
 typechecking ...
-type mismatch (expected [i32
-i32] but stack is [i32])
+type mismatch (expected [i32 i32] but stack is [i32])
 [35]
 ```
 

--- a/example/zig/README.md
+++ b/example/zig/README.md
@@ -74,6 +74,10 @@ OPTIONS
        -I VAL
            headers path
 
+       --invoke-with-symbols
+           Invoke the entry point of the program with symbolic values instead
+           of dummy constants.
+
        --model-output-format=VAL (absent=scfg)
             The format of the output model ("json" or "scfg")
 

--- a/src/ast/binary.ml
+++ b/src/ast/binary.ml
@@ -52,31 +52,33 @@ type custom =
   | Uninterpreted of string
   | From_annot of binary Annot.annot
 
-type modul =
-  { id : string option
-  ; types : binary rec_type array
-  ; global : (global, binary global_type) Runtime.t array
-  ; table : (binary table, binary table_type) Runtime.t array
-  ; mem : (mem, limits) Runtime.t array
-  ; func : (binary func, binary block_type) Runtime.t array
-      (* TODO: switch to func_type *)
-  ; elem : elem array
-  ; data : data array
-  ; exports : exports
-  ; start : int option
-  ; custom : custom list
-  }
+module Module = struct
+  type t =
+    { id : string option
+    ; types : binary rec_type array
+    ; global : (global, binary global_type) Runtime.t array
+    ; table : (binary table, binary table_type) Runtime.t array
+    ; mem : (mem, limits) Runtime.t array
+    ; func : (binary func, binary block_type) Runtime.t array
+        (* TODO: switch to func_type *)
+    ; elem : elem array
+    ; data : data array
+    ; exports : exports
+    ; start : int option
+    ; custom : custom list
+    }
 
-let empty_modul =
-  { id = None
-  ; types = [||]
-  ; global = [||]
-  ; table = [||]
-  ; mem = [||]
-  ; func = [||]
-  ; elem = [||]
-  ; data = [||]
-  ; exports = { global = []; mem = []; table = []; func = [] }
-  ; start = None
-  ; custom = []
-  }
+  let empty =
+    { id = None
+    ; types = [||]
+    ; global = [||]
+    ; table = [||]
+    ; mem = [||]
+    ; func = [||]
+    ; elem = [||]
+    ; data = [||]
+    ; exports = { global = []; mem = []; table = []; func = [] }
+    ; start = None
+    ; custom = []
+    }
+end

--- a/src/ast/binary.ml
+++ b/src/ast/binary.ml
@@ -81,4 +81,66 @@ module Module = struct
     ; start = None
     ; custom = []
     }
+
+  (** Exports *)
+
+  (** Return the first function exported as [name] if it exists. Return [None]
+      otherwise.*)
+  let find_exported_func_from_name name m =
+    List.find_opt
+      (function { name = name'; _ } -> String.equal name name')
+      m.exports.func
+
+  (** Imports *)
+
+  (** Return the index of a function imported from a given [modul_name] and
+      [func_name] if it exists. Return [None] otherwise. *)
+  let find_imported_func_index ~modul_name ~func_name m =
+    Array.find_index
+      (function
+        | Runtime.Imported { Imported.modul; name; assigned_name = _; desc = _ }
+          ->
+          String.equal modul_name modul && String.equal func_name name
+        | Local _ -> false )
+      m.func
+
+  (** Look for an imported function index, adding it if not already imported. *)
+  let add_import_if_not_present ~modul_name ~func_name ~desc m =
+    match find_imported_func_index ~modul_name ~func_name m with
+    | Some i -> (Types.Raw i, m)
+    | None ->
+      let f =
+        Runtime.Imported
+          { Imported.modul = modul_name
+          ; name = func_name
+          ; assigned_name = None
+          ; desc
+          }
+      in
+      let func = Array.append m.func [| f |] in
+      let m = { m with func } in
+      let i = Array.length func - 1 in
+      (Types.Raw i, m)
+
+  (** Functions *)
+
+  (** Add a function [f] to a module [m] and returns the module and the index of
+      the added function. *)
+  let add_func f m =
+    let len = Array.length m.func in
+    let func =
+      Array.init
+        (Array.length m.func + 1)
+        (fun i -> if i = len then f else m.func.(i))
+    in
+
+    ({ m with func }, len)
+
+  (** Return the type of the function at index [id]. *)
+  let get_func_type id m =
+    if id >= Array.length m.func then None
+    else
+      match m.func.(id) with
+      | Local f -> Some f.type_f
+      | Imported i -> Some i.desc
 end

--- a/src/ast/binary_encoder.ml
+++ b/src/ast/binary_encoder.ml
@@ -728,7 +728,7 @@ let keep_imported values =
 
 let encode
   ({ func; table; global; exports; start; data; mem; types; elem; _ } :
-    Binary.modul ) =
+    Binary.Module.t ) =
   let buf = Buffer.create 256 in
 
   let local_funcs = keep_local func in

--- a/src/ast/binary_to_text.ml
+++ b/src/ast/binary_to_text.ml
@@ -235,8 +235,18 @@ let from_exports (exports : Binary.exports) : Text.module_field list =
 let from_start = function None -> [] | Some n -> [ MStart (Raw n) ]
 
 let modul
-  { Binary.id; types; global; table; mem; func; elem; data; start; exports; _ }
-    =
+  { Binary.Module.id
+  ; types
+  ; global
+  ; table
+  ; mem
+  ; func
+  ; elem
+  ; data
+  ; start
+  ; exports
+  ; _
+  } =
   let fields =
     from_types types @ from_global global @ from_table table @ from_mem mem
     @ from_func func @ from_elem elem @ from_data data @ from_exports exports

--- a/src/ast/binary_to_text.mli
+++ b/src/ast/binary_to_text.mli
@@ -2,4 +2,4 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-val modul : Binary.modul -> Text.modul
+val modul : Binary.Module.t -> Text.modul

--- a/src/ast/code_generator.mli
+++ b/src/ast/code_generator.mli
@@ -2,4 +2,4 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-val generate : bool -> Binary.modul -> Binary.modul Result.t
+val generate : bool -> Binary.Module.t -> Binary.Module.t Result.t

--- a/src/ast/compile.mli
+++ b/src/ast/compile.mli
@@ -10,7 +10,7 @@ module Any : sig
     -> rac:bool
     -> srac:bool
     -> 'extern_func Kind.t
-    -> Binary.modul Result.t
+    -> Binary.Module.t Result.t
 
   val until_optimize :
        unsafe:bool
@@ -18,7 +18,7 @@ module Any : sig
     -> srac:bool
     -> optimize:bool
     -> 'extern_func Kind.t
-    -> Binary.modul Result.t
+    -> Binary.Module.t Result.t
 
   (** compile a module with a given link state and produce a new link state and
       a runnable module *)
@@ -47,7 +47,7 @@ end
 
 module File : sig
   val until_binary_validate :
-    unsafe:bool -> rac:bool -> srac:bool -> Fpath.t -> Binary.modul Result.t
+    unsafe:bool -> rac:bool -> srac:bool -> Fpath.t -> Binary.Module.t Result.t
 
   val until_optimize :
        unsafe:bool
@@ -55,7 +55,7 @@ module File : sig
     -> srac:bool
     -> optimize:bool
     -> Fpath.t
-    -> Binary.modul Result.t
+    -> Binary.Module.t Result.t
 
   (** compile a file with a given link state and produce a new link state and a
       runnable module *)
@@ -86,10 +86,18 @@ module Text : sig
   val until_text_validate : unsafe:bool -> Text.modul -> Text.modul Result.t
 
   val until_binary :
-    unsafe:bool -> rac:bool -> srac:bool -> Text.modul -> Binary.modul Result.t
+       unsafe:bool
+    -> rac:bool
+    -> srac:bool
+    -> Text.modul
+    -> Binary.Module.t Result.t
 
   val until_binary_validate :
-    unsafe:bool -> rac:bool -> srac:bool -> Text.modul -> Binary.modul Result.t
+       unsafe:bool
+    -> rac:bool
+    -> srac:bool
+    -> Text.modul
+    -> Binary.Module.t Result.t
 
   val until_optimize :
        unsafe:bool
@@ -97,7 +105,7 @@ module Text : sig
     -> srac:bool
     -> optimize:bool
     -> Text.modul
-    -> Binary.modul Result.t
+    -> Binary.Module.t Result.t
 
   (** compile a module with a given link state and produce a new link state and
       a runnable module *)
@@ -126,10 +134,10 @@ end
 
 module Binary : sig
   val until_binary_validate :
-    unsafe:bool -> Binary.modul -> Binary.modul Result.t
+    unsafe:bool -> Binary.Module.t -> Binary.Module.t Result.t
 
   val until_optimize :
-    unsafe:bool -> optimize:bool -> Binary.modul -> Binary.modul Result.t
+    unsafe:bool -> optimize:bool -> Binary.Module.t -> Binary.Module.t Result.t
 
   (** compile a module with a given link state and produce a new link state and
       a runnable module *)
@@ -138,7 +146,7 @@ module Binary : sig
     -> optimize:bool
     -> name:string option
     -> 'f Link.state
-    -> Binary.modul
+    -> Binary.Module.t
     -> ('f Link.module_to_run * 'f Link.state) Result.t
 
   (** compile and interpret a module with a given link state and produce a new
@@ -148,6 +156,6 @@ module Binary : sig
     -> optimize:bool
     -> name:string option
     -> Concrete_extern_func.extern_func Link.state
-    -> Binary.modul
+    -> Binary.Module.t
     -> Concrete_extern_func.extern_func Link.state Result.t
 end

--- a/src/ast/kind.ml
+++ b/src/ast/kind.ml
@@ -5,5 +5,5 @@
 type 'extern_func t =
   | Wat of Text.modul
   | Wast of Text.script
-  | Wasm of Binary.modul
+  | Wasm of Binary.Module.t
   | Ocaml of 'extern_func Link.extern_module

--- a/src/ast/kind.mli
+++ b/src/ast/kind.mli
@@ -5,5 +5,5 @@
 type 'extern_func t =
   | Wat of Text.modul
   | Wast of Text.script
-  | Wasm of Binary.modul
+  | Wasm of Binary.Module.t
   | Ocaml of 'extern_func Link.extern_module

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -105,6 +105,13 @@ let includes =
   let doc = "headers path" in
   Arg.(value & opt_all existing_dir_conv [] & info [ "I" ] ~doc)
 
+let invoke_with_symbols =
+  let doc =
+    "Invoke the entry point of the program with symbolic values instead of \
+     dummy constants."
+  in
+  Arg.(value & flag & info [ "invoke-with-symbols" ] ~doc)
+
 let model_output_format =
   let doc = {| The format of the output model ("json" or "scfg") |} in
   Arg.(value & opt model_format_conv Scfg & info [ "model-output-format" ] ~doc)
@@ -219,12 +226,13 @@ let c_cmd =
     Arg.(value & flag & info [ "e-acsl" ] ~doc)
   and+ solver
   and+ model_output_format
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_c.cmd ~debug ~arch ~property ~testcomp ~workspace ~workers ~opt_lvl
     ~includes ~files ~profiling ~unsafe ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
     ~fail_mode ~concolic ~eacsl ~solver ~profile ~model_output_format
-    ~entry_point
+    ~entry_point ~invoke_with_symbols
 
 (* owi cpp *)
 
@@ -254,11 +262,13 @@ let cpp_cmd =
   and+ solver
   and+ profile
   and+ model_output_format
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_cpp.cmd ~debug ~arch ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
     ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
     ~fail_mode ~concolic ~solver ~profile ~model_output_format ~entry_point
+    ~invoke_with_symbols
 
 (* owi conc *)
 
@@ -285,11 +295,12 @@ let conc_cmd =
   and+ files
   and+ profile
   and+ model_output_format
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_conc.cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
-    ~model_output_format ~entry_point
+    ~model_output_format ~entry_point ~invoke_with_symbols
 
 (* owi fmt *)
 
@@ -362,9 +373,10 @@ let replay_cmd =
       & opt (some existing_file_conv) None
       & info [ "replay-file" ] ~doc )
   and+ source_file
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_replay.cmd ~profiling ~debug ~unsafe ~optimize ~replay_file ~source_file
-    ~entry_point
+    ~entry_point ~invoke_with_symbols
 
 (* owi run *)
 
@@ -410,11 +422,13 @@ let rust_cmd =
   and+ solver
   and+ profile
   and+ model_output_format
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_rust.cmd ~debug ~arch ~workers ~opt_lvl ~includes ~files ~profiling
     ~unsafe ~optimize ~no_stop_at_failure ~no_value
     ~no_assert_failure_expression_printing ~deterministic_result_order
     ~fail_mode ~concolic ~solver ~profile ~model_output_format ~entry_point
+    ~invoke_with_symbols
 
 (* owi script *)
 
@@ -459,11 +473,12 @@ let sym_cmd =
   and+ files
   and+ profile
   and+ model_output_format
-  and+ entry_point in
+  and+ entry_point
+  and+ invoke_with_symbols in
   Cmd_sym.cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
-    ~model_output_format ~entry_point
+    ~model_output_format ~entry_point ~invoke_with_symbols
 
 (* owi validate *)
 
@@ -549,11 +564,12 @@ let zig_cmd =
   and+ profile
   and+ solver
   and+ model_output_format
+  and+ invoke_with_symbols
   and+ entry_point in
   Cmd_zig.cmd ~debug ~includes ~workers ~files ~profiling ~unsafe ~optimize
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
-    ~model_output_format ~entry_point
+    ~model_output_format ~entry_point ~invoke_with_symbols
 
 (* owi *)
 

--- a/src/cmd/cmd_c.ml
+++ b/src/cmd/cmd_c.ml
@@ -168,8 +168,8 @@ let metadata ~workspace arch property files : unit Result.t =
 let cmd ~debug ~arch ~property ~testcomp:_ ~workspace ~workers ~opt_lvl
   ~includes ~files ~profiling ~unsafe ~optimize ~no_stop_at_failure ~no_value
   ~no_assert_failure_expression_printing ~deterministic_result_order ~fail_mode
-  ~concolic ~eacsl ~solver ~profile ~model_output_format ~entry_point :
-  unit Result.t =
+  ~concolic ~eacsl ~solver ~profile ~model_output_format ~entry_point
+  ~invoke_with_symbols : unit Result.t =
   let includes = Cmd_utils.c_files_location @ includes in
   let* (_exists : bool) = OS.Dir.create ~path:true workspace in
   let* files = eacsl_instrument eacsl debug ~includes files in
@@ -181,4 +181,4 @@ let cmd ~debug ~arch ~property ~testcomp:_ ~workspace ~workers ~opt_lvl
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
-    ~model_output_format ~entry_point
+    ~model_output_format ~entry_point ~invoke_with_symbols

--- a/src/cmd/cmd_c.mli
+++ b/src/cmd/cmd_c.mli
@@ -26,4 +26,5 @@ val cmd :
   -> profile:Fpath.t option
   -> model_output_format:Cmd_utils.model_output_format
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_conc.ml
+++ b/src/cmd/cmd_conc.ml
@@ -16,7 +16,8 @@ let ( let** ) (t : 'a Result.t Choice.t) (f : 'a -> 'b Result.t Choice.t) :
   Choice.bind t (fun t ->
     match t with Error e -> Choice.return (Error e) | Ok x -> f x )
 
-let simplify_then_link ~entry_point ~unsafe ~rac ~srac ~optimize link_state m =
+let simplify_then_link ~entry_point ~invoke_with_symbols ~unsafe ~rac ~srac
+  ~optimize link_state m =
   let* m =
     match m with
     | Kind.Wat _ | Wasm _ ->
@@ -24,15 +25,15 @@ let simplify_then_link ~entry_point ~unsafe ~rac ~srac ~optimize link_state m =
     | Wast _ -> Fmt.error_msg "can't run concolic interpreter on a script"
     | Ocaml _ -> assert false
   in
-  let* m = Cmd_utils.set_entry_point entry_point m in
+  let* m = Cmd_utils.set_entry_point entry_point invoke_with_symbols m in
   let+ m, link_state =
     Compile.Binary.until_link ~unsafe ~optimize ~name:None link_state m
   in
   let module_to_run = Concolic.convert_module_to_run m in
   (link_state, module_to_run)
 
-let simplify_then_link_files ~entry_point ~unsafe ~rac ~srac ~optimize filenames
-    =
+let simplify_then_link_files ~entry_point ~invoke_with_symbols ~unsafe ~rac
+  ~srac ~optimize filenames =
   let link_state = Link.empty_state in
   let link_state =
     Link.extern_module' link_state ~name:"symbolic"
@@ -50,8 +51,8 @@ let simplify_then_link_files ~entry_point ~unsafe ~rac ~srac ~optimize filenames
         let* link_state, modules_to_run = acc in
         let* m0dule = Parse.guess_from_file filename in
         let+ link_state, module_to_run =
-          simplify_then_link ~entry_point ~unsafe ~rac ~srac ~optimize
-            link_state m0dule
+          simplify_then_link ~entry_point ~invoke_with_symbols ~unsafe ~rac
+            ~srac ~optimize link_state m0dule
         in
         (link_state, module_to_run :: modules_to_run) )
       (Ok (link_state, []))
@@ -445,7 +446,7 @@ let assignments_to_model (assignments : (Smtml.Symbol.t * V.t) list) :
 let cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers:_
   ~no_stop_at_failure:_ ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order:_ ~fail_mode:_ ~(workspace : Fpath.t) ~solver
-  ~files ~profile ~model_output_format ~entry_point =
+  ~files ~profile ~model_output_format ~entry_point ~invoke_with_symbols =
   Option.iter Stats.init_logger_to_file profile;
   if profiling then Log.profiling_on := true;
   if debug then Log.debug_on := true;
@@ -460,7 +461,8 @@ let cmd ~profiling ~debug ~unsafe ~rac ~srac ~optimize ~workers:_
   let* _created_dir = Bos.OS.Dir.create ~path:true ~mode:0o755 workspace in
   let solver = Solver.fresh solver () in
   let* link_state, modules_to_run =
-    simplify_then_link_files ~entry_point ~unsafe ~rac ~srac ~optimize files
+    simplify_then_link_files ~entry_point ~invoke_with_symbols ~unsafe ~rac
+      ~srac ~optimize files
   in
   let tree = fresh_tree [] in
   let* result = run solver tree link_state modules_to_run in

--- a/src/cmd/cmd_conc.mli
+++ b/src/cmd/cmd_conc.mli
@@ -21,4 +21,5 @@ val cmd :
   -> profile:Fpath.t option
   -> model_output_format:Cmd_utils.model_output_format
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_cpp.ml
+++ b/src/cmd/cmd_cpp.ml
@@ -82,7 +82,7 @@ let compile ~entry_point ~includes ~opt_lvl debug (files : Fpath.t list) :
 let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
-  ~model_output_format ~entry_point : unit Result.t =
+  ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
   let includes = Cmd_utils.c_files_location @ includes in
   let* modul = compile ~entry_point ~includes ~opt_lvl debug files in
   let files = [ modul ] in
@@ -91,3 +91,4 @@ let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace:(Fpath.v "owi-out")
     ~solver ~files ~profile ~model_output_format ~entry_point
+    ~invoke_with_symbols

--- a/src/cmd/cmd_cpp.ml
+++ b/src/cmd/cmd_cpp.ml
@@ -60,7 +60,6 @@ let compile ~entry_point ~includes ~opt_lvl debug (files : Fpath.t list) :
   let out = Fpath.v "a.out.wasm" in
 
   let* binc = Cmd_utils.find_installed_c_file (Fpath.v "libc.wasm") in
-  let entry_point = Option.value entry_point ~default:"main" in
   let wasmld_cmd : Cmd.t =
     Cmd.(
       wasmld_bin % "-z" % "stack-size=8388608"
@@ -83,9 +82,11 @@ let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
   ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
+  let entry_point = Option.value entry_point ~default:"main" in
   let includes = Cmd_utils.c_files_location @ includes in
   let* modul = compile ~entry_point ~includes ~opt_lvl debug files in
   let files = [ modul ] in
+  let entry_point = Some entry_point in
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing

--- a/src/cmd/cmd_cpp.mli
+++ b/src/cmd/cmd_cpp.mli
@@ -22,4 +22,5 @@ val cmd :
   -> profile:Fpath.t option
   -> model_output_format:Cmd_utils.model_output_format
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_replay.ml
+++ b/src/cmd/cmd_replay.ml
@@ -4,7 +4,8 @@
 
 open Syntax
 
-let run_file ~unsafe ~optimize ~entry_point filename model =
+let run_file ~unsafe ~optimize ~entry_point ~invoke_with_symbols filename model
+    =
   let next =
     let next = ref ~-1 in
     fun () ->
@@ -145,7 +146,7 @@ let run_file ~unsafe ~optimize ~entry_point filename model =
   let* m =
     Compile.File.until_binary_validate ~rac:false ~srac:false ~unsafe filename
   in
-  let* m = Cmd_utils.set_entry_point entry_point m in
+  let* m = Cmd_utils.set_entry_point entry_point invoke_with_symbols m in
   let* m, link_state =
     Compile.Binary.until_link ~unsafe link_state ~optimize ~name:None m
   in
@@ -153,7 +154,7 @@ let run_file ~unsafe ~optimize ~entry_point filename model =
   c
 
 let cmd ~profiling ~debug ~unsafe ~optimize ~replay_file ~source_file
-  ~entry_point =
+  ~entry_point ~invoke_with_symbols =
   if profiling then Log.profiling_on := true;
   if debug then Log.debug_on := true;
   let* model =
@@ -180,5 +181,8 @@ let cmd ~profiling ~debug ~unsafe ~optimize ~replay_file ~source_file
       in
       Array.of_list model
   in
-  let+ () = run_file ~unsafe ~optimize ~entry_point source_file model in
+  let+ () =
+    run_file ~unsafe ~optimize ~entry_point ~invoke_with_symbols source_file
+      model
+  in
   Fmt.pr "All OK@."

--- a/src/cmd/cmd_replay.mli
+++ b/src/cmd/cmd_replay.mli
@@ -10,4 +10,5 @@ val cmd :
   -> replay_file:Fpath.t
   -> source_file:Fpath.t
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_rust.ml
+++ b/src/cmd/cmd_rust.ml
@@ -45,7 +45,7 @@ let compile ~entry_point ~includes:_ ~opt_lvl:_ debug (files : Fpath.t list) :
 let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
-  ~model_output_format ~entry_point : unit Result.t =
+  ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
   let* modul = compile ~entry_point ~includes ~opt_lvl debug files in
   let files = [ modul ] in
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
@@ -53,3 +53,4 @@ let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace:(Fpath.v "owi-out")
     ~solver ~files ~profile ~model_output_format ~entry_point
+    ~invoke_with_symbols

--- a/src/cmd/cmd_rust.ml
+++ b/src/cmd/cmd_rust.ml
@@ -8,7 +8,6 @@ open Syntax
 (* TODO: investigate which parameters makes sense *)
 let compile ~entry_point ~includes:_ ~opt_lvl:_ debug (files : Fpath.t list) :
   Fpath.t Result.t =
-  let entry_point = Option.value entry_point ~default:"main" in
   let* rustc_bin = OS.Cmd.resolve @@ Cmd.v "rustc" in
 
   let* libowi_sym_rlib =
@@ -46,8 +45,10 @@ let cmd ~debug ~arch:_ ~workers ~opt_lvl ~includes ~files ~profiling ~unsafe
   ~optimize ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
   ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
+  let entry_point = Option.value entry_point ~default:"main" in
   let* modul = compile ~entry_point ~includes ~opt_lvl debug files in
   let files = [ modul ] in
+  let entry_point = Some entry_point in
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing

--- a/src/cmd/cmd_rust.mli
+++ b/src/cmd/cmd_rust.mli
@@ -22,4 +22,5 @@ val cmd :
   -> profile:Fpath.t option
   -> model_output_format:Cmd_utils.model_output_format
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_sym.mli
+++ b/src/cmd/cmd_sym.mli
@@ -27,4 +27,5 @@ val cmd :
   -> profile:Fpath.t option
   -> model_output_format:Cmd_utils.model_output_format
   -> entry_point:string option
+  -> invoke_with_symbols:bool
   -> unit Result.t

--- a/src/cmd/cmd_utils.ml
+++ b/src/cmd/cmd_utils.ml
@@ -40,14 +40,14 @@ let write_testcase =
 
 (* Entry-point *)
 
-let find_exported_name exported_names (m : Binary.modul) =
+let find_exported_name exported_names (m : Binary.Module.t) =
   List.find_opt
     (function
       | { Binary.name; _ } when List.mem name exported_names -> true
       | _ -> false )
     m.exports.func
 
-let find_imported_func modul_name func_name (m : Binary.modul) =
+let find_imported_func modul_name func_name (m : Binary.Module.t) =
   Array.find_index
     (function
       | Runtime.Imported { Imported.modul; name; assigned_name = _; desc = _ }
@@ -56,7 +56,7 @@ let find_imported_func modul_name func_name (m : Binary.modul) =
       | Local _ | Imported _ -> false )
     m.func
 
-let set_entry_point entry_point invoke_with_symbols (m : Binary.modul) =
+let set_entry_point entry_point invoke_with_symbols (m : Binary.Module.t) =
   (* We are checking if there's a start function *)
   if Option.is_some m.start then
     if Option.is_some entry_point then

--- a/src/cmd/cmd_utils.mli
+++ b/src/cmd/cmd_utils.mli
@@ -12,7 +12,10 @@ val write_testcase : dir:Fpath.t -> Smtml.Value.t list -> unit Result.t
 
 (* harness stuff *)
 val set_entry_point :
-  string option -> Binary.modul -> (Binary.modul, [> `Msg of string ]) result
+     string option
+  -> bool
+  -> Binary.modul
+  -> (Binary.modul, [> `Msg of string ]) result
 
 (* installed files *)
 val c_files_location : Fpath.t list

--- a/src/cmd/cmd_utils.mli
+++ b/src/cmd/cmd_utils.mli
@@ -14,8 +14,8 @@ val write_testcase : dir:Fpath.t -> Smtml.Value.t list -> unit Result.t
 val set_entry_point :
      string option
   -> bool
-  -> Binary.modul
-  -> (Binary.modul, [> `Msg of string ]) result
+  -> Binary.Module.t
+  -> (Binary.Module.t, [> `Msg of string ]) result
 
 (* installed files *)
 val c_files_location : Fpath.t list

--- a/src/cmd/cmd_validate.ml
+++ b/src/cmd/cmd_validate.ml
@@ -5,7 +5,7 @@
 open Syntax
 
 let validate filename =
-  let+ (_modul : Binary.modul) =
+  let+ (_modul : Binary.Module.t) =
     Compile.File.until_binary_validate ~unsafe:false ~rac:false ~srac:false
       filename
   in

--- a/src/cmd/cmd_zig.ml
+++ b/src/cmd/cmd_zig.ml
@@ -7,7 +7,6 @@ open Syntax
 
 let compile ~entry_point ~includes debug (files : Fpath.t list) :
   Fpath.t Result.t =
-  let entry_point = Option.value entry_point ~default:"_start" in
   let includes =
     Cmd.of_list (List.map (fun p -> Fmt.str "-I%a" Fpath.pp p) includes)
   in
@@ -48,9 +47,11 @@ let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
   ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
   let includes = Cmd_utils.zig_files_location @ includes in
+  let entry_point = Option.value entry_point ~default:"_start" in
   let* modul = compile ~entry_point ~includes debug files in
   let workspace = Fpath.v "owi-out" in
   let files = [ modul ] in
+  let entry_point = Some entry_point in
   (if concolic then Cmd_conc.cmd else Cmd_sym.cmd)
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing

--- a/src/cmd/cmd_zig.ml
+++ b/src/cmd/cmd_zig.ml
@@ -46,7 +46,7 @@ let compile ~entry_point ~includes debug (files : Fpath.t list) :
 let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
   ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
   ~deterministic_result_order ~fail_mode ~concolic ~solver ~profile
-  ~model_output_format ~entry_point : unit Result.t =
+  ~model_output_format ~entry_point ~invoke_with_symbols : unit Result.t =
   let includes = Cmd_utils.zig_files_location @ includes in
   let* modul = compile ~entry_point ~includes debug files in
   let workspace = Fpath.v "owi-out" in
@@ -55,4 +55,4 @@ let cmd ~debug ~workers ~includes ~files ~profiling ~unsafe ~optimize
     ~profiling ~debug ~unsafe ~rac:false ~srac:false ~optimize ~workers
     ~no_stop_at_failure ~no_value ~no_assert_failure_expression_printing
     ~deterministic_result_order ~fail_mode ~workspace ~solver ~files ~profile
-    ~model_output_format ~entry_point
+    ~model_output_format ~entry_point ~invoke_with_symbols

--- a/src/link/link.ml
+++ b/src/link/link.ml
@@ -358,7 +358,7 @@ let populate_exports env (exports : Binary.exports) : exports Result.t =
   let* functions, names = fill_exports Link_env.get_func exports.func names in
   Ok { globals; memories; tables; functions; defined_names = names }
 
-let modul (ls : 'f state) ~name (modul : Binary.modul) =
+let modul (ls : 'f state) ~name (modul : Binary.Module.t) =
   Log.debug0 "linking      ...@\n";
   let* envs, (env, init_active_data, init_active_elem) =
     Env_id.with_fresh_id

--- a/src/link/link.mli
+++ b/src/link/link.mli
@@ -52,7 +52,7 @@ val empty_state : 'f state
 val modul :
      'f state
   -> name:string option
-  -> Binary.modul
+  -> Binary.Module.t
   -> ('f module_to_run * 'f state) Result.t
 
 (** register a module inside a link state, producing a new link state *)

--- a/src/optimize/optimize.ml
+++ b/src/optimize/optimize.ml
@@ -2,7 +2,6 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-open Binary
 open Types
 
 let rec optimize_expr expr : bool * binary instr list =
@@ -477,5 +476,5 @@ let optimize_runtime_func = function
 
 let modul m =
   Log.debug0 "optimizing   ...@\n";
-  let func = Array.map optimize_runtime_func m.func in
+  let func = Array.map optimize_runtime_func m.Binary.Module.func in
   { m with func }

--- a/src/optimize/optimize.mli
+++ b/src/optimize/optimize.mli
@@ -4,4 +4,4 @@
 
 (** Optimize module *)
 
-val modul : Binary.modul -> Binary.modul
+val modul : Binary.Module.t -> Binary.Module.t

--- a/src/parser/binary_parser.ml
+++ b/src/parser/binary_parser.ml
@@ -1190,7 +1190,7 @@ let sections_iterate (input : Input.t) =
     List.filter_map (Option.map (fun x -> Uninterpreted x)) custom_sections
   in
 
-  { id = None
+  { Binary.Module.id = None
   ; types
   ; global
   ; mem

--- a/src/parser/binary_parser.mli
+++ b/src/parser/binary_parser.mli
@@ -2,8 +2,8 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-val from_string : string -> Binary.modul Result.t
+val from_string : string -> Binary.Module.t Result.t
 
-val from_channel : in_channel -> Binary.modul Result.t
+val from_channel : in_channel -> Binary.Module.t Result.t
 
-val from_file : Fpath.t -> Binary.modul Result.t
+val from_file : Fpath.t -> Binary.Module.t Result.t

--- a/src/parser/parse.mli
+++ b/src/parser/parse.mli
@@ -45,12 +45,12 @@ end
 module Binary : sig
   module Module : sig
     (** Parse a module from a string. *)
-    val from_string : string -> Binary.modul Result.t
+    val from_string : string -> Binary.Module.t Result.t
 
     (** Parse a module from a channel. *)
-    val from_channel : in_channel -> Binary.modul Result.t
+    val from_channel : in_channel -> Binary.Module.t Result.t
 
     (** Parse a module from a file. *)
-    val from_file : Fpath.t -> Binary.modul Result.t
+    val from_file : Fpath.t -> Binary.Module.t Result.t
   end
 end

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -31,7 +31,8 @@ let model (S (solver_module, s)) ~symbols ~pc =
       | None -> assert false
       | Some model -> model
     end
-    | `Unsat | `Unknown -> assert false
+    | `Unsat -> assert false
+    | `Unknown -> assert false
   in
   Stats.close_span ();
   model

--- a/src/text_to_binary/rewrite.ml
+++ b/src/text_to_binary/rewrite.ml
@@ -482,7 +482,7 @@ let rewrite_annots (modul : Assigned.t) :
   text Annot.annot list -> Binary.custom list Result.t =
   list_map (rewrite_annot modul)
 
-let modul (modul : Assigned.t) : Binary.modul Result.t =
+let modul (modul : Assigned.t) : Binary.Module.t Result.t =
   Log.debug0 "rewriting    ...@\n";
   let typemap = typemap modul.typ in
   let* global =
@@ -521,7 +521,7 @@ let modul (modul : Assigned.t) : Binary.modul Result.t =
   let data = Named.to_array data in
   let func = Named.to_array func in
 
-  { Binary.id
+  { Binary.Module.id
   ; mem
   ; table
   ; types

--- a/src/text_to_binary/rewrite.mli
+++ b/src/text_to_binary/rewrite.mli
@@ -2,4 +2,4 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-val modul : Assigned.t -> Binary.modul Result.t
+val modul : Assigned.t -> Binary.Module.t Result.t

--- a/src/validate/binary_validate.ml
+++ b/src/validate/binary_validate.ml
@@ -205,7 +205,9 @@ end = struct
 
   let pop required stack =
     match match_prefix ~prefix:required ~stack with
-    | None -> Error (`Type_mismatch "pop")
+    | None ->
+      let msg = Fmt.str "expected %a but stack is %a" pp required pp stack in
+      Error (`Type_mismatch msg)
     | Some stack -> Ok stack
 
   let pop_ref = function

--- a/src/validate/binary_validate.ml
+++ b/src/validate/binary_validate.ml
@@ -21,6 +21,8 @@ let typ_equal t1 t2 =
   | Something, _ | _, Something -> true
   | _, _ -> false
 
+let sp fmt () = Fmt.string fmt " "
+
 let pp_typ fmt = function
   | Num_type t -> pp_num_type fmt t
   | Ref_type t -> pp_heap_type fmt t

--- a/src/validate/binary_validate.mli
+++ b/src/validate/binary_validate.mli
@@ -5,4 +5,4 @@
 (** Module to typecheck a simplified module. *)
 
 (** typecheck a given module *)
-val modul : Binary.modul -> unit Result.t
+val modul : Binary.Module.t -> unit Result.t

--- a/test/c/dune
+++ b/test/c/dune
@@ -2,14 +2,13 @@
  (deps
   %{bin:owi}
   (package owi)
-  concolic.c
-  malloc_aligned.c
-  main.c
   bool.c
   char.c
+  concolic.c
+  entry_point.c
   exit.c
   klee_compat.c
   main.c
   malloc_aligned.c
   range.c
-  entry_point.c))
+  invoke_with_symbols.c))

--- a/test/c/invoke_with_symbols.c
+++ b/test/c/invoke_with_symbols.c
@@ -1,6 +1,6 @@
 #include <owi.h>
 
-void f(int n, long int m, float x, double y) {
+void f(int n, long long int m, float x, double y) {
     owi_assume(n == 1);
     owi_assume(y == -1234.);
     owi_assume(n > m);

--- a/test/c/invoke_with_symbols.c
+++ b/test/c/invoke_with_symbols.c
@@ -1,0 +1,9 @@
+#include <owi.h>
+
+void f(int n, long int m, float x, double y) {
+    owi_assume(n == 1);
+    owi_assume(y == -1234.);
+    owi_assume(n > m);
+    owi_assume(x > y);
+    owi_assert(x != n);
+}

--- a/test/c/invoke_with_symbols.t
+++ b/test/c/invoke_with_symbols.t
@@ -1,0 +1,10 @@
+  $ owi c --entry-point=f --invoke-with-symbols ./invoke_with_symbols.c
+  Assert failure: (f32.ne (f32.convert_i32_s symbol_0) symbol_2)
+  model {
+    symbol symbol_0 i32 1
+    symbol symbol_1 i32 0
+    symbol symbol_2 f32 1.
+    symbol symbol_3 f64 -1234.
+  }
+  Reached problem!
+  [13]

--- a/test/c/invoke_with_symbols.t
+++ b/test/c/invoke_with_symbols.t
@@ -2,7 +2,7 @@
   Assert failure: (f32.ne (f32.convert_i32_s symbol_0) symbol_2)
   model {
     symbol symbol_0 i32 1
-    symbol symbol_1 i32 0
+    symbol symbol_1 i64 0
     symbol symbol_2 f32 1.
     symbol symbol_3 f64 -1234.
   }

--- a/test/wasm2wat/from_c.t
+++ b/test/wasm2wat/from_c.t
@@ -1,5 +1,5 @@
   $ owi c from_c.c
   All OK
   $ owi wasm2wat a.out.wasm > a.out.wat
-  $ owi sym a.out.wat
+  $ owi sym a.out.wat --entry-point main
   All OK


### PR DESCRIPTION
Fix #558 

This option allows to automatically use symbols to invoke the entry point. Now that we have `--entry-point` this is very useful!

The code is ugly for now, I'll fix that later.