### PR TITLE
proper error on double free

### DIFF
--- a/src/interpret/trap.ml
+++ b/src/interpret/trap.ml
@@ -16,6 +16,7 @@ type t =
   | Extern_call_null_arg
   | Memory_leak_use_after_free
   | Memory_heap_buffer_overflow
+  | Double_free
 
 let to_string = function
   | Out_of_bounds_table_access -> "out of bounds table access"
@@ -31,3 +32,4 @@ let to_string = function
   | Extern_call_null_arg -> "extern call null arg"
   | Memory_leak_use_after_free -> "memory leak use after free"
   | Memory_heap_buffer_overflow -> "memory heap buffer overflow"
+  | Double_free -> "double free"

--- a/src/interpret/trap.mli
+++ b/src/interpret/trap.mli
@@ -16,5 +16,6 @@ type t =
   | Extern_call_null_arg
   | Memory_leak_use_after_free
   | Memory_heap_buffer_overflow
+  | Double_free
 
 val to_string : t -> string

--- a/src/intf/symbolic_memory_intf.ml
+++ b/src/intf/symbolic_memory_intf.ml
@@ -53,8 +53,7 @@ module type S = sig
     -> size:Smtml.Expr.t
     -> Smtml.Expr.t Symbolic_choice_without_memory.t
 
-  val free :
-    t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t
+  val free : t -> Smtml.Expr.t -> Smtml.Expr.t Symbolic_choice_without_memory.t
 
   val load_8_s :
     t -> Smtml.Expr.t -> Symbolic_value.int32 Symbolic_choice_without_memory.t

--- a/src/symbolic/symbolic_memory_concretizing.ml
+++ b/src/symbolic/symbolic_memory_concretizing.ml
@@ -143,12 +143,12 @@ module Backend = struct
 
   let free m p =
     let open Symbolic_choice_without_memory in
-    let+ base = ptr p in
-    if not @@ Map.mem base m.chunks then Fmt.failwith "Memory leak double free"
+    let* base = ptr p in
+    if not @@ Map.mem base m.chunks then trap Trap.Double_free
     else begin
       let chunks = Map.remove base m.chunks in
       m.chunks <- chunks;
-      Symbolic_value.const_i32 base
+      return (Symbolic_value.const_i32 base)
     end
 
   let realloc m ~ptr ~size =

--- a/test/c/double_free.c
+++ b/test/c/double_free.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+void f(void) {
+  void *a = malloc(10);
+  free(a);
+  free(a);
+}

--- a/test/c/double_free.t
+++ b/test/c/double_free.t
@@ -1,0 +1,5 @@
+  $ owi c double_free.c --entry-point=f
+  Trap: double free
+  model
+  Reached problem!
+  [13]

--- a/test/c/dune
+++ b/test/c/dune
@@ -5,10 +5,11 @@
   bool.c
   char.c
   concolic.c
+  double_free.c
   entry_point.c
   exit.c
+  invoke_with_symbols.c
   klee_compat.c
   main.c
   malloc_aligned.c
-  range.c
-  invoke_with_symbols.c))
+  range.c))


### PR DESCRIPTION
As noticed in #602, we were not properly displaying a model after a double free, but crashing brutally. This is now fixed. :)