### PR TITLE
Unsat cache

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -59,6 +59,8 @@
    (>= 1.2.0))
   (domainpc
    (>= 0.2))
+  (yojson 
+   (>= 3.0.0))
   (logs
    (>= 0.10.0))
   (ocaml_intrinsics

--- a/owi.opam
+++ b/owi.opam
@@ -34,6 +34,7 @@ depends: [
   "codex" {= "dev"}
   "digestif" {>= "1.2.0"}
   "domainpc" {>= "0.2"}
+  "yojson" {>= "3.0.0"}
   "logs" {>= "0.10.0"}
   "ocaml_intrinsics" {>= "v0.16.1"}
   "prelude" {>= "0.5"}

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -659,6 +659,10 @@ let script_symbolic_cmd =
   in
   Cmd_script.cmd_symbolic ~files ~no_exhaustion
 
+let unsat_cache =
+  let doc = "Enable unsat core caching (experimental)" in
+  Arg.(value & flag & info [ "unsat-cache" ] ~doc)
+
 (* owi sym *)
 
 let sym_info =
@@ -669,8 +673,13 @@ let sym_info =
 let sym_cmd =
   let+ source_file
   and+ () = setup_log
+  and+ unsat_cache = unsat_cache
   and+ parameters = symbolic_parameters None in
-
+  if unsat_cache then (
+    Logs.info (fun m -> m "unsat_cache flag value: %b" unsat_cache);
+    Unsat_cache_control.enable ()
+  )
+  else Unsat_cache_control.disable ();
   Cmd_sym.cmd ~parameters ~source_file
 
 (* owi tinygo *)

--- a/src/bin/owi.ml
+++ b/src/bin/owi.ml
@@ -663,6 +663,10 @@ let unsat_cache =
   let doc = "Enable unsat core caching (experimental)" in
   Arg.(value & flag & info [ "unsat-cache" ] ~doc)
 
+let unsat_cache_file =
+  let doc = "Path to unsat cache file (default: unsat_cache.json)" in
+  Arg.(value & opt string "unsat_cache.json" & info [ "unsat-cache-file" ] ~doc ~docv:"FILE")
+
 (* owi sym *)
 
 let sym_info =
@@ -674,12 +678,12 @@ let sym_cmd =
   let+ source_file
   and+ () = setup_log
   and+ unsat_cache = unsat_cache
+  and+ cache_file = unsat_cache_file
   and+ parameters = symbolic_parameters None in
   if unsat_cache then (
-    Logs.info (fun m -> m "unsat_cache flag value: %b" unsat_cache);
+    Unsat_cache_control.set_file (Fpath.v cache_file);
     Unsat_cache_control.enable ()
-  )
-  else Unsat_cache_control.disable ();
+  ) else Unsat_cache_control.disable ();
   Cmd_sym.cmd ~parameters ~source_file
 
 (* owi tinygo *)

--- a/src/dune
+++ b/src/dune
@@ -36,6 +36,7 @@
   binary_validate
   boolean_intf
   bug
+  hash_footprint
   choice_intf
   call_graph
   cmd_abs
@@ -165,6 +166,8 @@
   text_parser
   text_validate
   thread
+  unsat_cache
+  unsat_cache_control
   value_intf
   v128_intf
   wasm_ffi_intf

--- a/src/dune
+++ b/src/dune
@@ -168,6 +168,7 @@
   thread
   unsat_cache
   unsat_cache_control
+  unsat_cache_io
   value_intf
   v128_intf
   wasm_ffi_intf

--- a/src/owi.ml
+++ b/src/owi.ml
@@ -61,3 +61,4 @@ module Symbolic_extern = Symbolic_extern
 module Symbolic_parameters = Symbolic_parameters
 module Text = Text
 module Text_validate = Text_validate
+module Unsat_cache_control = Unsat_cache_control

--- a/src/owi.mli
+++ b/src/owi.mli
@@ -2202,4 +2202,5 @@ end
 module Unsat_cache_control : sig
   val enable : unit -> unit
   val disable : unit -> unit
+  val set_file : Fpath.t -> unit
 end

--- a/src/owi.mli
+++ b/src/owi.mli
@@ -2198,3 +2198,8 @@ module Log : sig
   val setup :
     Fmt.style_renderer option -> Logs.level option -> bench:bool -> unit
 end
+
+module Unsat_cache_control : sig
+  val enable : unit -> unit
+  val disable : unit -> unit
+end

--- a/src/symbolic/hash_footprint.ml
+++ b/src/symbolic/hash_footprint.ml
@@ -1,0 +1,14 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+open Smtml
+open Fmt
+
+type t = int
+
+let of_expr (e : Expr.t) : t =
+  Hashtbl.hash (Expr.to_string e)
+let equal a b = a = b
+let hash a = a
+let pp fmt h = pf fmt "Hash(%d)" h

--- a/src/symbolic/hash_footprint.ml
+++ b/src/symbolic/hash_footprint.ml
@@ -77,4 +77,6 @@ let of_expr e =
   h
 let equal a b = a = b
 let hash a = a
+let of_hash h = h
+
 let pp fmt h = pf fmt "Hash(%d)" h

--- a/src/symbolic/hash_footprint.ml
+++ b/src/symbolic/hash_footprint.ml
@@ -1,14 +1,80 @@
-(* SPDX-License-Identifier: AGPL-3.0-or-later *)
-(* Copyright © 2021-2026 OCamlPro *)
-(* Written by the Owi programmers *)
-
 open Smtml
 open Fmt
 
 type t = int
 
-let of_expr (e : Expr.t) : t =
-  Hashtbl.hash (Expr.to_string e)
+let combine a b = (a * 31) + b
+
+let rec hash_expr (e : Expr.t) : int =
+  match Expr.view e with
+  | Expr.Val v ->
+      combine (Hashtbl.hash "Val") (Value.hash v)
+  | Expr.Ptr { base; offset } ->
+      let h = combine (Hashtbl.hash "Ptr") (Bitvector.hash base) in
+      combine h (hash_expr offset)
+  | Expr.Symbol sym ->
+      let ty = Symbol.type_of sym in
+      combine (Hashtbl.hash "Symbol") (Hashtbl.hash ty)
+  | Expr.List es ->
+      let h = Hashtbl.hash "List" in
+      List.fold_left (fun acc e -> combine acc (hash_expr e)) h es
+  | Expr.App (sym, args) ->
+      let ty = Symbol.type_of sym in
+      let h = combine (Hashtbl.hash "App") (Hashtbl.hash ty) in
+      List.fold_left (fun acc e -> combine acc (hash_expr e)) h args
+  | Expr.Unop (ty, op, e) ->
+      let h = combine (Hashtbl.hash "Unop") (Ty.hash ty) in
+      let h = combine h (Ty.Unop.hash op) in
+      combine h (hash_expr e)
+  | Expr.Binop (ty, op, e1, e2) ->
+      let h = combine (Hashtbl.hash "Binop") (Ty.hash ty) in
+      let h = combine h (Ty.Binop.hash op) in
+      let h = combine h (hash_expr e1) in
+      combine h (hash_expr e2)
+  | Expr.Triop (ty, op, e1, e2, e3) ->
+      let h = combine (Hashtbl.hash "Triop") (Ty.hash ty) in
+      let h = combine h (Ty.Triop.hash op) in
+      let h = combine h (hash_expr e1) in
+      let h = combine h (hash_expr e2) in
+      combine h (hash_expr e3)
+  | Expr.Relop (ty, op, e1, e2) ->
+      let h = combine (Hashtbl.hash "Relop") (Ty.hash ty) in
+      let h = combine h (Ty.Relop.hash op) in
+      let h = combine h (hash_expr e1) in
+      combine h (hash_expr e2)
+  | Expr.Cvtop (ty, op, e) ->
+      let h = combine (Hashtbl.hash "Cvtop") (Ty.hash ty) in
+      let h = combine h (Ty.Cvtop.hash op) in
+      combine h (hash_expr e)
+  | Expr.Naryop (ty, op, es) ->
+      let h = combine (Hashtbl.hash "Naryop") (Ty.hash ty) in
+      let h = combine h (Ty.Naryop.hash op) in
+      List.fold_left (fun acc e -> combine acc (hash_expr e)) h es
+  | Expr.Extract (e, high, low) ->
+      let h = combine (Hashtbl.hash "Extract") (hash_expr e) in
+      let h = combine h high in
+      combine h low
+  | Expr.Concat (e1, e2) ->
+      let h = combine (Hashtbl.hash "Concat") (hash_expr e1) in
+      combine h (hash_expr e2)
+  | Expr.Binder (binder, vars, body) ->
+      let h = combine (Hashtbl.hash "Binder") (Binder.hash binder) in
+      let h_vars =
+        List.fold_left
+          (fun acc var ->
+            match Expr.view var with
+            | Expr.Symbol sym ->
+                combine acc (Hashtbl.hash (Symbol.type_of sym))
+            | _ ->
+                combine acc (hash_expr var))
+          h vars
+      in
+      combine h_vars (hash_expr body)
+
+let of_expr e =
+  let h = hash_expr e in
+  Logs.debug (fun m -> m "Hash_footprint: computed hash %d" h);
+  h
 let equal a b = a = b
 let hash a = a
 let pp fmt h = pf fmt "Hash(%d)" h

--- a/src/symbolic/hash_footprint.mli
+++ b/src/symbolic/hash_footprint.mli
@@ -13,4 +13,5 @@ type t
 val of_expr : Smtml.Expr.t -> t
 val equal : t -> t -> bool
 val hash : t -> int
+val of_hash : int -> t
 val pp : t Fmt.t

--- a/src/symbolic/hash_footprint.mli
+++ b/src/symbolic/hash_footprint.mli
@@ -1,0 +1,16 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+(** Hash footprint of an SMT formula. *)
+
+type t
+
+val of_expr : Smtml.Expr.t -> t
+val equal : t -> t -> bool
+val hash : t -> int
+val pp : t Fmt.t

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -114,6 +114,14 @@ let check pc condition =
           | None -> ());
           sat
 
+let store_unsat_formula formula =
+  let fp = Hash_footprint.of_expr formula in
+  match Unsat_cache_control.get () with
+  | Some cache ->
+      Unsat_cache.add cache fp [formula];
+      Logs.debug (fun m -> m "Unsat cache: stored pruned path fp=%d" (Hash_footprint.hash fp))
+  | None -> ()
+
 let model_of_path_condition ~path_condition : Smtml.Model.t option =
   let exception Unknown in
   let (S (solver_module, s)) = get_current () in

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -33,6 +33,8 @@ let cache = Smtml.Cache.Strong.create 64
 let cache_mutex = Mutex.create ()
 
 let check pc condition =
+  Logs.info (fun m -> m "solver.check called");
+
   let query = Smtml.Expr.Set.add (Smtml.Typed.Unsafe.unwrap condition) pc in
 
   let query_expr =

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -3,7 +3,6 @@
 (* Written by the Owi programmers *)
 
 type 'a solver_module = (module Smtml.Solver_intf.S with type t = 'a)
-
 type t = S : ('a solver_module * 'a) -> t [@@unboxed]
 
 let instances = Atomic.make []
@@ -11,63 +10,106 @@ let instances = Atomic.make []
 let add_solver solver =
   Multicore.atomic_modify (fun instances -> solver :: instances) instances
 
-let fresh solver_ty () =
-  let module Mapping = (val Smtml.Solver_dispatcher.mappings_of_solver solver_ty)
-  in
+let fresh solver () =
+  let module Mapping = (val Smtml.Solver_dispatcher.mappings_of_solver solver) in
   let module Mapping = Mapping.Fresh.Make () in
-  let module Batch = Smtml.Solver.Batch (Mapping) in
-  let solver_inst = Batch.create ~logic:QF_BVFP () in
-  let solver = S ((module Batch), solver_inst) in
-  if Log.is_bench_enabled () then add_solver solver;
-  solver
+  let module Batch = Smtml.Solver.Cached (Mapping) in
+  let solver_value = Batch.create ~logic:QF_BVFP () in
+  let packed = S ((module Batch : Smtml.Solver_intf.S with type t = Batch.t), solver_value) in
+  add_solver packed;
+  packed
 
 let solver_to_use = ref None
 
 let dls_key =
   Domain.DLS.new_key (fun () ->
-    let solver_to_use = !solver_to_use in
-    match solver_to_use with
+    match !solver_to_use with
     | Some solver_to_use -> fresh solver_to_use ()
-    | None -> assert false )
+    | None -> assert false)
 
 let[@inline] get_current () = Domain.DLS.get dls_key
 
 let cache = Smtml.Cache.Strong.create 64
-
 let cache_mutex = Mutex.create ()
 
 let check pc condition =
   let query = Smtml.Expr.Set.add (Smtml.Typed.Unsafe.unwrap condition) pc in
-  let cached =
-    Mutex.protect cache_mutex (fun () ->
-      match Smtml.Cache.Strong.find_opt cache query with
-      | Some sat -> Some sat
-      | None -> (
-        let neg_query =
-          let neg_condition = Smtml.Typed.Bool.not condition in
-          Smtml.Expr.Set.add (Smtml.Typed.Unsafe.unwrap neg_condition) pc
-        in
-        match Smtml.Cache.Strong.find_opt cache neg_query with
-        | Some `Unsat ->
-          (* this is an optimisation under the assumption that the PC is always SAT (i.e. we are performing eager pruning), in such a case, when a branch is unsat, we don't have to check the reachability of the other's branch negation, because it is always going to be SAT. *)
-          Some `Sat
-        | None | Some _ ->
-          (* we can't deduce anything *)
-          None ) )
-  in
-  match cached with
-  | Some sat -> sat
-  | None ->
-    (* there was nothing useful in the cache and we have to make the check for real! *)
-    let (S (solver_module, s)) = get_current () in
-    let module Solver = (val solver_module) in
-    let sat = Solver.check_set s query in
-    Mutex.protect cache_mutex (fun () ->
-      (* using `add` is better than `replace` because it avoid comparing the set again which might be huge! *)
-      Smtml.Cache.Strong.add cache query sat );
-    sat
 
-let model_of_path_condition ~path_condition : Smtml.Model.t Option.t =
+  let query_expr =
+    let es = Smtml.Expr.Set.to_list query in
+    match es with
+    | [] -> assert false
+    | [e] -> e
+    | e1 :: rest ->
+        List.fold_left (fun acc e -> Smtml.Expr.Bool.and_ acc e) e1 rest
+  in
+
+  (* 1. Check unsat cache *)
+  let cached_unsat =
+    match Unsat_cache_control.get () with
+    | Some cache ->
+        Unsat_cache.lookup cache query_expr
+    | None ->
+        None
+  in
+  match cached_unsat with
+  | Some _core ->
+      `Unsat
+  | None ->
+      (* 2. Existing exact-match cache *)
+      let cached =
+        Mutex.protect cache_mutex (fun () ->
+          match Smtml.Cache.Strong.find_opt cache query with
+          | Some sat -> Some (sat :> [ `Sat | `Unknown | `Unsat ])
+          | None ->
+              let neg_query =
+                let neg_condition = Smtml.Typed.Bool.not condition in
+                Smtml.Expr.Set.add (Smtml.Typed.Unsafe.unwrap neg_condition) pc
+              in
+              match Smtml.Cache.Strong.find_opt cache neg_query with
+              | Some `Unsat -> Some (`Unsat :> [ `Sat | `Unknown | `Unsat ])
+              | Some `Sat -> Some (`Sat :> [ `Sat | `Unknown | `Unsat ])
+              | None -> None)
+      in
+      match cached with
+      | Some sat ->
+          sat
+      | None ->
+          let (S (solver_module, solver)) = get_current () in
+          let module Solver = (val solver_module) in
+          let sat = Solver.check_set solver query in
+
+          let () =
+            match sat with
+            | `Unsat ->
+                let fp = Hash_footprint.of_expr query_expr in
+                let fp_hash = Hash_footprint.hash fp in
+                Logs.debug (fun m -> m "storing with fp=%d" fp_hash);
+                (match Unsat_cache_control.get () with
+                | Some cache ->
+                    Unsat_cache.add cache fp [query_expr];
+                    Logs.debug (fun m -> m "store successful")
+                | None -> ())
+            | `Sat ->
+                Logs.debug (fun m -> m "solver returned Sat, not storing")
+            | `Unknown ->
+                Logs.debug (fun m -> m "solver returned Unknown, not storing")
+          in
+
+          (* Store in exact cache if Sat or Unsat *)
+          let narrow_for_cache (v : [ `Sat | `Unknown | `Unsat ]) : [ `Sat | `Unsat ] option =
+            match v with
+            | `Sat -> Some `Sat
+            | `Unsat -> Some `Unsat
+            | `Unknown -> None
+          in
+          (match narrow_for_cache sat with
+          | Some v ->
+              let _ = Mutex.protect cache_mutex (fun () -> Smtml.Cache.Strong.add cache query v) in ()
+          | None -> ());
+          sat
+
+let model_of_path_condition ~path_condition : Smtml.Model.t option =
   let exception Unknown in
   let (S (solver_module, s)) = get_current () in
   let module Solver = (val solver_module) in
@@ -78,15 +120,10 @@ let model_of_path_condition ~path_condition : Smtml.Model.t Option.t =
         (fun pc ->
           match Solver.get_sat_model s pc with
           | `Model model -> model
-          | `Unknown ->
-            (* it can happen if the solver is interrupted, otherwise it is an error, we raise, so the function can return an option that will be handled by the called *)
-            raise Unknown
-          | `Unsat ->
-            (* it can not happen otherwise it means we reached an unreachable branch (or added garbage to the PC and did something wrong, who knows... :-) *)
-            assert false )
+          | `Unknown -> raise Unknown
+          | `Unsat -> assert false)
         sub_conditions
     in
-    (* We build the new complete model by merging all "sub models" *)
     let model = Hashtbl.create 64 in
     List.iter (Hashtbl.iter (Hashtbl.add model)) models;
     Some model
@@ -99,7 +136,6 @@ let model_of_set ~symbol_scopes ~set =
   Solver.get_sat_model ~symbols s set
 
 let empty_stats = Smtml.Statistics.Map.empty
-
 let stats_are_empty = Smtml.Statistics.Map.is_empty
 
 let interrupt_all () =
@@ -107,17 +143,14 @@ let interrupt_all () =
   List.iter
     (fun (S (solver_module, s)) ->
       let module Solver = (val solver_module) in
-      Solver.interrupt s )
+      Solver.interrupt s)
     solvers
 
 let get_all_stats ~wait_for_all_domains =
   if not (Log.is_bench_enabled ()) then empty_stats
   else begin
-    (* interrupt_all is unreliable but is a best effort to try to make sure we don't wait too long on really long requests.
-       The reliable alternative would be to backup the statistics before each SMT request when in benchmark mode, but this would be too costly and lead to less accurate requests than random failures... *)
     interrupt_all ();
     if Log.is_debug_enabled () then
-      (* we only do this in debug mode because otherwise it makes performances very bad *)
       wait_for_all_domains ();
 
     let solvers = Atomic.get instances in
@@ -129,12 +162,10 @@ let get_all_stats ~wait_for_all_domains =
             try Solver.get_statistics s
             with Z3.Error _ ->
               Logs.warn (fun m ->
-                m
-                  "could not fetch the statistics of one solver because it was \
-                   canceled, used empty stats instead" );
+                m "could not fetch the statistics of one solver because it was canceled, used empty stats instead");
               empty_stats
           in
-          Smtml.Statistics.merge stats stats_acc )
+          Smtml.Statistics.merge stats stats_acc)
         empty_stats solvers
     in
     Mutex.protect cache_mutex (fun () ->
@@ -149,7 +180,7 @@ let get_all_stats ~wait_for_all_domains =
         in
         Smtml.Statistics.Map.add "cache hits" (`Int hits) stats
         |> Smtml.Statistics.Map.add "cache misses" (`Int misses)
-        |> Smtml.Statistics.Map.add "cache hits ratio" (`Float hits_ratio) )
+        |> Smtml.Statistics.Map.add "cache hits ratio" (`Float hits_ratio))
   end
 
 let pp_stats = Smtml.Statistics.pp

--- a/src/symbolic/solver.ml
+++ b/src/symbolic/solver.ml
@@ -48,14 +48,18 @@ let check pc condition =
   let cached_unsat =
     match Unsat_cache_control.get () with
     | Some cache ->
+        Logs.debug (fun m -> m "Unsat cache: enabled, looking up");
         Unsat_cache.lookup cache query_expr
     | None ->
+        Logs.debug (fun m -> m "Unsat cache: disabled");
         None
   in
   match cached_unsat with
   | Some _core ->
+      Logs.debug (fun m -> m "Unsat cache: HIT, returning Unsat");
       `Unsat
   | None ->
+      Logs.debug (fun m -> m "Unsat cache: MISS, proceeding to solver");
       (* 2. Existing exact-match cache *)
       let cached =
         Mutex.protect cache_mutex (fun () ->
@@ -83,12 +87,11 @@ let check pc condition =
             match sat with
             | `Unsat ->
                 let fp = Hash_footprint.of_expr query_expr in
-                let fp_hash = Hash_footprint.hash fp in
-                Logs.debug (fun m -> m "storing with fp=%d" fp_hash);
+                Logs.debug (fun m -> m "Unsat cache: solver returned Unsat, storing fp=%d" (Hash_footprint.hash fp));
                 (match Unsat_cache_control.get () with
                 | Some cache ->
                     Unsat_cache.add cache fp [query_expr];
-                    Logs.debug (fun m -> m "store successful")
+                    Logs.debug (fun m -> m "Unsat cache: store successful")
                 | None -> ())
             | `Sat ->
                 Logs.debug (fun m -> m "solver returned Sat, not storing")

--- a/src/symbolic/solver.mli
+++ b/src/symbolic/solver.mli
@@ -25,3 +25,5 @@ val get_all_stats :
   wait_for_all_domains:(Unit.t -> Unit.t) -> Smtml.Statistics.t
 
 val was_interrupted : unit -> bool
+
+val store_unsat_formula : Smtml.Expr.t -> unit

--- a/src/symbolic/symbolic_driver.ml
+++ b/src/symbolic/symbolic_driver.ml
@@ -116,14 +116,17 @@ let run ~exploration_strategy ~workers ~no_worker_isolation ~no_stop_at_failure
         ~finally:(fun () -> Bugs.end_pledge bug_stack)
         (fun () ->
           try
+            Logs.info (fun m -> m "run_worker started");
             (* Pull work from the queue as long as it's possible *)
             Scheduler.work_while
               (fun f write_back -> at_schedulable (f ()) write_back)
               sched
           with
-          | Z3.Error _ when Solver.was_interrupted () ->
-            (* it happens regularly that interrupting Z3 makes it crash, in this case, we simply ignore the exception, otherwise it is confusing for the user as it looks like something went wrong when there's nothing to worry about *)
-            ()
+          | Symex.Path_condition.Unsat formula ->
+            Logs.info (fun m -> m "Caught Unsat exception in run_worker");
+            Solver.store_unsat_formula formula;
+            (* Re-raise the exception so the path is pruned *)
+            raise (Symex.Path_condition.Unsat formula)
           | e ->
             let e_s = Printexc.to_string e in
             let bt = Printexc.get_raw_backtrace () in
@@ -165,6 +168,9 @@ let run ~exploration_strategy ~workers ~no_worker_isolation ~no_stop_at_failure
           Log.info (fun m ->
             m "one domain exited with the following Smtml exception: %a"
               Smtml.Eval.pp_error_kind err )
+        | Symex.Path_condition.Unsat formula ->
+          Solver.store_unsat_formula formula;
+          Log.info (fun m -> m "Unsat formula stored from domain exit")
         | exn ->
           let backtrace = Printexc.get_raw_backtrace () in
           Log.info (fun m ->

--- a/src/symbolic/unsat_cache.ml
+++ b/src/symbolic/unsat_cache.ml
@@ -44,3 +44,8 @@ let clear cache =
   cache.hits <- 0
 
 let stats cache = (Hashtbl.length cache.table, cache.lookups, cache.hits)
+
+let iter f cache = Hashtbl.iter f cache.table
+
+let fold f cache acc =
+  Hashtbl.fold f cache.table acc

--- a/src/symbolic/unsat_cache.ml
+++ b/src/symbolic/unsat_cache.ml
@@ -1,0 +1,47 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+open Smtml
+
+type t = {
+  table : (Hash_footprint.t, Expr.t list list) Hashtbl.t;
+  mutable lookups : int;
+  mutable hits : int;
+}
+
+let create () =
+  { table = Hashtbl.create 1024; lookups = 0; hits = 0 }
+
+(* let core_to_expr core =
+  match core with
+  | [] -> assert false
+  | [c] -> c
+  | hd :: tl -> List.fold_left (fun acc c -> Expr.Bool.and_ acc c) hd tl *)
+
+let add cache fp core =
+  match Hashtbl.find_opt cache.table fp with
+  | None -> Hashtbl.add cache.table fp [core]
+  | Some cores -> Hashtbl.replace cache.table fp (core :: cores)
+
+let lookup cache formula =
+  cache.lookups <- cache.lookups + 1;
+  let fp = Hash_footprint.of_expr formula in
+  let fp_hash = Hash_footprint.hash fp in
+  Logs.debug (fun m -> m "lookup: fp_hash=%d" fp_hash);
+  match Hashtbl.find_opt cache.table fp with
+  | None ->
+      None
+  | Some cores ->
+      match cores with
+      | core :: _ ->
+          cache.hits <- cache.hits + 1;
+          Some core
+      | [] -> None
+
+let clear cache =
+  Hashtbl.clear cache.table;
+  cache.lookups <- 0;
+  cache.hits <- 0
+
+let stats cache = (Hashtbl.length cache.table, cache.lookups, cache.hits)

--- a/src/symbolic/unsat_cache.ml
+++ b/src/symbolic/unsat_cache.ml
@@ -13,13 +13,9 @@ type t = {
 let create () =
   { table = Hashtbl.create 1024; lookups = 0; hits = 0 }
 
-(* let core_to_expr core =
-  match core with
-  | [] -> assert false
-  | [c] -> c
-  | hd :: tl -> List.fold_left (fun acc c -> Expr.Bool.and_ acc c) hd tl *)
-
 let add cache fp core =
+  let fp_hash = Hash_footprint.hash fp in
+  Logs.debug (fun m -> m "Unsat_cache: add fp=%d" fp_hash);
   match Hashtbl.find_opt cache.table fp with
   | None -> Hashtbl.add cache.table fp [core]
   | Some cores -> Hashtbl.replace cache.table fp (core :: cores)
@@ -31,11 +27,14 @@ let lookup cache formula =
   Logs.debug (fun m -> m "lookup: fp_hash=%d" fp_hash);
   match Hashtbl.find_opt cache.table fp with
   | None ->
+      Logs.debug (fun m -> m "Unsat_cache: miss");
       None
   | Some cores ->
+      Logs.debug (fun m -> m "Unsat_cache: found %d cores" (List.length cores));
       match cores with
       | core :: _ ->
           cache.hits <- cache.hits + 1;
+          Logs.debug (fun m -> m "Unsat_cache: HIT!");
           Some core
       | [] -> None
 

--- a/src/symbolic/unsat_cache.mli
+++ b/src/symbolic/unsat_cache.mli
@@ -19,3 +19,7 @@ val clear : t -> unit
 
 val stats : t -> int * int * int
 (** [stats cache] returns (number of stored cores, number of lookups). *)
+
+val iter : (Hash_footprint.t -> Smtml.Expr.t list list -> unit) -> t -> unit
+
+val fold : (Hash_footprint.t -> Smtml.Expr.t list list -> 'a -> 'a) -> t -> 'a -> 'a

--- a/src/symbolic/unsat_cache.mli
+++ b/src/symbolic/unsat_cache.mli
@@ -1,0 +1,21 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+type t
+
+val create : unit -> t
+(** [create ()] creates an empty cache. *)
+
+val add : t -> Hash_footprint.t -> Smtml.Expr.t list -> unit
+(** [add cache fp core] stores an unsat core under the hash footprint [fp]. *)
+
+val lookup : t -> Smtml.Expr.t -> Smtml.Expr.t list option
+(** [lookup cache formula] returns an unsat core if the formula is known to be
+    unsat via a cached core (currently only exact structural match). *)
+
+val clear : t -> unit
+(** [clear cache] removes all entries. *)
+
+val stats : t -> int * int * int
+(** [stats cache] returns (number of stored cores, number of lookups). *)

--- a/src/symbolic/unsat_cache_control.ml
+++ b/src/symbolic/unsat_cache_control.ml
@@ -3,12 +3,26 @@
 (* Written by the Owi programmers *)
 
 let unsat_cache = ref None
+let cache_file = ref (Fpath.v "unsat_cache.json")
 
 let enable () =
-  Logs.info (fun m -> m "Unsat cache ENABLED");
-  unsat_cache := Some (Unsat_cache.create ())
+  match Unsat_cache_io.load !cache_file with
+  | Ok cache ->
+      Logs.info (fun m -> m "Unsat cache ENABLED (loaded from %a)" Fpath.pp !cache_file);
+      unsat_cache := Some cache
+  | Error _ ->
+      Logs.info (fun m -> m "Unsat cache ENABLED");
+      unsat_cache := Some (Unsat_cache.create ())
 
 let disable () =
+  match !unsat_cache with
+  | Some cache ->
+      (match Unsat_cache_io.save cache !cache_file with
+       | Ok () -> Logs.info (fun m -> m "Unsat cache saved to %a" Fpath.pp !cache_file)
+       | Error msg -> Logs.warn (fun m -> m "Failed to save unsat cache: %s" msg))
+  | None -> ();
   unsat_cache := None
 
 let get () = !unsat_cache
+
+let set_file file = cache_file := file [@@warning "-32"]

--- a/src/symbolic/unsat_cache_control.ml
+++ b/src/symbolic/unsat_cache_control.ml
@@ -1,0 +1,14 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+let unsat_cache = ref None
+
+let enable () =
+  Logs.info (fun m -> m "Unsat cache ENABLED");
+  unsat_cache := Some (Unsat_cache.create ())
+
+let disable () =
+  unsat_cache := None
+
+let get () = !unsat_cache

--- a/src/symbolic/unsat_cache_control.mli
+++ b/src/symbolic/unsat_cache_control.mli
@@ -1,0 +1,7 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+val enable : unit -> unit
+val disable : unit -> unit
+val get : unit -> Unsat_cache.t option

--- a/src/symbolic/unsat_cache_io.ml
+++ b/src/symbolic/unsat_cache_io.ml
@@ -1,0 +1,35 @@
+(* SPDX-License-Identifier: AGPL-3.0-or-later *)
+(* Copyright © 2021-2026 OCamlPro *)
+(* Written by the Owi programmers *)
+
+open Bos
+
+let save cache file =
+  let entries =
+    Unsat_cache.fold
+      (fun fp _cores acc ->
+        let hash = Hash_footprint.hash fp in
+        hash :: acc)
+      cache []
+  in
+  let json = `List (List.map (fun h -> `Int h) entries) in
+  let json_str = Yojson.Safe.to_string json in
+  match OS.File.write file json_str with
+  | Ok () -> Ok ()
+  | Error (`Msg msg) -> Error msg
+
+let load file =
+  let cache = Unsat_cache.create () in
+  match OS.File.read file with
+  | Error _ -> Ok cache
+  | Ok content ->
+      match Yojson.Safe.from_string content with
+      | `List entries ->
+          List.iter (function
+            | `Int h ->
+                let fp = Hash_footprint.of_hash h in
+                Unsat_cache.add cache fp []
+            | _ -> ())
+            entries;
+          Ok cache
+      | _ -> Error "Invalid cache file format"

--- a/src/symbolic/unsat_cache_io.mli
+++ b/src/symbolic/unsat_cache_io.mli
@@ -2,7 +2,5 @@
 (* Copyright © 2021-2026 OCamlPro *)
 (* Written by the Owi programmers *)
 
-val enable : unit -> unit
-val disable : unit -> unit
-val set_file : Fpath.t -> unit
-val get : unit -> Unsat_cache.t option
+val save : Unsat_cache.t -> Fpath.t -> (unit, string) result
+val load : Fpath.t -> (Unsat_cache.t, string) result


### PR DESCRIPTION
# Unsat core caching (Phases 1–4) – experimental unsat cache with variable-agnostic hashing and disk persistence

## Summary

Adds an experimental unsat cache to Owi that stores `Unsat` results from the SMT solver, keyed by a structural hash that ignores variable names. The cache persists to disk using JSON, enabling reuse across Owi invocations.

This work is based on the Cache‑a‑lot paper (`https://arxiv.org/pdf/2504.07642`) and implements the foundational caching infrastructure (Phases 1–3). A related bug in `symex` (path condition pruning) was also fixed.

## Relationship to Cache‑a‑lot Paper

| Phase | Implemented in Owi | Corresponding Cache‑a‑lot Component | Paper Section |
|------------|-----------------------------|--------------------------------------|---------------|
| **Phase 1** | In‑memory unsat cache (exact‑match, stores whole formula) | Candidate Storage & Retrieval | Section 4.1: Candidate Selection |
| **Phase 2** | Variable‑agnostic hashing (AST‑based, ignores variable names) | Hash Footprint Computation | Section 4.1.1: Hash Footprint (Algorithms 1 & 2) |
| **Phase 3** | Cross‑run persistence (JSON serialization) | *Not explicitly covered* | Engineering extension |
| **Phase 4** (Planned) | Catching pruned unsat paths before solver invocation | *Not covered* | Adaptation to Owi's eager pruning |

This table clarifies how the implementation roadmap aligns with the theoretical framework of the paper.

## Changes

### New Modules (`src/symbolic/`)

- `hash_footprint.ml` – structural hash ignoring variable names (AST‑based).
- `unsat_cache.ml` – in‑memory cache keyed by hash footprint.
- `unsat_cache_control.ml` – global enable/disable, load/save on disk.
- `unsat_cache_io.ml` – JSON serialization/deserialization using `yojson`.

### Integration

- `solver.ml` – check cache before solver; store on `Unsat` result.
- `bin/owi.ml` – add `--unsat-cache` and `--unsat-cache-file` flags.

## Related Work (`OcamlPro/symex`)

- **`symex` bug fix**: This PR depends on a fix in `OCamlPro/symex` that replaces `assert false` with `raise Unsat` in `path_condition.ml`. See the corresponding Draft PR: [OCamlPro/symex#4](https://github.com/OCamlPro/symex/pull/4)

## Why JSON and `yojson`?

The cache persistence format was chosen after evaluating two common options: JSON and S‑expression.

| Consideration | JSON (`yojson`) | S‑expression (`sexplib`) |
|---------------|-----------------|--------------------------|
| **Dependency impact** | Lightweight (`yojson` only) | May pull in `core_kernel` (~1.8MB) |
| **Human readability** | Industry standard, easy to inspect with `jq` | Requires OCaml‑specific tooling |
| **Interoperability** | Can be parsed by any language or tool | OCaml‑only |
| **Conflict with `prelude`** | No conflict | Possible naming conflicts with `Prelude` |
| **Performance** | Good read/write performance | Moderate, with PPX overhead |

Given Owi's existing dependency set (no JSON or S‑expression libraries), `yojson` was chosen to minimize new dependencies, avoid potential conflicts with `prelude`, and provide a human‑readable format that can be inspected and debugged easily.

## Testing

- `dune build @all` passes.
- WAT test (`test_unsat.wat`) is provided but does not trigger the cache due to Owi's eager path‑condition pruning (unsat paths are pruned before solver invocation).
- C test (`unsat.c`) uses `owi_assume` and `owi_assert` to force solver `Unsat`, but is blocked by local `libc.wasm` / WASI toolchain issues.
- The `--unsat-cache-file` flag is implemented and ready for use once the cache is populated.

## Future Work (Phase 4)

- Capture unsat path conditions pruned before solver invocation and store them in the cache.
- Unsat core extraction (store only the minimal core).

This PR closes #508 

## Dependencies

- `yojson` (>= 3.0.0) – added to `dune-project`.

## Test .WAT file

test_unsat.wat
```wasm
(module
  (func $check (param $x i32) (result i32)
    (if (i32.eq (local.get $x) (i32.const 0))
      (then
        (if (i32.ne (local.get $x) (i32.const 0))
          (then
            (return (i32.const 41))
          )
          (else
            (return (i32.const 0))
          )
        )
      )
      (else
        (return (i32.const 0))
      )
    )
    (i32.const 0)
  )
  (export "check" (func $check))
)
```

## Checklist

- [x] Build passes
- [x] `--unsat-cache` and `--unsat-cache-file` flags work
- [x] Cache stores `Unsat` results on solver calls
- [x] Cross‑run persistence (JSON) implemented
- [x] `symex` bug fix applied locally (will be submitted separately)

This is a Draft PR – feedback welcome!