### PR TITLE
Log SMT queries per test

### DIFF
--- a/bench/tool/tool.ml
+++ b/bench/tool/tool.ml
@@ -49,6 +49,8 @@ let wait_pid =
         Unix.sleepf timeout;
         did_timeout := true;
         (* we kill the process group id (pgid) which should be equal to pid *)
+        Unix.kill (-pid) 15;
+        Unix.sleepf 1.;
         Unix.kill (-pid) 9;
         Sys.set_signal Sys.sigchld Signal_default
       with Sigchld -> ()


### PR DESCRIPTION
This issue starts logging all SMT queries sent to the solver during each test in bench/. Logs are written to a queries_log.jsonl file per test.

What works
- Each query is logged as JSON (hash + assumptions).

Known issues
- No timing or performance info is logged yet.

Next steps
- Add query timing, memory, and CPU metrics.

How to use
```
git clone https://github.com/felixL-K/smtml -b trace-smt-queries
cd smtml && dune b @install && dune install

git clone https://github.com/felixL-K/owi -b trace-queries2
cd owi && dune exec -- testcomp/testcomp.exe <your-test-id>
```
