### PR TITLE
fix src/dune

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -127,7 +127,6 @@
   fmt.tty
   smtml
   hc
-  integers
   logs
   logs.cli
   logs.fmt


### PR DESCRIPTION
The `integers` dependency was removed in 4b37195b07faddda599eaf7f8c8054597855f7c8 .