### PR TITLE
More stuff for abs script

### DIFF
--- a/src/abstract/abstract_interpreter_control_flow.ml
+++ b/src/abstract/abstract_interpreter_control_flow.ml
@@ -331,8 +331,7 @@ module DenotFixpoint (S : DATA_STATE) = struct
     in
 
     let locals =
-      args @ List.map (fun (_str_opt, vt) -> init_value vt) func.locals
-      |> List.rev
+      List.rev args @ List.map (fun (_str_opt, vt) -> init_value vt) func.locals
       |> List.mapi (fun i x -> (i, x))
       |> Abstract_locals.of_list
     in
@@ -623,20 +622,15 @@ let modul (env : Abstract_env.t) ~(modul : int) =
   let abs_state = Abstract_state.empty modul Abstract_env.fold_globals env in
   eval_exprs ~modul abs_state env
 
-let exec_vfunc_from_outside ~ctx ~locals ~(modul : int) ~env (func : Kind.func)
-    =
+let exec_vfunc_from_outside ~ctx ~stack ~(modul : int) ~env (func : Kind.func) =
   let abs_state =
-    Abstract_state.empty_exec_state ~ctx ~locals ~modul
-      Abstract_env.fold_globals env
+    Abstract_state.empty_exec_state ~ctx ~stack ~modul Abstract_env.fold_globals
+      env
   in
+  Log.debug (fun m -> m "%a" (Abstract_state.pp ctx) abs_state);
   try
     match func with
     | Kind.Wasm { func; modul } -> (
-      let stack =
-        Abstract_locals.to_list locals
-        |> List.sort (fun (i1, _) (i2, _) -> compare i1 i2)
-        |> List.map snd
-      in
       let abs_state = { abs_state with stack } in
       match
         ConcreteFixpoint.eval_func

--- a/src/abstract/abstract_interpreter_control_flow.mli
+++ b/src/abstract/abstract_interpreter_control_flow.mli
@@ -14,7 +14,7 @@ val modul_with_ctx :
 
 val exec_vfunc_from_outside :
      ctx:Abstract_domain.Context.t
-  -> locals:Abstract_value.t Abstract_locals.t
+  -> stack:Abstract_stack.t
   -> modul:int
   -> env:Abstract_env.t
   -> Kind.func

--- a/src/abstract/abstract_state.ml
+++ b/src/abstract/abstract_state.ml
@@ -44,9 +44,9 @@ let empty modul fold_globals env =
   let call_stack = [] in
   { ctx; stack; locals; func_rt; invariant; globals; call_stack }
 
-let empty_exec_state ~ctx ~locals ~modul fold_globals env =
+let empty_exec_state ~ctx ~stack ~modul fold_globals env =
   let invariant = Abstract_invariant.empty () in
   let globals = init_globals ctx modul fold_globals env in
-  let stack = Abstract_stack.empty in
+  let locals = Abstract_locals.empty in
   let call_stack = [] in
   { ctx; stack; locals; func_rt = []; invariant; globals; call_stack }

--- a/src/script/script_abstract.ml
+++ b/src/script/script_abstract.ml
@@ -20,12 +20,8 @@ let do_action ctx env = function
     let* f, modul =
       Abstract_env.get_exported_func env ~module_name ~func_name
     in
-    let stack =
-      List.rev_map (Abstract_value.of_script_const ctx ~ty) args
-      |> List.mapi (fun i v -> (i, v))
-    in
-    let locals = Abstract_locals.of_list stack in
-    I.exec_vfunc_from_outside ~ctx ~locals ~modul ~env f
+    let stack = List.rev_map (Abstract_value.of_script_const ctx ~ty) args in
+    I.exec_vfunc_from_outside ~ctx ~stack ~modul ~env f
     end
   | Get (_module_name, _name) ->
     Log.info (fun m -> m "get...");
@@ -33,6 +29,31 @@ let do_action ctx env = function
 (* let* global = Link.get_global_from_module env mod_id name in *)
 (* let v = Abstract_value.of_concrete ctx global.value in *)
 (* Ok [ v ] *)
+
+let log_cmd : Wast.cmd -> unit =
+ fun cmd ->
+  let s =
+    match cmd with
+    | Text_module _ -> "module"
+    | Quoted_module _ -> "quoted module"
+    | Binary_module _ -> "binary module"
+    | Assert (Assert_trap_module _) -> "assert_trap"
+    | Assert (Assert_malformed_binary _)
+    | Assert (Assert_malformed_quote _)
+    | Assert (Assert_invalid_binary _)
+    | Assert (Assert_invalid _)
+    | Assert (Assert_invalid_quote _)
+    | Assert (Assert_unlinkable _)
+    | Assert (Assert_malformed _) ->
+      "assert_{malformed,invalid,unlinkable}_..."
+    | Assert (Assert_return _) -> "assert_return"
+    | Assert (Assert_trap _) -> "assert_trap"
+    | Assert (Assert_exhaustion _) -> "assert_exhaustion"
+    | Register _ -> "register"
+    | Action _ -> "action"
+    | Instance (_name, _mod_name) -> "instance"
+  in
+  Log.info (fun m -> m "*** %s" s)
 
 let run_one ~no_exhaustion:_
   (state : (Abstract_env.t * Abstract_domain.Context.t) Result.t) cmd =
@@ -47,6 +68,10 @@ let run_one ~no_exhaustion:_
   | Assert (Assert_return (action, res)) ->
     let* state = do_action ctx env action in
     let stack = List.rev state.stack in
+    Log.debug (fun m ->
+      m "assert_return : length: %i, check : %b"
+        (List.compare_lengths res stack)
+        (List.for_all2 (Abstract_value.equal_script_result ctx ~ty) res stack) );
     if
       List.compare_lengths res stack <> 0
       || not
@@ -59,6 +84,9 @@ let run_one ~no_exhaustion:_
       Error `Bad_result
     end
     else Ok (env, ctx)
+  | Register (name, mod_name) ->
+    let+ env = Abstract_env.register_last_module env ~name ~id:mod_name in
+    (env, ctx)
   | _ -> assert false
 
 let run ~no_exhaustion script =


### PR DESCRIPTION
With this, I can successfully run `test/cram/script/passing/localfun.wast` and `test/cram/script/passing/42.wast`. There's a lot of tests with recursive functions and/or `assert_trap`s so we can't run them yet