### PR TITLE
fix ABI for __int128, it does not compile to a Wasm v128 but to a

### DIFF
--- a/src/lang_c/libowi/include/owi.h
+++ b/src/lang_c/libowi/include/owi.h
@@ -18,8 +18,8 @@ __attribute__((import_module("owi"), import_name("i64_symbol")))  int64_t  owi_i
 __attribute__((import_module("owi"), import_name("i64_symbol"))) uint64_t owi_uint64(void);
 
 #ifndef __FRAMAC__
-__attribute__((import_module("owi"), import_name("v128_symbol"))) __int128 owi_int128(void);
-__attribute__((import_module("owi"), import_name("v128_symbol"))) unsigned __int128 owi_uint128(void);
+__int128 owi_int128(void);
+unsigned __int128 owi_uint128(void);
 #endif
 
 _Static_assert(sizeof(float) == 4, "Unsupported float size. Please open an issue.");

--- a/src/lang_c/libowi/src/owi.c
+++ b/src/lang_c/libowi/src/owi.c
@@ -57,3 +57,15 @@ long long owi_long_long(void) {
 unsigned long long owi_unsigned_long_long(void) {
   return magic_size_unsigned(unsigned long long);
 }
+
+__int128 owi_int128(void) {
+  int64_t high = owi_int64();
+  int64_t low = owi_int64();
+  return (__int128_t) high << 64 | (__uint128_t) low;
+}
+
+unsigned __int128 owi_uint128(void) {
+  int64_t high = owi_int64();
+  int64_t low = owi_int64();
+  return (__uint128_t) high << 64 | (__uint128_t) low;
+}


### PR DESCRIPTION
pointer to two i64 stored in memory...