### PR TITLE
Add REPL subcommand

### DIFF
--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -563,6 +563,16 @@ let replay_cmd =
   Cmd_replay.cmd ~unsafe ~replay_file ~source_file ~entry_point
     ~invoke_with_symbols
 
+(* owi repl *)
+let repl_info =
+  let doc = "Start an interactive REPL for WebAssembly" in
+  let man = [] @ shared_man in
+  Cmd.info "repl" ~version ~doc ~sdocs ~man
+
+let repl_cmd =
+  let+ () = setup_log in
+  Cmd_repl.cmd ()
+
 (* owi run *)
 
 let run_info =
@@ -790,6 +800,7 @@ let cli =
     ; Cmd.v iso_info iso_cmd
     ; Cmd.v llvm_info llvm_cmd
     ; Cmd.v replay_info replay_cmd
+    ; Cmd.v repl_info repl_cmd
     ; Cmd.v run_info run_cmd
     ; Cmd.v rust_info rust_cmd
     ; Cmd.group script_info

--- a/src/cmd/cmd_repl.ml
+++ b/src/cmd/cmd_repl.ml
@@ -4,6 +4,11 @@
 
 open Result
 
+exception Interrupt
+
+let () =
+  Sys.(set_signal sigint (Signal_handle (fun _ -> raise Interrupt)))
+
 let read_line_stdin () =
   let rec read_chars acc =
     let buf = Bytes.create 1 in
@@ -24,7 +29,10 @@ let cmd () =
 
   let rec loop env =
     Fmt.pr "> %!";
-    match try Some (read_line_stdin ()) with End_of_file -> None with
+    match
+      try Some (read_line_stdin ())
+      with End_of_file -> None | Interrupt -> Fmt.pr "\n"; None
+    with
     | None ->
         Log.app (fun m -> m "Bye!");
         Ok ()

--- a/src/cmd/cmd_repl.ml
+++ b/src/cmd/cmd_repl.ml
@@ -1,0 +1,61 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+open Result
+
+let read_line_stdin () =
+  let rec read_chars acc =
+    let buf = Bytes.create 1 in
+    match Unix.read Unix.stdin buf 0 1 with
+    | 0 -> raise End_of_file
+    | _ ->
+        let byte = Bytes.get_uint8 buf 0 in
+        if byte = 10 then
+          String.concat "" (List.rev acc)
+        else
+          read_chars (String.make 1 (Char.chr byte) :: acc)
+  in
+  read_chars []
+
+let cmd () =
+  let env = Concrete_env.empty () in
+  let module I = Interpret.Concrete (Interpret.Default_parameters) in
+
+  let rec loop env =
+    Fmt.pr "> %!";
+    match try Some (read_line_stdin ()) with End_of_file -> None with
+    | None ->
+        Log.app (fun m -> m "Bye!");
+        Ok ()
+    | Some raw_input ->
+        let input = String.trim raw_input in
+        if String.equal input "quit" || String.equal input "exit" then (
+          Log.app (fun m -> m "Bye!");
+          Ok ()
+        ) else if String.equal input "" then
+          loop env
+        else
+          let temp_file = Fpath.v "repl_input.wat" in
+          let content = String.concat "" [input; "\n"] in
+          match Bos.OS.File.write temp_file content with
+          | Error e ->
+              Log.err (fun m -> m "Failed to write temp file: %s" (err_to_string e));
+              loop env
+          | Ok () ->
+              match Compile.File.until_validate ~unsafe:false temp_file with
+              | Error e ->
+                  Log.err (fun m -> m "Parse error: %s" (err_to_string e));
+                  loop env
+              | Ok module_ ->
+                  match Compile.Binary.until_concrete_link ~unsafe:false env ~name:None module_ with
+                  | Ok (modul, env') ->
+                      (match I.modul env' ~modul with
+                       | Ok () -> Log.app (fun m -> m "OK")
+                       | Error e -> Log.err (fun m -> m "Execution error: %s" (err_to_string e)));
+                      loop env'
+                  | Error e ->
+                      Log.err (fun m -> m "Link/execution error: %s" (err_to_string e));
+                      loop env
+  in
+  loop env

--- a/src/cmd/cmd_repl.mli
+++ b/src/cmd/cmd_repl.mli
@@ -1,0 +1,5 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+val cmd : unit -> unit Result.t

--- a/src/dune
+++ b/src/dune
@@ -47,6 +47,7 @@
   cmd_fmt
   cmd_fuzz
   cmd_haskell
+  cmd_repl
   cmd_instrument_label
   cmd_iso
   cmd_llvm

--- a/src/owi.ml
+++ b/src/owi.ml
@@ -21,6 +21,7 @@ module Cmd_instrument_label = Cmd_instrument_label
 module Cmd_iso = Cmd_iso
 module Cmd_llvm = Cmd_llvm
 module Cmd_replay = Cmd_replay
+module Cmd_repl = Cmd_repl
 module Cmd_run = Cmd_run
 module Cmd_rust = Cmd_rust
 module Cmd_script = Cmd_script

--- a/src/owi.mli
+++ b/src/owi.mli
@@ -2117,6 +2117,10 @@ module Cmd_replay : sig
     -> unit Result.t
 end
 
+module Cmd_repl : sig
+  val cmd : unit -> unit Result.t
+end
+
 module Cmd_run : sig
   val cmd :
        unsafe:bool


### PR DESCRIPTION
# Add REPL subcommand

Adds an interactive REPL for WebAssembly text format (WAT). Useful for quick experiments and learning.

## Changes

- `src/cmd/cmd_repl.ml` & `.mli`: new command implementation.
- `src/bin/owi.ml`: register the `repl` subcommand.
- `src/owi.ml` & `.mli`: expose the `Cmd_repl` module.

## Usage

```bash
$ owi repl
> (module)
OK
> (module (func $main (result i32) (i32.const 42)) (export "main" (func $main)))
OK
> quit
Bye!
```
## Limitations: 
- Single‑line input only (multi‑line to be added later).
- Stateful functions: exports are not kept across commands (environment is reset each time).
- Auto‑completion / history: not yet implemented.

Closes #94 

