### PR TITLE
Pp group assign rewrite

### DIFF
--- a/src/ast/compile.ml
+++ b/src/ast/compile.ml
@@ -10,7 +10,7 @@ module Text = struct
 
   let until_group ~unsafe m =
     let* m = until_text_validate ~unsafe m in
-    Grouped.of_symbolic m
+    Grouped.of_text m
 
   let until_assign ~unsafe m =
     let* m = until_group ~unsafe m in

--- a/src/ast/types.ml
+++ b/src/ast/types.ml
@@ -917,7 +917,7 @@ type 'a str_type =
   | Def_array_t of 'a field_type
   | Def_func_t of 'a func_type
 
-let str_type fmt = function
+let pp_str_type fmt = function
   | Def_struct_t t -> pp_struct_type fmt t
   | Def_array_t t -> pp_array_type fmt t
   | Def_func_t t -> pp_func_type fmt t
@@ -937,7 +937,7 @@ let compare_str_type t1 t2 =
 type 'a sub_type = final * 'a indice list * 'a str_type
 
 let pp_sub_type fmt (f, ids, t) =
-  pf fmt "(sub %a %a %a)" pp_final f pp_indices ids str_type t
+  pf fmt "(sub %a %a %a)" pp_final f pp_indices ids pp_str_type t
 
 let sub_type_eq (f1, ids1, t1) (f2, ids2, t2) =
   final_eq f1 f2 && List.equal indice_eq ids1 ids2 && str_type_eq t1 t2

--- a/src/data_structures/imported.ml
+++ b/src/data_structures/imported.ml
@@ -9,3 +9,7 @@ type 'a t =
   ; assigned_name : string option
   ; desc : 'a
   }
+
+let pp pp_desc fmt { modul; name; assigned_name; desc } =
+  Fmt.pf fmt "{@\n  @[<v>modul: %S@\nname: %S@\nassigned_name: %a@\ndesc: %a@]}"
+    modul name Types.pp_id_opt assigned_name pp_desc desc

--- a/src/data_structures/imported.mli
+++ b/src/data_structures/imported.mli
@@ -9,3 +9,5 @@ type 'a t =
   ; assigned_name : string option
   ; desc : 'a
   }
+
+val pp : 'a Fmt.t -> Format.formatter -> 'a t -> unit

--- a/src/data_structures/indexed.ml
+++ b/src/data_structures/indexed.ml
@@ -29,3 +29,10 @@ let list_to_array l =
     l
   |> List.map (fun { value; _ } -> value)
   |> Array.of_list
+
+let pp pp_v fmt { index; value } =
+  Fmt.pf fmt "{ index = %d ; value = %a }" index pp_v value
+
+let pp_list pp_v fmt l =
+  let pp fmt v = pp pp_v fmt v in
+  Fmt.pf fmt "[%a]" (Fmt.list ~sep:(fun fmt () -> Fmt.pf fmt " ; ") pp) l

--- a/src/data_structures/indexed.mli
+++ b/src/data_structures/indexed.mli
@@ -17,3 +17,7 @@ val get_at : int -> 'a t list -> 'a option
 val has_index : int -> 'a t -> bool
 
 val list_to_array : 'a t list -> 'a array
+
+val pp : 'a Fmt.t -> Format.formatter -> 'a t -> unit
+
+val pp_list : 'a Fmt.t -> Format.formatter -> 'a t list -> unit

--- a/src/data_structures/named.ml
+++ b/src/data_structures/named.ml
@@ -22,3 +22,16 @@ let map f v =
   { v with values }
 
 let to_array v = Indexed.list_to_array v.values
+
+let pp_values pp_v fmt values = Indexed.pp_list pp_v fmt values
+
+let pp_named fmt named =
+  Fmt.iter_bindings
+    ~sep:(fun fmt () -> Fmt.pf fmt " ; ")
+    String_map.iter
+    (fun fmt (name, n) -> Fmt.pf fmt "(%S, %d)" name n)
+    fmt named
+
+let pp pp_v fmt { values; named } =
+  Fmt.pf fmt "{@\n  @[<v>values: %a@\nnamed: %a@]}" (pp_values pp_v) values
+    pp_named named

--- a/src/data_structures/named.mli
+++ b/src/data_structures/named.mli
@@ -16,3 +16,5 @@ val fold : (int -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 val map : ('a Indexed.t -> 'b Indexed.t) -> 'a t -> 'b t
 
 val to_array : 'a t -> 'a array
+
+val pp : 'a Fmt.t -> Format.formatter -> 'a t -> unit

--- a/src/data_structures/runtime.ml
+++ b/src/data_structures/runtime.ml
@@ -5,3 +5,8 @@
 type ('a, 'b) t =
   | Local of 'a
   | Imported of 'b Imported.t
+
+let pp ~pp_local ~pp_imported fmt = function
+  | Local local -> Fmt.pf fmt "Local (%a)" pp_local local
+  | Imported imported ->
+    Fmt.pf fmt "Imported (%a)" (Imported.pp pp_imported) imported

--- a/src/data_structures/runtime.mli
+++ b/src/data_structures/runtime.mli
@@ -2,6 +2,13 @@
 (* Copyright © 2021-2024 OCamlPro *)
 (* Written by the Owi programmers *)
 
-type ('a, 'b) t =
-  | Local of 'a
-  | Imported of 'b Imported.t
+type ('local, 'imported) t =
+  | Local of 'local
+  | Imported of 'imported Imported.t
+
+val pp :
+     pp_local:'local Fmt.t
+  -> pp_imported:'imported Fmt.t
+  -> Format.formatter
+  -> ('local, 'imported) t
+  -> unit

--- a/src/text_to_binary/assigned.ml
+++ b/src/text_to_binary/assigned.ml
@@ -63,7 +63,19 @@ let pp_annots fmt annots =
 let pp fmt
   { id; typ; global; table; mem; func; elem; data; exports; start; annots } =
   Fmt.pf fmt
-    {|{@\n  @[<v>id: %a@\ntyp: %a@\nglobal: %a@\ntable: %a@\nmem: %a@\nfunc: %a@\nelem: %a@\ndata: %a@\nexports: %a@\nstart: %a@\nannots: %a@]@\n}|}
+    "{@\n\
+    \  @[<v>id: %a@\n\
+     typ: %a@\n\
+     global: %a@\n\
+     table: %a@\n\
+     mem: %a@\n\
+     func: %a@\n\
+     elem: %a@\n\
+     data: %a@\n\
+     exports: %a@\n\
+     start: %a@\n\
+     annots: %a@]@\n\
+     }"
     pp_id id pp_typ typ pp_global global pp_table table pp_mem mem pp_func func
     pp_elem elem pp_data data Grouped.pp_opt_exports exports pp_start start
     pp_annots annots

--- a/src/text_to_binary/assigned.mli
+++ b/src/text_to_binary/assigned.mli
@@ -33,3 +33,5 @@ val find_table : t -> text indice -> binary indice Result.t
 val find_elem : t -> text indice -> binary indice Result.t
 
 val find_type : t -> text indice -> binary indice Result.t
+
+val pp : Format.formatter -> t -> unit

--- a/src/text_to_binary/grouped.ml
+++ b/src/text_to_binary/grouped.ml
@@ -110,7 +110,21 @@ let pp fmt
   ; annots
   } =
   Fmt.pf fmt
-    {|{@\n  @[<v>id: %a@\ntyp: %a@\nfunction_type: %a@\ntype_checks: %a@\nglobal: %a@\ntable: %a@\nmem: %a@\nfunc: %a@\nelem: %a@\ndata: %a@\nexports: %a@\nstart: %a@\nannots: %a@]@\n}|}
+    "{@\n\
+    \  @[<v>id: %a@\n\
+     typ: %a@\n\
+     function_type: %a@\n\
+     type_checks: %a@\n\
+     global: %a@\n\
+     table: %a@\n\
+     mem: %a@\n\
+     func: %a@\n\
+     elem: %a@\n\
+     data: %a@\n\
+     exports: %a@\n\
+     start: %a@\n\
+     annots: %a@]@\n\
+     }"
     pp_id id pp_typ typ pp_function_type function_type pp_type_checks
     type_checks pp_global global pp_table table pp_mem mem pp_func func pp_elem
     elem pp_data data pp_opt_exports exports pp_start start pp_annots annots

--- a/src/text_to_binary/grouped.ml
+++ b/src/text_to_binary/grouped.ml
@@ -110,9 +110,8 @@ let pp fmt
   ; annots
   } =
   Fmt.pf fmt
-    "{@\n\
-    \  @[<v>id: %a@\n\
-     typ: %a@\n\
+    "{id: %a@\n\
+    \  @[<v>typ: %a@\n\
      function_type: %a@\n\
      type_checks: %a@\n\
      global: %a@\n\

--- a/src/text_to_binary/grouped.ml
+++ b/src/text_to_binary/grouped.ml
@@ -286,9 +286,11 @@ let add_field curr (fields : t) = function
     ok @@ add_data data fields curr
   | MStart start -> Ok { fields with start = Some start }
 
-let of_symbolic { Text.fields; id; annots } =
+let of_text { Text.fields; id; annots } =
   Logs.debug (fun m -> m "grouping     ...");
   let+ modul =
     list_fold_left (add_field (init_curr ())) (empty_module id) fields
   in
-  { modul with annots }
+  let modul = { modul with annots } in
+  Logs.debug (fun m -> m "%a" pp modul);
+  modul

--- a/src/text_to_binary/grouped.mli
+++ b/src/text_to_binary/grouped.mli
@@ -39,3 +39,5 @@ type t =
   }
 
 val of_symbolic : Text.modul -> t Result.t
+
+val pp : Format.formatter -> t -> unit

--- a/src/text_to_binary/grouped.mli
+++ b/src/text_to_binary/grouped.mli
@@ -16,6 +16,8 @@ type opt_exports =
   ; func : opt_export list
   }
 
+val pp_opt_exports : Format.formatter -> opt_exports -> unit
+
 type type_check = text indice * text func_type
 
 type t =
@@ -38,6 +40,6 @@ type t =
   ; annots : text Annot.annot list
   }
 
-val of_symbolic : Text.modul -> t Result.t
+val of_text : Text.modul -> t Result.t
 
 val pp : Format.formatter -> t -> unit

--- a/test/sym/print_pc.t
+++ b/test/sym/print_pc.t
@@ -2,7 +2,84 @@
   owi: [INFO] parsing      ...
   owi: [INFO] checking     ...
   owi: [DEBUG] grouping     ...
+  owi: [DEBUG] {id: 
+                 typ: []
+                 function_type: [(func (param $x i32)) ; (func (result i32))]
+                 type_checks: []
+                 global: []
+                 table: []
+                 mem: []
+                 func: [{ index = 1 ; value = Local ((func $f (param $x i32)
+                   local.get $x
+                   i32.const 1
+                   i32.lt_u
+                   (if
+                     (then
+                       unreachable
+                     )
+                   )
+                 )) } ; { index = 0 ; value = Imported ({
+                   modul: "symbolic"
+                   name: "i32_symbol"
+                   assigned_name:  $i32_symbol
+                   desc:  (result i32)}) }]
+                 elem: []
+                 data: []
+                 exports: {
+                   global: []
+                   mem: []
+                   table: []
+                   func: [("f", $f)]
+                   }
+                 start: 
+                 annots: []
+               }
   owi: [DEBUG] assigning    ...
+  owi: [DEBUG] {
+                 id: 
+                 typ: {
+                   values: [{ index = 0 ; value = (func (result i32)) } ; { index = 1 ; value = (func (param $x i32)) }]
+                   named: }
+                 global: {
+                   values: []
+                   named: }
+                 table: {
+                   values: []
+                   named: }
+                 mem: {
+                   values: []
+                   named: }
+                 func: {
+                   values: [{ index = 1 ; value = Local ((func $f (param $x i32)
+                     local.get $x
+                     i32.const 1
+                     i32.lt_u
+                     (if
+                       (then
+                         unreachable
+                       )
+                     )
+                   )) } ; { index = 0 ; value = Imported ({
+                     modul: "symbolic"
+                     name: "i32_symbol"
+                     assigned_name:  $i32_symbol
+                     desc:  (result i32)}) }]
+                   named: ("f", 1) ; ("i32_symbol", 0)}
+                 elem: {
+                   values: []
+                   named: }
+                 data: {
+                   values: []
+                   named: }
+                 exports: {
+                   global: []
+                   mem: []
+                   table: []
+                   func: [("f", $f)]
+                   }
+                 start: 
+                 annots: []
+               }
   owi: [DEBUG] rewriting    ...
   owi: [INFO] typechecking ...
   owi: [INFO] typechecking ...


### PR DESCRIPTION
cc @Ekdohibs, running with `-vv` should now display the grouped and the assigned module. The rendering is not perfect but it should be more than good enough to help debugging (you can see a sample output by looking at the promoted test)