### PR TITLE
add a bump allocator

### DIFF
--- a/src/cmd/cmd_replay.ml
+++ b/src/cmd/cmd_replay.ml
@@ -28,7 +28,7 @@ let run_file ~unsafe ~optimize ~entry_point ~invoke_with_symbols filename model
     let assume _ = ()
 
     let assert' n =
-      if not @@ Prelude.Int32.equal n 0l then begin
+      if Prelude.Int32.equal n 0l then begin
         Fmt.epr "Assertion failure was correctly reached\n";
         exit 0
       end
@@ -49,7 +49,9 @@ let run_file ~unsafe ~optimize ~entry_point ~invoke_with_symbols filename model
 
     let symbol_bool = symbol_char
 
-    let abort () = ()
+    let abort () =
+      Fmt.epr "Unexpected abort call.\n";
+      exit 121
 
     let alloc _m _addr size =
       let r = !brk in

--- a/test/replay/alloc.c
+++ b/test/replay/alloc.c
@@ -1,0 +1,12 @@
+#include <owi.h>
+#include <stdlib.h>
+
+int main() {
+  int size = owi_i32();
+  owi_assume(size < 10);
+  owi_assume(size > 0);
+  int* ptr = (int*) malloc(size);
+  free(ptr);
+  owi_assert(0);
+  return ptr;
+}

--- a/test/replay/alloc.scfg
+++ b/test/replay/alloc.scfg
@@ -1,0 +1,3 @@
+model {
+  symbol symbol_0 i32 9
+}

--- a/test/replay/alloc.t
+++ b/test/replay/alloc.t
@@ -1,0 +1,176 @@
+  $ owi c alloc.c -o alloc.wasm -O0 --no-value
+  Assert failure: false
+  model {
+    symbol symbol_0 i32
+  }
+  Reached problem!
+  [13]
+
+  $ owi replay --replay-file alloc.scfg alloc.wasm --entry-point=main --debug
+  typechecking ...
+  typechecking ...
+  linking      ...
+  interpreting ...
+  stack        : [  ]
+  running instr: i32.const 1024
+  stack        : [ i32.const 1024 ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ; i32.const 1024 ]
+  running instr: i32.const 4
+  stack        : [ i32.const 4 ; i32.const 0 ; i32.const 1024 ]
+  running instr: memory.init 0
+  stack        : [  ]
+  running instr: data.drop 0
+  stack        : [  ]
+  stack        : [  ]
+  running instr: call 12
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ; i32.const 0 ]
+  running instr: call 8
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: call 7
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: global.get 0
+  stack        : [ i32.const 8389648 ]
+  running instr: i32.const 16
+  stack        : [ i32.const 16 ; i32.const 8389648 ]
+  running instr: i32.sub
+  stack        : [ i32.const 8389632 ]
+  running instr: local.tee 0
+  stack        : [ i32.const 8389632 ]
+  running instr: global.set 0
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ]
+  running instr: call 3
+  stack        : [ i32.const 9 ; i32.const 8389632 ]
+  running instr: i32.store offset=12 align=4
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ]
+  running instr: i32.load offset=12 align=4
+  stack        : [ i32.const 9 ]
+  running instr: i32.const 10
+  stack        : [ i32.const 10 ; i32.const 9 ]
+  running instr: i32.lt_s
+  stack        : [ i32.const 1 ]
+  running instr: i32.const 1
+  stack        : [ i32.const 1 ; i32.const 1 ]
+  running instr: i32.and
+  stack        : [ i32.const 1 ]
+  running instr: call 4
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ]
+  running instr: i32.load offset=12 align=4
+  stack        : [ i32.const 9 ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ; i32.const 9 ]
+  running instr: i32.gt_s
+  stack        : [ i32.const 1 ]
+  running instr: i32.const 1
+  stack        : [ i32.const 1 ; i32.const 1 ]
+  running instr: i32.and
+  stack        : [ i32.const 1 ]
+  running instr: call 4
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ; i32.const 8389632 ]
+  running instr: i32.load offset=12 align=4
+  stack        : [ i32.const 9 ; i32.const 8389632 ]
+  running instr: call 5
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ]
+  running instr: i32.const -2147483648
+  stack        : [ i32.const -2147483648 ; i32.const 0 ]
+  running instr: local.get 0
+  stack        : [ i32.const 9 ; i32.const -2147483648 ; i32.const 0 ]
+  running instr: i32.clz
+  stack        : [ i32.const 28 ; i32.const -2147483648 ; i32.const 0 ]
+  running instr: i32.shr_u
+  stack        : [ i32.const 8 ; i32.const 0 ]
+  running instr: i32.const 16
+  stack        : [ i32.const 16 ; i32.const 8 ; i32.const 0 ]
+  running instr: local.get 0
+  stack        : [ i32.const 9 ; i32.const 16 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.const 32
+  stack        : [ i32.const 32 ; i32.const 9 ; i32.const 16 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.lt_u
+  stack        : [ i32.const 1 ; i32.const 16 ; i32.const 8 ; i32.const 0 ]
+  running instr: select
+  stack        : [ i32.const 8 ; i32.const 0 ]
+  running instr: local.tee 1
+  stack        : [ i32.const 8 ; i32.const 0 ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.load offset=1024 align=4
+  stack        : [ i32.const 8389648 ; i32.const 8 ; i32.const 0 ]
+  running instr: local.tee 2
+  stack        : [ i32.const 8389648 ; i32.const 8 ; i32.const 0 ]
+  running instr: local.get 1
+  stack        : [ i32.const 8 ; i32.const 8389648 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.const -1
+  stack        : [ i32.const -1 ; i32.const 8 ; i32.const 8389648 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.add
+  stack        : [ i32.const 7 ; i32.const 8389648 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.and
+  stack        : [ i32.const 0 ; i32.const 8 ; i32.const 0 ]
+  running instr: local.tee 1
+  stack        : [ i32.const 0 ; i32.const 8 ; i32.const 0 ]
+  running instr: i32.sub
+  stack        : [ i32.const 8 ; i32.const 0 ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ; i32.const 8 ; i32.const 0 ]
+  running instr: local.get 1
+  stack        : [ i32.const 0 ; i32.const 0 ; i32.const 8 ; i32.const 0 ]
+  running instr: select
+  stack        : [ i32.const 0 ; i32.const 0 ]
+  running instr: local.get 2
+  stack        : [ i32.const 8389648 ; i32.const 0 ; i32.const 0 ]
+  running instr: i32.add
+  stack        : [ i32.const 8389648 ; i32.const 0 ]
+  running instr: local.tee 1
+  stack        : [ i32.const 8389648 ; i32.const 0 ]
+  running instr: local.get 0
+  stack        : [ i32.const 9 ; i32.const 8389648 ; i32.const 0 ]
+  running instr: i32.add
+  stack        : [ i32.const 8389657 ; i32.const 0 ]
+  running instr: i32.store offset=1024 align=4
+  stack        : [  ]
+  running instr: local.get 1
+  stack        : [ i32.const 8389648 ]
+  running instr: local.get 0
+  stack        : [ i32.const 9 ; i32.const 8389648 ]
+  running instr: call 1
+  stack        : [ i32.const 0 ]
+  stack        : [ i32.const 0 ; i32.const 8389632 ]
+  running instr: i32.store offset=8 align=4
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 8389632 ]
+  running instr: i32.load offset=8 align=4
+  stack        : [ i32.const 0 ]
+  running instr: call 6
+  calling func : func anonymous
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 0 ]
+  running instr: call 2
+  stack        : [ i32.const 0 ]
+  running instr: drop
+  stack        : [  ]
+  stack        : [  ]
+  running instr: i32.const 0
+  stack        : [ i32.const 0 ]
+  running instr: call 0
+  Assertion failure was correctly reached

--- a/test/replay/assert_false.scfg
+++ b/test/replay/assert_false.scfg
@@ -1,4 +1,4 @@
 model {
-  symbol symbol_0 i32 -1852749051
-  symbol symbol_1 i32 293770786
+  symbol symbol_0 i32 294734597
+  symbol symbol_1 i32 -1853712862
 }

--- a/test/replay/assert_false.t
+++ b/test/replay/assert_false.t
@@ -21,27 +21,27 @@
   calling func : func f
   stack        : [  ]
   running instr: call 2
-  stack        : [ i32.const -1852749051 ]
+  stack        : [ i32.const 294734597 ]
   running instr: local.set 0
   stack        : [  ]
   running instr: call 2
-  stack        : [ i32.const 293770786 ]
+  stack        : [ i32.const -1853712862 ]
   running instr: local.set 1
   stack        : [  ]
   running instr: local.get 0
-  stack        : [ i32.const -1852749051 ]
+  stack        : [ i32.const 294734597 ]
   running instr: local.get 1
-  stack        : [ i32.const 293770786 ; i32.const -1852749051 ]
+  stack        : [ i32.const -1853712862 ; i32.const 294734597 ]
   running instr: i32.lt_u
-  stack        : [ i32.const 0 ]
+  stack        : [ i32.const 1 ]
   running instr: call 1
   stack        : [  ]
   running instr: local.get 0
-  stack        : [ i32.const -1852749051 ]
+  stack        : [ i32.const 294734597 ]
   running instr: local.get 1
-  stack        : [ i32.const 293770786 ; i32.const -1852749051 ]
+  stack        : [ i32.const -1853712862 ; i32.const 294734597 ]
   running instr: i32.gt_u
-  stack        : [ i32.const 1 ]
+  stack        : [ i32.const 0 ]
   running instr: call 0
   Assertion failure was correctly reached
 

--- a/test/replay/dune
+++ b/test/replay/dune
@@ -2,6 +2,8 @@
  (deps
   %{bin:owi}
   (package owi)
+  alloc.c
+  alloc.scfg
   all_types.wat
   assert_false.wat
   assert_false.scfg

--- a/test/replay/range.t
+++ b/test/replay/range.t
@@ -35,4 +35,36 @@
   running instr: i32.ge_u
   stack        : [ i32.const 1 ]
   running instr: call 1
+  stack        : [  ]
+  running instr: local.get 0
+  stack        : [ i32.const 16 ]
+  running instr: i32.const 20
+  stack        : [ i32.const 20 ; i32.const 16 ]
+  running instr: i32.lt_u
+  stack        : [ i32.const 1 ]
+  running instr: call 1
+  stack        : [  ]
+  running instr: i32.const 200
+  stack        : [ i32.const 200 ]
+  running instr: i32.const 300
+  stack        : [ i32.const 300 ; i32.const 200 ]
+  running instr: call 0
+  stack        : [ i32.const 299 ]
+  running instr: local.set 1
+  stack        : [  ]
+  running instr: local.get 1
+  stack        : [ i32.const 299 ]
+  running instr: i32.const 200
+  stack        : [ i32.const 200 ; i32.const 299 ]
+  running instr: i32.ge_u
+  stack        : [ i32.const 1 ]
+  running instr: call 1
+  stack        : [  ]
+  running instr: local.get 1
+  stack        : [ i32.const 299 ]
+  running instr: i32.const 299
+  stack        : [ i32.const 299 ; i32.const 299 ]
+  running instr: i32.lt_u
+  stack        : [ i32.const 0 ]
+  running instr: call 1
   Assertion failure was correctly reached


### PR DESCRIPTION
closes #528 

For now, I get `Invalid_argument("index out of bounds")` on the following example: 
[example.zip](https://github.com/user-attachments/files/19633129/example.zip)
