### PR TITLE
chore(ci) : check copyright header on new .ml and .mli files #260

### DIFF
--- a/.github/check-headers.sh
+++ b/.github/check-headers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+END_YEAR=2024
+
+EXPECTED=$(cat <<EOF
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-${END_YEAR} OCamlPro *)
+(* Written by the Owi programmers *)
+EOF
+)
+
+if [ $# -eq 0 ]; then
+  echo "No files to check."
+  exit 0
+fi
+
+missing=()
+for file in "$@"; do
+  case "$file" in
+    *.ml|*.mli) ;;
+    *) continue ;;
+  esac
+  [ -f "$file" ] || continue
+  actual=$(head -n 3 "$file")
+  if [ "$actual" != "$EXPECTED" ]; then
+    missing+=("$file")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "The following new files have a missing or incorrect license header:"
+  printf '  %s\n' "${missing[@]}"
+  echo
+  echo "Expected header:"
+  echo "${EXPECTED}" | sed 's/^/  /'
+  exit 1
+fi
+
+echo "All new .ml and .mli files have a correct license header."

--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -1,0 +1,35 @@
+name: Check copyright headers
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  license-check:
+    name: Check license headers on new files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List new .ml and .mli files
+        id: new-files
+        run: |
+          files=$(git diff --name-only --diff-filter=A \
+            "origin/${{ github.base_ref }}"...HEAD \
+            -- '*.ml' '*.mli')
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$files" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Check License Header
+        run: |
+          if [ -z "${{ steps.new-files.outputs.files }}" ]; then
+            echo "No new .ml or .mli files in this PR."
+            exit 0
+          fi
+          xargs ./.github/check-headers.sh <<< "${{ steps.new-files.outputs.files }}"


### PR DESCRIPTION
## Summary

Adds a CI check that verifies new `.ml` and `.mli` files added in a pull
  request contain the expected copyright header:

  (* SPDX-License-Identifier: AGPL-3.0-or-later )
  ( Copyright © 2021-2024 OCamlPro )
  ( Written by the Owi programmers *)

## Details

  - `.github/check-headers.sh`: small bash script that takes a list of files
    as arguments, filters `.ml`/`.mli`, and checks the first 3 lines against
    the expected header. The end year is a single variable (`END_YEAR`) at
    the top of the script, easy to bump.
  - `.github/workflows/check-header.yml`: runs on `pull_request`, computes
    the list of **added** files (`git diff --diff-filter=A` between the PR
    base and HEAD), and passes them to the script. The job does not run when
    the PR does not add any `.ml`/`.mli` file.


Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité. 
Apologies if this is inappropriate or if the contribution does not meet the project’s standards 
— any feedback is welcome.