### PR TITLE
update to latest frama-c

### DIFF
--- a/doc/src/verification/eacsl.md
+++ b/doc/src/verification/eacsl.md
@@ -69,26 +69,29 @@ We can then call the function with symbolic values and see what happens. We shou
             (i >= 2 && \forall integer j; 2 <= j < i ==> i % j != 0));
 */
 void primes(int *is_prime, int n) {
-    for (int i = 0; i < n; ++i) is_prime[i] = 1;
-    for (int i = 2; i * i < n; ++i) {
-        if (!is_prime[i]) continue;
-        for (int j = i; i * j < n; ++j) {
-            is_prime[i * j] = 0;
-        }
+  for (int i = 0; i < n; ++i) {
+    is_prime[i] = 1;
+  }
+  for (int i = 2; i * i < n; ++i) {
+    if (!is_prime[i]) {
+      continue;
     }
+    for (int j = i; i * j < n; ++j) {
+      is_prime[i * j] = 0;
+    }
+  }
 }
 
 int main(void) {
-    int *is_prime;
-    is_prime = malloc(MAX_SIZE * sizeof(int));
+  int *is_prime = malloc(MAX_SIZE * sizeof(int));
 
-    int n = owi_int();
-    owi_assume(n >= 2);
-    owi_assume(n <= MAX_SIZE);
+  int n = owi_int("n");
+  owi_assume(n >= 2);
+  owi_assume(n <= MAX_SIZE);
 
-    primes(is_prime, n);
-    free(is_prime);
-    return 0;
+  primes(is_prime, n);
+  free(is_prime);
+  return 0;
 }
 ```
 
@@ -96,7 +99,7 @@ int main(void) {
 $ owi c --e-acsl primes.c -w1
 owi: [ERROR] Assert failure: false
 model {
-  symbol symbol_0 i32 2
+  symbol symbol_0 i32 2 n
 }
 owi: [ERROR] Reached problem!
 [13]
@@ -120,27 +123,29 @@ The problem is that we should mark `0` and `1` as non-prime during the initializ
             (i >= 2 && \forall integer j; 2 <= j < i ==> i % j != 0));
 */
 void primes(int *is_prime, int n) {
-    for (int i = 0; i < n; ++i) is_prime[i] = 1;
-    is_prime[0] = is_prime[1] = 0;
-    for (int i = 2; i * i < n; ++i) {
-        if (!is_prime[i]) continue;
-        for (int j = i; i * j < n; ++j) {
-            is_prime[i * j] = 0;
-        }
+  for (int i = 0; i < n; ++i)
+    is_prime[i] = 1;
+  is_prime[0] = is_prime[1] = 0;
+  for (int i = 2; i * i < n; ++i) {
+    if (!is_prime[i])
+      continue;
+    for (int j = i; i * j < n; ++j) {
+      is_prime[i * j] = 0;
     }
+  }
 }
 
 int main(void) {
-    int *is_prime;
-    is_prime = malloc(MAX_SIZE * sizeof(int));
+  int *is_prime;
+  is_prime = malloc(MAX_SIZE * sizeof(int));
 
-    int n = owi_int();
-    owi_assume(n >= 2);
-    owi_assume(n <= MAX_SIZE);
+  int n = owi_int("n");
+  owi_assume(n >= 2);
+  owi_assume(n <= MAX_SIZE);
 
-    primes(is_prime, n);
-    free(is_prime);
-    return 0;
+  primes(is_prime, n);
+  free(is_prime);
+  return 0;
 }
 ```
 

--- a/doc/src/verification/primes.c
+++ b/doc/src/verification/primes.c
@@ -10,24 +10,27 @@
             (i >= 2 && \forall integer j; 2 <= j < i ==> i % j != 0));
 */
 void primes(int *is_prime, int n) {
-    for (int i = 0; i < n; ++i) is_prime[i] = 1;
-    for (int i = 2; i * i < n; ++i) {
-        if (!is_prime[i]) continue;
-        for (int j = i; i * j < n; ++j) {
-            is_prime[i * j] = 0;
-        }
+  for (int i = 0; i < n; ++i) {
+    is_prime[i] = 1;
+  }
+  for (int i = 2; i * i < n; ++i) {
+    if (!is_prime[i]) {
+      continue;
     }
+    for (int j = i; i * j < n; ++j) {
+      is_prime[i * j] = 0;
+    }
+  }
 }
 
 int main(void) {
-    int *is_prime;
-    is_prime = malloc(MAX_SIZE * sizeof(int));
+  int *is_prime = malloc(MAX_SIZE * sizeof(int));
 
-    int n = owi_int();
-    owi_assume(n >= 2);
-    owi_assume(n <= MAX_SIZE);
+  int n = owi_int("n");
+  owi_assume(n >= 2);
+  owi_assume(n <= MAX_SIZE);
 
-    primes(is_prime, n);
-    free(is_prime);
-    return 0;
+  primes(is_prime, n);
+  free(is_prime);
+  return 0;
 }

--- a/doc/src/verification/primes2.c
+++ b/doc/src/verification/primes2.c
@@ -10,25 +10,27 @@
             (i >= 2 && \forall integer j; 2 <= j < i ==> i % j != 0));
 */
 void primes(int *is_prime, int n) {
-    for (int i = 0; i < n; ++i) is_prime[i] = 1;
-    is_prime[0] = is_prime[1] = 0;
-    for (int i = 2; i * i < n; ++i) {
-        if (!is_prime[i]) continue;
-        for (int j = i; i * j < n; ++j) {
-            is_prime[i * j] = 0;
-        }
+  for (int i = 0; i < n; ++i)
+    is_prime[i] = 1;
+  is_prime[0] = is_prime[1] = 0;
+  for (int i = 2; i * i < n; ++i) {
+    if (!is_prime[i])
+      continue;
+    for (int j = i; i * j < n; ++j) {
+      is_prime[i * j] = 0;
     }
+  }
 }
 
 int main(void) {
-    int *is_prime;
-    is_prime = malloc(MAX_SIZE * sizeof(int));
+  int *is_prime;
+  is_prime = malloc(MAX_SIZE * sizeof(int));
 
-    int n = owi_int();
-    owi_assume(n >= 2);
-    owi_assume(n <= MAX_SIZE);
+  int n = owi_int("n");
+  owi_assume(n >= 2);
+  owi_assume(n <= MAX_SIZE);
 
-    primes(is_prime, n);
-    free(is_prime);
-    return 0;
+  primes(is_prime, n);
+  free(is_prime);
+  return 0;
 }

--- a/src/lang_c/libowi/include/eacsl.h
+++ b/src/lang_c/libowi/include/eacsl.h
@@ -17,6 +17,8 @@
 void __e_acsl_memory_init(int *argc_ref, char ***argv, size_t ptr_size);
 void __e_acsl_memory_clean(void);
 
+int __e_acsl_aligned(void *ptr, size_t alignment);
+
 /* Tracking */
 void *__e_acsl_store_block(void *ptr, size_t size);
 void *__e_acsl_store_block_duplicate(void *ptr, size_t size);

--- a/src/lang_c/libowi/src/eacsl.c
+++ b/src/lang_c/libowi/src/eacsl.c
@@ -22,6 +22,10 @@ __attribute__((import_module("owi"), import_name("dealloc"))) void *free(void *)
 void __e_acsl_memory_init(int *argc_ref, char ***argv, size_t ptr_size) {}
 void __e_acsl_memory_clean(void) {}
 
+int __e_acsl_aligned(void *ptr, size_t alignment) {
+  return (ptr == NULL) || ((uintptr_t)ptr % alignment == 0);
+}
+
 /* Tracking */
 void *__e_acsl_store_block(void *ptr, size_t size) {}
 void *__e_acsl_store_block_duplicate(void *ptr, size_t size) {}

--- a/test/cram/c/eacsl/function/integer_dividable.c
+++ b/test/cram/c/eacsl/function/integer_dividable.c
@@ -7,13 +7,11 @@
     behavior no:
       assumes x % y != 0;
       ensures \result == 1; */
-int is_dividable(int x, int y) {
-  return x % y == 0;
-}
+int is_dividable(int x, int y) { return x % y == 0; }
 
 int main(void) {
-  int numerator = owi_int();
-  int denominator = owi_int();
+  int numerator = owi_int("numerator");
+  int denominator = owi_int("denominator");
 
   owi_assume(denominator != 0);
 

--- a/test/cram/c/eacsl/function/integer_dividable.t
+++ b/test/cram/c/eacsl/function/integer_dividable.t
@@ -1,8 +1,8 @@
   $ owi c --e-acsl integer_dividable.c --no-value --fail-on-assertion-only
   owi: [ERROR] Assert failure: (bool.eq (i32.rem_s symbol_0 symbol_1) 0)
   model {
-    symbol symbol_0 i32
-    symbol symbol_1 i32
+    symbol symbol_0 i32 numerator
+    symbol symbol_1 i32 denominator
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/function/max.c
+++ b/test/cram/c/eacsl/function/max.c
@@ -10,13 +10,11 @@
     disjoint behaviors;
     complete behaviors;
 */
-int max(int x, int y) {
-    return (x > y) ? x : y;
-}
+int max(int x, int y) { return (x > y) ? x : y; }
 
 int main(void) {
-    int x = owi_int();
-    int y = owi_int();
-    max(x, y);
-    return 0;
+  int x = owi_int("x");
+  int y = owi_int("y");
+  max(x, y);
+  return 0;
 }

--- a/test/cram/c/eacsl/function/max.t
+++ b/test/cram/c/eacsl/function/max.t
@@ -1,20 +1,20 @@
   $ owi c --e-acsl max.c --no-value -w1 --deterministic-result-order
   owi: [ERROR] Assert failure: false
   model {
-    symbol symbol_0 i32
-    symbol symbol_1 i32
+    symbol symbol_0 i32 x
+    symbol symbol_1 i32 y
   }
   
   owi: [ERROR] Trap: unreachable
   model {
-    symbol symbol_0 i32
-    symbol symbol_1 i32
+    symbol symbol_0 i32 x
+    symbol symbol_1 i32 y
   }
   
   owi: [ERROR] Trap: unreachable
   model {
-    symbol symbol_0 i32
-    symbol symbol_1 i32
+    symbol symbol_0 i32 x
+    symbol symbol_1 i32 y
   }
   
   owi: [ERROR] Reached 3 problems!

--- a/test/cram/c/eacsl/function/max_ptr.c
+++ b/test/cram/c/eacsl/function/max_ptr.c
@@ -5,20 +5,20 @@
     ensures  *p < *q;
 */
 void max_ptr(int *p, int *q) {
-    if (*p > *q) {
-        int tmp = *p;
-        *p = *q;
-        *q = tmp;
-    }
+  if (*p > *q) {
+    int tmp = *p;
+    *p = *q;
+    *q = tmp;
+  }
 }
 
 int main() {
-    int* p;
-    int* q;
-    p = (int*)malloc(sizeof(int));
-    q = (int*)malloc(sizeof(int));
-    *p = owi_int();
-    *q = owi_int();
-    max_ptr(p, q);
-    return 0;
+  int *p;
+  int *q;
+  p = (int *)malloc(sizeof(int));
+  q = (int *)malloc(sizeof(int));
+  *p = owi_int("p");
+  *q = owi_int("q");
+  max_ptr(p, q);
+  return 0;
 }

--- a/test/cram/c/eacsl/function/max_ptr.t
+++ b/test/cram/c/eacsl/function/max_ptr.t
@@ -1,8 +1,8 @@
   $ owi c --e-acsl max_ptr.c --no-value
   owi: [ERROR] Assert failure: (i32.lt_s symbol_0 symbol_1)
   model {
-    symbol symbol_0 i32
-    symbol symbol_1 i32
+    symbol symbol_0 i32 p
+    symbol symbol_1 i32 q
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/function/multi_behaviors.c
+++ b/test/cram/c/eacsl/function/multi_behaviors.c
@@ -32,13 +32,11 @@
     disjoint behaviors neg, pos;
     disjoint behaviors odd, even;
 */
-int f(int value) {
-    return value;
-}
+int f(int value) { return value; }
 
 int main() {
-    int value = owi_int();
-    owi_assume(value > INT_MIN);
-    f(value);
-    return 0;
+  int value = owi_int("value");
+  owi_assume(value > INT_MIN);
+  f(value);
+  return 0;
 }

--- a/test/cram/c/eacsl/ghost/case.c
+++ b/test/cram/c/eacsl/ghost/case.c
@@ -1,19 +1,22 @@
 #include <owi.h>
 
 int main(void) {
-    int n = owi_int();
-    //@ ghost int is_case2 = 0;
-    switch (n) {
-        case 0: break;
-        case 1: break;
-        /*@ ghost
-        case 2: {
-            is_case2 = 1;
-            // break; this break is not controlled
-        }
-        */
-        default: break;
-    }
-    //@ assert is_case2 == 0;
-    return 0;
+  int n = owi_int("n");
+  //@ ghost int is_case2 = 0;
+  switch (n) {
+  case 0:
+    break;
+  case 1:
+    break;
+  /*@ ghost
+  case 2: {
+      is_case2 = 1;
+      // break; this break is not controlled
+  }
+  */
+  default:
+    break;
+  }
+  //@ assert is_case2 == 0;
+  return 0;
 }

--- a/test/cram/c/eacsl/ghost/case.t
+++ b/test/cram/c/eacsl/ghost/case.t
@@ -1,7 +1,7 @@
   $ owi c --e-acsl ./case.c
   owi: [ERROR] Assert failure: (bool.ne symbol_0 2)
   model {
-    symbol symbol_0 i32 2
+    symbol symbol_0 i32 2 n
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/ghost/default.c
+++ b/test/cram/c/eacsl/ghost/default.c
@@ -1,21 +1,21 @@
 #include <owi.h>
 
 int main(void) {
-    int n = owi_int();
-    //@ ghost int is_default = 0;
-    switch (n) {
-        case 0: {
-            break;
-        }
-        case 1: {
-            break;
-        }
-        /*@ ghost default: {
-            is_default = 1;
-            break;
-        }
-        */
+  int n = owi_int("n");
+  //@ ghost int is_default = 0;
+  switch (n) {
+  case 0: {
+    break;
+  }
+  case 1: {
+    break;
+  }
+    /*@ ghost default: {
+        is_default = 1;
+        break;
     }
-    //@ assert is_default == 0;
-    return 0;
+    */
+  }
+  //@ assert is_default == 0;
+  return 0;
 }

--- a/test/cram/c/eacsl/ghost/default.t
+++ b/test/cram/c/eacsl/ghost/default.t
@@ -1,7 +1,7 @@
   $ owi c --e-acsl ./default.c --no-value
   owi: [ERROR] Assert failure: (i32.lt_u symbol_0 2)
   model {
-    symbol symbol_0 i32
+    symbol symbol_0 i32 n
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/ghost/else.c
+++ b/test/cram/c/eacsl/ghost/else.c
@@ -1,17 +1,17 @@
 #include <owi.h>
 
 int main(void) {
-    int x = owi_int();
-    owi_assume(x >= -1);
+  int x = owi_int("x");
+  owi_assume(x >= -1);
 
-    //@ ghost int num;
+  //@ ghost int num;
 
-    if (x >= 0) {
-        //@ ghost num = 42;
-    }
-    //@ ghost else num = 0;
+  if (x >= 0) {
+    //@ ghost num = 42;
+  }
+  //@ ghost else num = 0;
 
-   //@ assert num == 42;
+  //@ assert num == 42;
 
-    return 0;
+  return 0;
 }

--- a/test/cram/c/eacsl/ghost/else.t
+++ b/test/cram/c/eacsl/ghost/else.t
@@ -1,7 +1,7 @@
   $ owi c --e-acsl ./else.c --no-value --no-assert-failure-expression-printing
   owi: [ERROR] Assert failure
   model {
-    symbol symbol_0 i32
+    symbol symbol_0 i32 x
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/ghost/global.c
+++ b/test/cram/c/eacsl/ghost/global.c
@@ -6,16 +6,16 @@
     ensures cnt < 20;
 */
 void loop(int n) {
-    //@ ghost cnt = 0;
-    while (n--) {
-        //@ ghost cnt += 1;
-    }
+  //@ ghost cnt = 0;
+  while (n--) {
+    //@ ghost cnt += 1;
+  }
 }
 
 int main(void) {
-    int n = owi_int();
-    owi_assume(n > 10);
-    owi_assume(n <= 20);
-    loop(n);
-    return 0;
+  int n = owi_int("n");
+  owi_assume(n > 10);
+  owi_assume(n <= 20);
+  loop(n);
+  return 0;
 }

--- a/test/cram/c/eacsl/ghost/global.t
+++ b/test/cram/c/eacsl/ghost/global.t
@@ -1,7 +1,7 @@
   $ owi c --e-acsl ./global.c
   owi: [ERROR] Assert failure: (i32.lt_s symbol_0 20)
   model {
-    symbol symbol_0 i32 20
+    symbol symbol_0 i32 20 n
   }
   owi: [ERROR] Reached problem!
   [13]

--- a/test/cram/c/eacsl/ghost/parameter.c
+++ b/test/cram/c/eacsl/ghost/parameter.c
@@ -3,35 +3,37 @@
 #include <stdlib.h>
 
 typedef struct List {
-    int element;
-    struct List* next;
+  int element;
+  struct List *next;
 } List;
 
-void traverse(List* node) /*@ ghost (int length) */ {
-    /*@ loop variant length;
-    */
-    while (node != NULL) {
-        node = node->next;
-        //@ ghost length --;
-    }
+void traverse(List *node) /*@ ghost (int length) */ {
+  /*@ loop variant length;
+   */
+  while (node != NULL) {
+    node = node->next;
+    //@ ghost length --;
+  }
 }
 
-List* makeList(int element, List* next) {
-    List *node = (List *)malloc(sizeof(List));
-    if (node == NULL) return NULL;
-    node->element = element;
-    node->next = next;
-    return node;
+List *makeList(int element, List *next) {
+  List *node = (List *)malloc(sizeof(List));
+  if (node == NULL)
+    return NULL;
+  node->element = element;
+  node->next = next;
+  return node;
 }
 
-int size(List* node) {
-    if (node == NULL) return 0;
-    int cnt = 0;
-    while (node != NULL) {
-        node = node->next;
-        cnt ++;
-    }
-    return cnt;
+int size(List *node) {
+  if (node == NULL)
+    return 0;
+  int cnt = 0;
+  while (node != NULL) {
+    node = node->next;
+    cnt++;
+  }
+  return cnt;
 }
 
 /*@ ghost int ghost_size(List* node) {
@@ -45,11 +47,12 @@ int size(List* node) {
 }*/
 
 int main(void) {
-    int n = owi_int();
-    owi_assume(n >= 10);
-    owi_assume(n <= 20);
-    List *node = NULL;
-    while (n--) node = makeList(0, node);
-    traverse(node) /*@ ghost (ghost_size(node)) */ ;
-    return 0;
+  int n = owi_int("n");
+  owi_assume(n >= 10);
+  owi_assume(n <= 20);
+  List *node = NULL;
+  while (n--)
+    node = makeList(0, node);
+  traverse(node) /*@ ghost (ghost_size(node)) */;
+  return 0;
 }

--- a/test/cram/c/eacsl/loop/array_sum.c
+++ b/test/cram/c/eacsl/loop/array_sum.c
@@ -1,13 +1,13 @@
 #include <owi.h>
 #include <stdlib.h>
 
-int main (void) {
+int main(void) {
   int n = 10;
   int *t;
   t = (int *)malloc(n * sizeof(int));
 
   for (int i = 0; i < n; i++) {
-    t[i] = owi_int();
+    t[i] = owi_int("t[i]");
   }
 
   int sum = 0;


### PR DESCRIPTION
cc @S41d, for some reason, the E-ACSL instrumentation fails to see the macro and only sees `owi_int(string)`, thus it is failing on a call to it without a name. I went the easy way and added a name everywhere, WDYT?