### PR TITLE
Fix memarg binary encoding

### DIFF
--- a/src/ast/binary_encoder.ml
+++ b/src/ast/binary_encoder.ml
@@ -143,8 +143,8 @@ let write_limits buf (limits : limits) =
     write_u32_of_int buf max
 
 let write_memarg buf ({ offset; align } : memarg) =
-  write_u32 buf offset;
-  write_u32 buf align
+  write_u32 buf align;
+  write_u32 buf offset
 
 let write_memory buf ((_so, limits) : mem) = write_limits buf limits
 

--- a/test/wasm2wat/dune
+++ b/test/wasm2wat/dune
@@ -5,5 +5,6 @@
   done.wasm
   from_c.c
   m.wasm
+  memarg.wat
   locals.wasm
   locals_drop.wasm))

--- a/test/wasm2wat/memarg.t
+++ b/test/wasm2wat/memarg.t
@@ -41,8 +41,8 @@
   stack        : [  ]
   running instr: i32.const 1
   stack        : [ i32.const 1 ]
-  running instr: i32.load offset=1 align=1
-  stack        : [ i32.const -520159232 ]
+  running instr: i32.load align=2
+  stack        : [ i32.const -16777216 ]
   running instr: drop
   stack        : [  ]
   stack        : [  ]

--- a/test/wasm2wat/memarg.t
+++ b/test/wasm2wat/memarg.t
@@ -1,0 +1,48 @@
+  $ owi run memarg.wat --debug
+  parsing      ...
+  checking     ...
+  grouping     ...
+  assigning    ...
+  rewriting    ...
+  typechecking ...
+  linking      ...
+  interpreting ...
+  stack        : [  ]
+  running instr: call 0
+  calling func : func f
+  stack        : [  ]
+  running instr: i32.const 4
+  stack        : [ i32.const 4 ]
+  running instr: i32.const 99999999
+  stack        : [ i32.const 99999999 ; i32.const 4 ]
+  running instr: i32.store align=1
+  stack        : [  ]
+  running instr: i32.const 1
+  stack        : [ i32.const 1 ]
+  running instr: i32.load align=2
+  stack        : [ i32.const -16777216 ]
+  running instr: drop
+  stack        : [  ]
+  stack        : [  ]
+  $ owi wat2wasm memarg.wat
+  $ owi run memarg.wasm --debug
+  typechecking ...
+  linking      ...
+  interpreting ...
+  stack        : [  ]
+  running instr: call 0
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: i32.const 4
+  stack        : [ i32.const 4 ]
+  running instr: i32.const 99999999
+  stack        : [ i32.const 99999999 ; i32.const 4 ]
+  running instr: i32.store align=1
+  stack        : [  ]
+  running instr: i32.const 1
+  stack        : [ i32.const 1 ]
+  running instr: i32.load offset=1 align=1
+  stack        : [ i32.const -520159232 ]
+  running instr: drop
+  stack        : [  ]
+  stack        : [  ]

--- a/test/wasm2wat/memarg.wat
+++ b/test/wasm2wat/memarg.wat
@@ -1,0 +1,13 @@
+(module
+  (memory 1)
+  (func $f
+    i32.const 4
+    i32.const 99999999
+    i32.store
+
+    i32.const 1
+    i32.load align=2
+
+    drop
+  )
+  (start $f))


### PR DESCRIPTION
Fix #587.

@simon-camp, this should fix the issue you reported.

The first commit exhibit the bug: `stack : [ i32.const -16777216 ]` become `stack        : [ i32.const -520159232 ]` after going through the binary encoder.

And you can see the fix in the second one with the test now looking better.