### PR TITLE
fix `model-out-file` when set with `--no-stop-at-failure`

### DIFF
--- a/test/c/dune
+++ b/test/c/dune
@@ -14,4 +14,5 @@
   main.c
   malloc_aligned.c
   malloc_zero.c
+  multi_model.c
   range.c))

--- a/test/c/multi_model.c
+++ b/test/c/multi_model.c
@@ -1,0 +1,11 @@
+#include <owi.h>
+
+int main() {
+    int nondet = owi_bool();
+    if (nondet) {
+        owi_assert(0);
+    } else {
+        owi_assert(0);
+    }
+    return 0;
+}

--- a/test/c/multi_model.t
+++ b/test/c/multi_model.t
@@ -1,0 +1,7 @@
+  $ owi c multi_model.c -O0 --no-stop-at-failure --model-out-file=multi_model
+  Assert failure: false
+  Assert failure: false
+  Reached 2 problems!
+  [13]
+  $ rm multi_model_0.scfg
+  $ rm multi_model_1.scfg


### PR DESCRIPTION
~fixes an error in `test\fuzz\interprets.ml` as well~