### PR TITLE
Remove lift mem

### DIFF
--- a/src/concrete/concrete_memory.ml
+++ b/src/concrete/concrete_memory.ml
@@ -25,7 +25,8 @@ let grow mem delta =
   let old_size = Bytes.length mem.data in
   let new_mem = Bytes.extend mem.data 0 delta in
   Bytes.unsafe_fill new_mem old_size delta (Char.chr 0);
-  update_memory mem new_mem
+  update_memory mem new_mem;
+  Ok ()
 
 let fill mem ~pos ~len c =
   let pos = Int32.to_int pos in
@@ -44,7 +45,8 @@ let blit_string mem str ~src ~dst ~len =
   let src = Int32.to_int src in
   let dst = Int32.to_int dst in
   let len = Int32.to_int len in
-  Bytes.unsafe_blit_string str src mem.data dst len
+  Bytes.unsafe_blit_string str src mem.data dst len;
+  Ok ()
 
 let get_limit_max { limits; _ } = Option.map Int64.of_int limits.max
 

--- a/src/intf/memory_intf.ml
+++ b/src/intf/memory_intf.ml
@@ -27,14 +27,14 @@ module type T = sig
 
   val store_64 : t -> addr:i32 -> i64 -> unit choice
 
-  val grow : t -> i32 -> unit
+  val grow : t -> i32 -> unit choice
 
   val fill : t -> pos:i32 -> len:i32 -> char -> unit choice
 
   val blit :
     src:t -> src_idx:i32 -> dst:t -> dst_idx:i32 -> len:i32 -> unit choice
 
-  val blit_string : t -> string -> src:i32 -> dst:i32 -> len:i32 -> unit
+  val blit_string : t -> string -> src:i32 -> dst:i32 -> len:i32 -> unit choice
 
   val size : t -> i32
 

--- a/src/symbolic/state_monad.ml
+++ b/src/symbolic/state_monad.ml
@@ -46,11 +46,3 @@ let[@inline] liftF2 f x y = fun st -> f (run x st) (run y st)
 let[@inline] with_state f = fun st -> M.return (f st)
 
 let[@inline] modify_state f = fun st -> M.return ((), f st)
-
-let[@inline] project_state (project_and_backup : 'st1 -> 'st2 * 'backup) restore
-  other =
- fun st ->
-  let ( let+ ) = M.( let+ ) in
-  let proj, backup = project_and_backup st in
-  let+ res, new_state = run other proj in
-  (res, restore backup new_state)

--- a/src/symbolic/symbolic_choice.ml
+++ b/src/symbolic/symbolic_choice.ml
@@ -370,6 +370,3 @@ let assume c instr_counter =
       ~prio_false ~check_only_true_branch:true
   in
   if assertion_true then Eval_monad.return () else stop
-
-let lift_mem (mem_op : 'a t) : 'a t =
-  State_monad.project_state Thread.project Thread.restore mem_op

--- a/src/symbolic/symbolic_choice.mli
+++ b/src/symbolic/symbolic_choice.mli
@@ -67,5 +67,3 @@ val ite :
   -> Symbolic_value.t t
 
 val depth : unit -> int t
-
-val lift_mem : 'a t -> 'a t

--- a/src/symbolic/symbolic_memory_collection.ml
+++ b/src/symbolic/symbolic_memory_collection.ml
@@ -3,20 +3,25 @@
 module Map = Map.Make (Int32)
 
 type memory =
-  { mutable data : Symbolic_i32.t Map.t
-  ; mutable chunks : Symbolic_i32.t Map.t
-  ; mutable size : Symbolic_i32.t
+  { data : Symbolic_i32.t Map.t
+  ; chunks : Symbolic_i32.t Map.t
+  ; size : Symbolic_i32.t
+  ; id : int * int
   }
 
-let create_one size =
-  { data = Map.empty; chunks = Map.empty; size = Symbolic_i32.of_concrete size }
+let create_one size id =
+  { data = Map.empty
+  ; chunks = Map.empty
+  ; size = Symbolic_i32.of_concrete size
+  ; id
+  }
 
 (* WARNING: because we are doing an optimization in `Symbolic_choice`, the cloned state should not refer to a mutable value of the previous state. Assuming that the original state is not mutated is wrong. *)
-let clone_one { data; chunks; size } = { data; chunks; size }
+let clone_one m = m
 
-let convert (orig_mem : Concrete_memory.t) : memory =
+let convert (orig_mem : Concrete_memory.t) id : memory =
   let s = Concrete_memory.size_in_pages orig_mem in
-  create_one s
+  create_one s id
 
 type collection = (int * int, memory) Hashtbl.t
 
@@ -35,7 +40,9 @@ let get_memory env_id (orig_memory : Concrete_memory.t) collection g_id =
   let loc = (env_id, g_id) in
   match Hashtbl.find_opt collection loc with
   | None ->
-    let g = convert orig_memory in
+    let g = convert orig_memory loc in
     Hashtbl.add collection loc g;
     g
   | Some t -> t
+
+let set_memory collection memory = Hashtbl.replace collection memory.id memory

--- a/src/symbolic/symbolic_memory_collection.mli
+++ b/src/symbolic/symbolic_memory_collection.mli
@@ -3,9 +3,10 @@
 (* Written by the Owi programmers *)
 
 type memory =
-  { mutable data : Symbolic_i32.t Map.Make(Int32).t
-  ; mutable chunks : Symbolic_i32.t Map.Make(Int32).t
-  ; mutable size : Symbolic_i32.t
+  { data : Symbolic_i32.t Map.Make(Int32).t
+  ; chunks : Symbolic_i32.t Map.Make(Int32).t
+  ; size : Symbolic_i32.t
+  ; id : int * int
   }
 
 type collection
@@ -15,3 +16,5 @@ val init : unit -> collection
 val clone : collection -> collection
 
 val get_memory : int -> Concrete_memory.t -> collection -> int -> memory
+
+val set_memory : collection -> memory -> unit

--- a/src/symbolic/thread.ml
+++ b/src/symbolic/thread.ml
@@ -121,37 +121,3 @@ let clone
   ; bench_stats
   ; depth
   }
-
-let project (th : t) : t * _ =
-  let projected =
-    let num_symbols = num_symbols th in
-    let symbol_scopes = symbol_scopes th in
-    let pc = pc th in
-    let memories = Symbolic_memory_collection.init () in
-    let tables = tables th in
-    let globals = globals th in
-    let breadcrumbs = breadcrumbs th in
-    let labels = labels th in
-    let bench_stats = bench_stats th in
-    let depth = depth th in
-    create num_symbols symbol_scopes pc memories tables globals breadcrumbs
-      labels bench_stats ~depth
-  in
-  let backup = memories th in
-  (projected, backup)
-
-let restore backup th =
-  let num_symbols = num_symbols th in
-  let symbol_scopes = symbol_scopes th in
-  let pc = pc th in
-  let memories =
-    if true then Symbolic_memory_collection.clone backup else backup
-  in
-  let tables = tables th in
-  let globals = globals th in
-  let breadcrumbs = breadcrumbs th in
-  let labels = labels th in
-  let bench_stats = bench_stats th in
-  let depth = depth th in
-  create num_symbols symbol_scopes pc memories tables globals breadcrumbs labels
-    bench_stats ~depth

--- a/src/symbolic/thread.mli
+++ b/src/symbolic/thread.mli
@@ -56,7 +56,3 @@ val close_scope : t -> t
 val incr_path_count : t -> unit
 
 val incr_num_symbols : t -> t
-
-val project : t -> t * Symbolic_memory_collection.collection
-
-val restore : Symbolic_memory_collection.collection -> t -> t


### PR DESCRIPTION
@krtab, see the last commit for my currently failing attempt at removing lift_mem.

I basically made the memory immutable, which mean we now have to update the memory collection, this is done by adding an `id` to the memory. I was getting a lot of testcases errors coming from elements/table so I went into the interpreter to add potentially missing `Env.get_{table,elem,data}`. I also feel we should make all collections immutable, but also tables and everything.