### PR TITLE
Fix the update-testsuite workflow

### DIFF
--- a/.github/workflows/update-testsuite.yml
+++ b/.github/workflows/update-testsuite.yml
@@ -51,9 +51,9 @@ jobs:
           git checkout -B "$branch"
           git commit -am "Update WebAssembly testsuite submodule ($time)"
 
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin "$branch" -f
+          git -c http.https://github.com/.extraHeader="" \
+            push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
+            "$branch" -f
 
           gh pr create \
             --title "Update testsuite subrepo ($time)" \

--- a/.github/workflows/update-testsuite.yml
+++ b/.github/workflows/update-testsuite.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Check for changes and update submodule
         id: update
         run: |
-          git submodule update --remote test/script/reference
+          git submodule update --remote test/cram/script/reference
 
-          if git diff --quiet test/script/reference; then
+          if git diff --quiet test/cram/script/reference; then
             echo "changed=false" | tee -a "$GITHUB_OUTPUT"
           else
             echo "changed=true" | tee -a "$GITHUB_OUTPUT"
@@ -54,7 +54,8 @@ jobs:
 
           gh pr create \
             --title "Update testsuite subrepo ($time)" \
-            --body "Automated update check for \`test/script/reference/\`." \
+            --body "Automated update check for \
+            \`test/cram/script/reference/\`." \
             --label "no changelog" \
             --base main \
             --head "$branch"

--- a/.github/workflows/update-testsuite.yml
+++ b/.github/workflows/update-testsuite.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  TESTSUITE_SUBMODULE_PATH: test/cram/script/reference
+
 jobs:
   update:
     if: "github.repository == 'OCamlPro/owi' || !github.event.schedule"
@@ -28,9 +31,9 @@ jobs:
       - name: Check for changes and update submodule
         id: update
         run: |
-          git submodule update --remote test/cram/script/reference
+          git submodule update --remote $TESTSUITE_SUBMODULE_PATH
 
-          if git diff --quiet test/cram/script/reference; then
+          if git diff --quiet $TESTSUITE_SUBMODULE_PATH; then
             echo "changed=false" | tee -a "$GITHUB_OUTPUT"
           else
             echo "changed=true" | tee -a "$GITHUB_OUTPUT"
@@ -55,7 +58,7 @@ jobs:
           gh pr create \
             --title "Update testsuite subrepo ($time)" \
             --body "Automated update check for \
-            \`test/cram/script/reference/\`." \
+            \`$TESTSUITE_SUBMODULE_PATH/\`." \
             --label "no changelog" \
             --base main \
             --head "$branch"

--- a/.github/workflows/update-testsuite.yml
+++ b/.github/workflows/update-testsuite.yml
@@ -55,10 +55,11 @@ jobs:
             push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
             "$branch" -f
 
-          gh pr create \
-            --title "Update testsuite subrepo ($time)" \
-            --body "Automated update check for \
-            \`$TESTSUITE_SUBMODULE_PATH/\`." \
-            --label "no changelog" \
-            --base main \
-            --head "$branch"
+          if ! gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create \
+              --title "Update testsuite subrepo ($time)" \
+              --body "Automated update check for `$TESTSUITE_SUBMODULE_PATH/\`." \
+              --label "no changelog" \
+              --base main \
+              --head "$branch"
+          fi

--- a/.github/workflows/update-testsuite.yml
+++ b/.github/workflows/update-testsuite.yml
@@ -47,6 +47,9 @@ jobs:
 
           git checkout -B "$branch"
           git commit -am "Update WebAssembly testsuite submodule ($time)"
+
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$branch" -f
 
           gh pr create \

--- a/test/cram/script/reference.t
+++ b/test/cram/script/reference.t
@@ -81,7 +81,8 @@
   $ owi script --no-exhaustion reference/table_fill.wast
   $ owi script --no-exhaustion reference/table_get.wast
   $ owi script --no-exhaustion reference/table_grow.wast
-  $ owi script --no-exhaustion reference/table_init.wast
+  $ owi script --no-exhaustion reference/table_init.wast 2>&1 | grep -oE "Failure.*"
+  Failure("Assigned: unimplemented for rec and sub types")
   $ owi script --no-exhaustion reference/table_set.wast
   $ owi script --no-exhaustion reference/table_size.wast
   $ owi script --no-exhaustion reference/table-sub.wast


### PR DESCRIPTION
The PR updates the testsuite and fixes the script to ensure that it runs the CI after every push, updates the right subrepo (since it changed), and only attempt to create a PR only if the PR does not already exist.